### PR TITLE
Fix: Improve categories toast feedback

### DIFF
--- a/client/src/components/pages/Store/Products/Categories/AddCategoriesModal.jsx
+++ b/client/src/components/pages/Store/Products/Categories/AddCategoriesModal.jsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 
 import {
   Button,
@@ -21,19 +21,22 @@ export function AddCategoriesModal({
   addCategoriesShowModal,
   setAddCategoriesShowModal,
 }) {
-  const t = useTranslations("categories");
+  const categoryTranslations = useTranslations("categories");
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const isSubmittingRef = useRef(false);
 
-  const handleSubmit = async (e) => {
-    e.preventDefault();
-    if (isSubmitting) return;
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    if (isSubmittingRef.current) return;
 
+    isSubmittingRef.current = true;
     try {
       setIsSubmitting(true);
       await addCategory(data);
       setData({ categoryName: "" });
       setAddCategoriesShowModal(false);
     } finally {
+      isSubmittingRef.current = false;
       setIsSubmitting(false);
     }
   };
@@ -52,17 +55,17 @@ export function AddCategoriesModal({
       placement="center"
     >
       <ModalContent>
-        <ModalHeader>{t("modal.titleAdd")}</ModalHeader>
+        <ModalHeader>{categoryTranslations("modal.titleAdd")}</ModalHeader>
         <ModalBody>
           <form className="space-y-4" onSubmit={handleSubmit}>
             <Input
-              label={t("modal.categoryNameLabel")}
+              label={categoryTranslations("modal.categoryNameLabel")}
               type="text"
-              placeholder={t("modal.categoryNamePlaceholder")}
+              placeholder={categoryTranslations("modal.categoryNamePlaceholder")}
               isRequired
-              errorMessage={t("modal.errorMsgInputFieldEmpty")}
+              errorMessage={categoryTranslations("modal.errorMsgInputFieldEmpty")}
               value={data.categoryName ?? ""}
-              onChange={(e) => onChange({ categoryName: e.target.value })}
+              onChange={(event) => onChange({ categoryName: event.target.value })}
             />
             <ModalFooter className="flex justify-between p-0 my-4">
               <Button
@@ -71,15 +74,16 @@ export function AddCategoriesModal({
                 className="px-6 py-2 border border-border text-foreground hover:bg-muted disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
                 onPress={() => setAddCategoriesShowModal(false)}
               >
-                {t("modal.cancelButton")}
+                {categoryTranslations("modal.cancelButton")}
               </Button>
               <Button
                 color="primary"
                 className="bg-green-800"
                 type="submit"
+                isDisabled={isSubmitting}
                 isLoading={isSubmitting}
               >
-                {t("modal.submitButton")}
+                {categoryTranslations("modal.submitButton")}
               </Button>
             </ModalFooter>
           </form>

--- a/client/src/components/pages/Store/Products/Categories/AddCategoriesModal.jsx
+++ b/client/src/components/pages/Store/Products/Categories/AddCategoriesModal.jsx
@@ -14,8 +14,8 @@ import {
 import { useTranslations } from "next-intl";
 
 export function AddCategoriesModal({
-  data,
-  setData,
+  categoryForm,
+  setCategoryForm,
   addCategory,
   onChange,
   addCategoriesShowModal,
@@ -32,8 +32,8 @@ export function AddCategoriesModal({
     isSubmittingRef.current = true;
     try {
       setIsSubmitting(true);
-      await addCategory(data);
-      setData({ categoryName: "" });
+      await addCategory(categoryForm);
+      setCategoryForm({ categoryName: "" });
       setAddCategoriesShowModal(false);
     } catch {
       return;
@@ -66,7 +66,7 @@ export function AddCategoriesModal({
               placeholder={categoryTranslations("modal.categoryNamePlaceholder")}
               isRequired
               errorMessage={categoryTranslations("modal.errorMsgInputFieldEmpty")}
-              value={data.categoryName ?? ""}
+              value={categoryForm.categoryName ?? ""}
               onChange={(event) => onChange({ categoryName: event.target.value })}
             />
             <ModalFooter className="flex justify-between p-0 my-4">

--- a/client/src/components/pages/Store/Products/Categories/AddCategoriesModal.jsx
+++ b/client/src/components/pages/Store/Products/Categories/AddCategoriesModal.jsx
@@ -35,6 +35,8 @@ export function AddCategoriesModal({
       await addCategory(data);
       setData({ categoryName: "" });
       setAddCategoriesShowModal(false);
+    } catch {
+      return;
     } finally {
       isSubmittingRef.current = false;
       setIsSubmitting(false);

--- a/client/src/components/pages/Store/Products/Categories/Categories.jsx
+++ b/client/src/components/pages/Store/Products/Categories/Categories.jsx
@@ -25,8 +25,8 @@ export function Categories({ categories, createCategory, updateCategory, deleteC
 
   const categoryTranslations = useTranslations("categories");
 
-  const handleCategoryFormChange = (newData) => {
-    setCategoryForm((prev) => ({ ...prev, ...newData }));
+  const handleCategoryFormChange = (categoryFormUpdates) => {
+    setCategoryForm((previousCategoryForm) => ({ ...previousCategoryForm, ...categoryFormUpdates }));
   };
 
   const handleEditCategory = (category) => {
@@ -48,13 +48,13 @@ export function Categories({ categories, createCategory, updateCategory, deleteC
       await createCategory(formData.categoryName, "product");
       await refreshData();
       addToast({ description: categoryTranslations("toasts.createSuccess"), color: "success" });
-    } catch (error) {
+    } catch (createCategoryError) {
       addToast({
         title: categoryTranslations("toasts.createErrorTitle"),
         description: categoryTranslations("toasts.createErrorDescription"),
         color: "danger",
       });
-      throw error;
+      throw createCategoryError;
     }
   };
 
@@ -62,13 +62,13 @@ export function Categories({ categories, createCategory, updateCategory, deleteC
     try {
       await updateCategory(formData);
       addToast({ description: categoryTranslations("toasts.updateSuccess"), color: "success" });
-    } catch (error) {
+    } catch (updateCategoryError) {
       addToast({
         title: categoryTranslations("toasts.updateErrorTitle"),
         description: categoryTranslations("toasts.updateErrorDescription"),
         color: "danger",
       });
-      throw error;
+      throw updateCategoryError;
     }
   };
 
@@ -80,13 +80,13 @@ export function Categories({ categories, createCategory, updateCategory, deleteC
         addToast({ description: categoryTranslations("toasts.deleteSuccess"), color: "success" });
       }
       setDeleteCategoriesShowModal(false);
-    } catch (error) {
+    } catch (deleteCategoryError) {
       addToast({
         title: categoryTranslations("toasts.deleteErrorTitle"),
         description: categoryTranslations("toasts.deleteErrorDescription"),
         color: "danger",
       });
-      throw error;
+      throw deleteCategoryError;
     }
   };
 
@@ -119,8 +119,8 @@ export function Categories({ categories, createCategory, updateCategory, deleteC
       </div>
 
       <AddCategoriesModal
-        data={categoryForm}
-        setData={setCategoryForm}
+        categoryForm={categoryForm}
+        setCategoryForm={setCategoryForm}
         addCategory={handleAddCategory}
         onChange={handleCategoryFormChange}
         addCategoriesShowModal={addCategoriesShowModal}
@@ -128,8 +128,8 @@ export function Categories({ categories, createCategory, updateCategory, deleteC
       />
 
       <EditCategoriesModal
-        data={categoryForm}
-        setData={setCategoryForm}
+        categoryForm={categoryForm}
+        setCategoryForm={setCategoryForm}
         category={selectedCategory}
         onChange={handleCategoryFormChange}
         updateCategory={handleUpdateCategory}

--- a/client/src/components/pages/Store/Products/Categories/Categories.jsx
+++ b/client/src/components/pages/Store/Products/Categories/Categories.jsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 
-import { Button } from "@heroui/react";
+import { addToast, Button } from "@heroui/react";
 import { useTranslations } from "next-intl";
 
 import { RequirePermission } from "@/hooks/usePermission";
@@ -23,7 +23,7 @@ export function Categories({ categories, createCategory, updateCategory, deleteC
     categoryName: "",
   });
 
-  const t = useTranslations("categories");
+  const categoryTranslations = useTranslations("categories");
 
   const handleCategoryFormChange = (newData) => {
     setCategoryForm((prev) => ({ ...prev, ...newData }));
@@ -44,16 +44,58 @@ export function Categories({ categories, createCategory, updateCategory, deleteC
   };
 
   const handleAddCategory = async (formData) => {
-    await createCategory(formData.categoryName, "product");
-    await refreshData();
+    try {
+      await createCategory(formData.categoryName, "product");
+      await refreshData();
+      addToast({ description: categoryTranslations("toasts.createSuccess"), color: "success" });
+    } catch (error) {
+      addToast({
+        title: categoryTranslations("toasts.createErrorTitle"),
+        description: categoryTranslations("toasts.createErrorDescription"),
+        color: "danger",
+      });
+      throw error;
+    }
+  };
+
+  const handleUpdateCategory = async (formData) => {
+    try {
+      await updateCategory(formData);
+      addToast({ description: categoryTranslations("toasts.updateSuccess"), color: "success" });
+    } catch (error) {
+      addToast({
+        title: categoryTranslations("toasts.updateErrorTitle"),
+        description: categoryTranslations("toasts.updateErrorDescription"),
+        color: "danger",
+      });
+      throw error;
+    }
+  };
+
+  const handleConfirmDeleteCategory = async () => {
+    try {
+      if (categoryToDelete?.id) {
+        await deleteCategory(categoryToDelete.id);
+        await refreshData();
+        addToast({ description: categoryTranslations("toasts.deleteSuccess"), color: "success" });
+      }
+      setDeleteCategoriesShowModal(false);
+    } catch (error) {
+      addToast({
+        title: categoryTranslations("toasts.deleteErrorTitle"),
+        description: categoryTranslations("toasts.deleteErrorDescription"),
+        color: "danger",
+      });
+      throw error;
+    }
   };
 
   return (
     <RequirePermission allOf={["categories_read"]}>
       <header className="flex items-center justify-between mb-6 mt-10">
         <div>
-          <h2 className="text-lg md:text-2xl font-semibold text-green-900">{t("title")}</h2>
-          <p className="text-gray-800 mt-1 md:mt-2 text-sm">{t("subtitle")}</p>
+          <h2 className="text-lg md:text-2xl font-semibold text-green-900">{categoryTranslations("title")}</h2>
+          <p className="text-gray-800 mt-1 md:mt-2 text-sm">{categoryTranslations("subtitle")}</p>
         </div>
         <RequirePermission allOf={["categories_create"]}>
           <Button
@@ -64,7 +106,7 @@ export function Categories({ categories, createCategory, updateCategory, deleteC
               setAddCategoriesShowModal(true);
             }}
           >
-            {t("addCategory")}
+            {categoryTranslations("addCategory")}
           </Button>
         </RequirePermission>
       </header>
@@ -90,7 +132,7 @@ export function Categories({ categories, createCategory, updateCategory, deleteC
         setData={setCategoryForm}
         category={selectedCategory}
         onChange={handleCategoryFormChange}
-        updateCategory={updateCategory}
+        updateCategory={handleUpdateCategory}
         editCategoriesShowModal={editCategoriesShowModal}
         setEditCategoriesShowModal={setEditCategoriesShowModal}
       />
@@ -99,13 +141,7 @@ export function Categories({ categories, createCategory, updateCategory, deleteC
         category={categoryToDelete}
         deleteCategoriesShowModal={deleteCategoriesShowModal}
         setDeleteCategoriesShowModal={setDeleteCategoriesShowModal}
-        onConfirm={async () => {
-          if (categoryToDelete?.id) {
-            await deleteCategory(categoryToDelete.id);
-            await refreshData();
-          }
-          setDeleteCategoriesShowModal(false);
-        }}
+        onConfirm={handleConfirmDeleteCategory}
       />
     </RequirePermission>
   );

--- a/client/src/components/pages/Store/Products/Categories/CategoriesTable.jsx
+++ b/client/src/components/pages/Store/Products/Categories/CategoriesTable.jsx
@@ -15,13 +15,13 @@ import { EditButton } from "@/components/shared/EditButton";
 import { RequirePermission } from "@/hooks/usePermission";
 
 export function CategoriesTable({ categories, canManageCategories, onEditCategory, onDeleteCategory }) {
-  const t = useTranslations("categories");
+  const categoryTranslations = useTranslations("categories");
 
   return (
-    <Table className="min-w-[400px]" removeWrapper aria-label={t("tableAriaLabel")}>
+    <Table className="min-w-[400px]" removeWrapper aria-label={categoryTranslations("tableAriaLabel")}>
       <TableHeader>
-        <TableColumn className="py-2 px-3 w-[200px]">{t("name")}</TableColumn>
-        <TableColumn className={canManageCategories ? "py-2 px-3 w-40 text-right" : "hidden"}>{t("actions")}</TableColumn>
+        <TableColumn className="py-2 px-3 w-[200px]">{categoryTranslations("name")}</TableColumn>
+        <TableColumn className={canManageCategories ? "py-2 px-3 w-40 text-right" : "hidden"}>{categoryTranslations("actions")}</TableColumn>
       </TableHeader>
       <TableBody>
         {categories.map((category) => (
@@ -30,10 +30,10 @@ export function CategoriesTable({ categories, canManageCategories, onEditCategor
             <TableCell className={canManageCategories ? "py-2 px-3" : "hidden"}>
               <div className="flex justify-end gap-2">
                 <RequirePermission allOf={["categories_update"]}>
-                  <EditButton onPress={() => onEditCategory(category)}>{t("edit")}</EditButton>
+                  <EditButton onPress={() => onEditCategory(category)}>{categoryTranslations("edit")}</EditButton>
                 </RequirePermission>
                 <RequirePermission allOf={["categories_delete"]}>
-                  <DeleteButton onPress={() => onDeleteCategory(category)}>{t("delete")}</DeleteButton>
+                  <DeleteButton onPress={() => onDeleteCategory(category)}>{categoryTranslations("delete")}</DeleteButton>
                 </RequirePermission>
               </div>
             </TableCell>

--- a/client/src/components/pages/Store/Products/Categories/DeleteCategoriesModal.jsx
+++ b/client/src/components/pages/Store/Products/Categories/DeleteCategoriesModal.jsx
@@ -1,10 +1,28 @@
 "use client";
 
+import { useRef, useState } from "react";
+
 import { Modal, ModalContent, ModalHeader, ModalBody, ModalFooter, Button } from "@heroui/react";
 import { useTranslations } from "next-intl";
 
 export function DeleteCategoriesModal({ category, deleteCategoriesShowModal, setDeleteCategoriesShowModal, onConfirm }) {
-  const t = useTranslations("categories");
+  const categoryTranslations = useTranslations("categories");
+  const [isDeleting, setIsDeleting] = useState(false);
+  const isDeletingRef = useRef(false);
+
+  const handleConfirmDeleteCategory = async () => {
+    if (isDeletingRef.current) return;
+
+    isDeletingRef.current = true;
+    try {
+      setIsDeleting(true);
+      await onConfirm?.();
+    } finally {
+      isDeletingRef.current = false;
+      setIsDeleting(false);
+    }
+  };
+
   return (
     <Modal
       isOpen={deleteCategoriesShowModal}
@@ -16,10 +34,10 @@ export function DeleteCategoriesModal({ category, deleteCategoriesShowModal, set
       }}
     >
       <ModalContent>
-        <ModalHeader>{t("modal.titleDelete")}</ModalHeader>
+        <ModalHeader>{categoryTranslations("modal.titleDelete")}</ModalHeader>
         <ModalBody>
-          <p>{t("modal.subtitleDelete")}<b> {category?.name}</b>?</p>
-          <p className="text-red-500 text-sm">{t("modal.warningDelete")}</p>
+          <p>{categoryTranslations("modal.subtitleDelete")}<b> {category?.name}</b>?</p>
+          <p className="text-red-500 text-sm">{categoryTranslations("modal.warningDelete")}</p>
         </ModalBody>
         <ModalFooter>
           <Button
@@ -27,11 +45,17 @@ export function DeleteCategoriesModal({ category, deleteCategoriesShowModal, set
             type="button"
             className="px-6 py-2 border border-border text-foreground hover:bg-muted disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
             onPress={() => setDeleteCategoriesShowModal(false)}
+            isDisabled={isDeleting}
           >
-            {t("modal.cancelButton")}
+            {categoryTranslations("modal.cancelButton")}
           </Button>
-          <Button color="danger" onPress={onConfirm}>
-            {t("modal.deleteButton")}
+          <Button
+            color="danger"
+            onPress={handleConfirmDeleteCategory}
+            isDisabled={isDeleting}
+            isLoading={isDeleting}
+          >
+            {categoryTranslations("modal.deleteButton")}
           </Button>
         </ModalFooter>
       </ModalContent>

--- a/client/src/components/pages/Store/Products/Categories/DeleteCategoriesModal.jsx
+++ b/client/src/components/pages/Store/Products/Categories/DeleteCategoriesModal.jsx
@@ -17,6 +17,8 @@ export function DeleteCategoriesModal({ category, deleteCategoriesShowModal, set
     try {
       setIsDeleting(true);
       await onConfirm?.();
+    } catch {
+      return;
     } finally {
       isDeletingRef.current = false;
       setIsDeleting(false);

--- a/client/src/components/pages/Store/Products/Categories/EditCategoriesModal.jsx
+++ b/client/src/components/pages/Store/Products/Categories/EditCategoriesModal.jsx
@@ -14,8 +14,8 @@ import {
 import { useTranslations } from "next-intl";
 
 export function EditCategoriesModal({
-  data,
-  setData,
+  categoryForm,
+  setCategoryForm,
   onChange,
   updateCategory,
   editCategoriesShowModal,
@@ -26,7 +26,7 @@ export function EditCategoriesModal({
   const isSubmittingRef = useRef(false);
 
   const handleOnCloseModal = () => {
-    setData({ categoryId: "", categoryName: "" });
+    setCategoryForm({ categoryId: "", categoryName: "" });
     setEditCategoriesShowModal(false);
   };
 
@@ -37,7 +37,7 @@ export function EditCategoriesModal({
     isSubmittingRef.current = true;
     try {
       setIsSubmitting(true);
-      await updateCategory(data);
+      await updateCategory(categoryForm);
       setEditCategoriesShowModal(false);
     } catch {
       return;
@@ -70,7 +70,7 @@ export function EditCategoriesModal({
               placeholder={categoryTranslations("modal.categoryNamePlaceholder")}
               isRequired
               errorMessage={categoryTranslations("modal.errorMsgInputFieldEmpty")}
-              value={data.categoryName ?? ""}
+              value={categoryForm.categoryName ?? ""}
               onChange={(event) => onChange({ categoryName: event.target.value })}
             />
             <ModalFooter className="flex justify-between p-0 my-4">

--- a/client/src/components/pages/Store/Products/Categories/EditCategoriesModal.jsx
+++ b/client/src/components/pages/Store/Products/Categories/EditCategoriesModal.jsx
@@ -39,6 +39,8 @@ export function EditCategoriesModal({
       setIsSubmitting(true);
       await updateCategory(data);
       setEditCategoriesShowModal(false);
+    } catch {
+      return;
     } finally {
       isSubmittingRef.current = false;
       setIsSubmitting(false);

--- a/client/src/components/pages/Store/Products/Categories/EditCategoriesModal.jsx
+++ b/client/src/components/pages/Store/Products/Categories/EditCategoriesModal.jsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 
 import {
   Button,
@@ -21,23 +21,26 @@ export function EditCategoriesModal({
   editCategoriesShowModal,
   setEditCategoriesShowModal,
 }) {
-  const t = useTranslations("categories");
+  const categoryTranslations = useTranslations("categories");
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const isSubmittingRef = useRef(false);
 
   const handleOnCloseModal = () => {
     setData({ categoryId: "", categoryName: "" });
     setEditCategoriesShowModal(false);
   };
 
-  const handleSubmit = async (e) => {
-    e.preventDefault();
-    if (isSubmitting) return;
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    if (isSubmittingRef.current) return;
 
+    isSubmittingRef.current = true;
     try {
       setIsSubmitting(true);
       await updateCategory(data);
       setEditCategoriesShowModal(false);
     } finally {
+      isSubmittingRef.current = false;
       setIsSubmitting(false);
     }
   };
@@ -56,17 +59,17 @@ export function EditCategoriesModal({
       }}
     >
       <ModalContent>
-        <ModalHeader>{t("modal.titleEdit")}</ModalHeader>
+        <ModalHeader>{categoryTranslations("modal.titleEdit")}</ModalHeader>
         <ModalBody>
           <form className="space-y-4" onSubmit={handleSubmit}>
             <Input
-              label={t("modal.categoryNameLabel")}
+              label={categoryTranslations("modal.categoryNameLabel")}
               type="text"
-              placeholder={t("modal.categoryNamePlaceholder")}
+              placeholder={categoryTranslations("modal.categoryNamePlaceholder")}
               isRequired
-              errorMessage={t("modal.errorMsgInputFieldEmpty")}
+              errorMessage={categoryTranslations("modal.errorMsgInputFieldEmpty")}
               value={data.categoryName ?? ""}
-              onChange={(e) => onChange({ categoryName: e.target.value })}
+              onChange={(event) => onChange({ categoryName: event.target.value })}
             />
             <ModalFooter className="flex justify-between p-0 my-4">
               <Button
@@ -75,15 +78,16 @@ export function EditCategoriesModal({
                 className="px-6 py-2 border border-border text-foreground hover:bg-muted disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
                 onPress={() => handleOnCloseModal()}
               >
-                {t("modal.cancelButton")}
+                {categoryTranslations("modal.cancelButton")}
               </Button>
               <Button
                 color="primary"
                 className="bg-green-800"
                 type="submit"
+                isDisabled={isSubmitting}
                 isLoading={isSubmitting}
               >
-                {t("modal.editButton")}
+                {categoryTranslations("modal.editButton")}
               </Button>
             </ModalFooter>
           </form>

--- a/client/src/components/pages/Store/Products/Categories/__tests__/AddCategoriesModal.test.jsx
+++ b/client/src/components/pages/Store/Products/Categories/__tests__/AddCategoriesModal.test.jsx
@@ -69,6 +69,20 @@ describe("AddCategoriesModal", () => {
     expect(setAddCategoriesShowModal).toHaveBeenCalledWith(false);
   });
 
+  it("does not reset or close when addCategory fails", async () => {
+    const addCategory = jest.fn(() => Promise.reject(new Error("add failed")));
+    const setAddCategoriesShowModal = jest.fn();
+    const setData = jest.fn();
+
+    renderModal({ addCategory, setAddCategoriesShowModal, setData });
+
+    fireEvent.click(screen.getByText("modal.submitButton"));
+
+    await waitFor(() => expect(addCategory).toHaveBeenCalledWith(baseData));
+    expect(setData).not.toHaveBeenCalled();
+    expect(setAddCategoriesShowModal).not.toHaveBeenCalledWith(false);
+  });
+
   it("prevents double submit while submitting", () => {
     const addCategory = jest.fn(() => new Promise(() => {}));
     renderModal({ addCategory });

--- a/client/src/components/pages/Store/Products/Categories/__tests__/AddCategoriesModal.test.jsx
+++ b/client/src/components/pages/Store/Products/Categories/__tests__/AddCategoriesModal.test.jsx
@@ -4,21 +4,21 @@ import { I18nProvider } from "@/i18n/I18nProvider";
 
 import { AddCategoriesModal } from "../AddCategoriesModal";
 
-const baseData = {
+const baseCategoryForm = {
   categoryId: "",
   categoryName: "New Cat",
 };
 
-const renderModal = (props = {}) => render(
+const renderModal = (modalProps = {}) => render(
   <I18nProvider>
     <AddCategoriesModal
-      data={baseData}
-      setData={jest.fn()}
+      categoryForm={baseCategoryForm}
+      setCategoryForm={jest.fn()}
       addCategory={jest.fn(() => Promise.resolve())}
       onChange={jest.fn()}
       addCategoriesShowModal
       setAddCategoriesShowModal={jest.fn()}
-      {...props}
+      {...modalProps}
     />
   </I18nProvider>,
 );
@@ -55,31 +55,31 @@ describe("AddCategoriesModal", () => {
     expect(setAddCategoriesShowModal).toHaveBeenCalledWith(false);
   });
 
-  it("calls addCategory with data on submit and closes modal", async () => {
+  it("calls addCategory with category form on submit and closes modal", async () => {
     const addCategory = jest.fn(() => Promise.resolve());
     const setAddCategoriesShowModal = jest.fn();
-    const setData = jest.fn();
+    const setCategoryForm = jest.fn();
 
-    renderModal({ addCategory, setAddCategoriesShowModal, setData });
+    renderModal({ addCategory, setAddCategoriesShowModal, setCategoryForm });
 
     fireEvent.click(screen.getByText("modal.submitButton"));
 
-    await waitFor(() => expect(addCategory).toHaveBeenCalledWith(baseData));
-    expect(setData).toHaveBeenCalledWith({ categoryName: "" });
+    await waitFor(() => expect(addCategory).toHaveBeenCalledWith(baseCategoryForm));
+    expect(setCategoryForm).toHaveBeenCalledWith({ categoryName: "" });
     expect(setAddCategoriesShowModal).toHaveBeenCalledWith(false);
   });
 
   it("does not reset or close when addCategory fails", async () => {
     const addCategory = jest.fn(() => Promise.reject(new Error("add failed")));
     const setAddCategoriesShowModal = jest.fn();
-    const setData = jest.fn();
+    const setCategoryForm = jest.fn();
 
-    renderModal({ addCategory, setAddCategoriesShowModal, setData });
+    renderModal({ addCategory, setAddCategoriesShowModal, setCategoryForm });
 
     fireEvent.click(screen.getByText("modal.submitButton"));
 
-    await waitFor(() => expect(addCategory).toHaveBeenCalledWith(baseData));
-    expect(setData).not.toHaveBeenCalled();
+    await waitFor(() => expect(addCategory).toHaveBeenCalledWith(baseCategoryForm));
+    expect(setCategoryForm).not.toHaveBeenCalled();
     expect(setAddCategoriesShowModal).not.toHaveBeenCalledWith(false);
   });
 

--- a/client/src/components/pages/Store/Products/Categories/__tests__/Categories.test.jsx
+++ b/client/src/components/pages/Store/Products/Categories/__tests__/Categories.test.jsx
@@ -4,6 +4,11 @@ import { I18nProvider } from "@/i18n/I18nProvider";
 
 import { Categories } from "../Categories";
 
+jest.mock("@heroui/react", () => {
+  const actual = jest.requireActual("@heroui/react");
+  return { ...actual, addToast: jest.fn() };
+});
+
 jest.mock("@/hooks/usePermission", () => ({
   RequirePermission: ({ children }) => <>{children}</>,
   usePermission: () => true,
@@ -21,6 +26,8 @@ const categories = [
   { id: "cat-1", name: "Hardware" },
   { id: "cat-2", name: "Gadgets" },
 ];
+
+const { addToast } = require("@heroui/react");
 
 const renderCategories = (props = {}) => render(
   <I18nProvider>
@@ -97,6 +104,35 @@ describe("Categories", () => {
 
     await waitFor(() => expect(createCategory).toHaveBeenCalledWith("New Category", "product"));
     expect(refreshData).toHaveBeenCalled();
+    expect(addToast).toHaveBeenCalledWith({
+      description: "toasts.createSuccess",
+      color: "success",
+    });
+  });
+
+  it("shows an error toast and keeps add modal open when category creation fails", async () => {
+    const createCategory = jest.fn(() => Promise.reject(new Error("create failed")));
+    renderCategories({ createCategory });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("addCategory"));
+    });
+
+    fireEvent.change(screen.getByLabelText("modal.categoryNameLabel"), {
+      target: { value: "New Category" },
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("modal.submitButton"));
+    });
+
+    await waitFor(() => expect(createCategory).toHaveBeenCalledWith("New Category", "product"));
+    expect(addToast).toHaveBeenCalledWith({
+      title: "toasts.createErrorTitle",
+      description: "toasts.createErrorDescription",
+      color: "danger",
+    });
+    expect(screen.getByText("modal.titleAdd")).toBeInTheDocument();
   });
 
   it("calls updateCategory when saving an edited category", async () => {
@@ -117,6 +153,36 @@ describe("Categories", () => {
     await waitFor(() => expect(updateCategory).toHaveBeenCalledWith(
       expect.objectContaining({ categoryName: "Hardware Updated" }),
     ));
+    expect(addToast).toHaveBeenCalledWith({
+      description: "toasts.updateSuccess",
+      color: "success",
+    });
+  });
+
+  it("shows an error toast and keeps edit modal open when category update fails", async () => {
+    const updateCategory = jest.fn(() => Promise.reject(new Error("update failed")));
+    renderCategories({ updateCategory });
+
+    await act(async () => {
+      fireEvent.click(screen.getAllByText("edit")[0].closest("button"));
+    });
+
+    const input = screen.getByLabelText("modal.categoryNameLabel");
+    fireEvent.change(input, { target: { value: "Hardware Updated" } });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("modal.editButton"));
+    });
+
+    await waitFor(() => expect(updateCategory).toHaveBeenCalledWith(
+      expect.objectContaining({ categoryName: "Hardware Updated" }),
+    ));
+    expect(addToast).toHaveBeenCalledWith({
+      title: "toasts.updateErrorTitle",
+      description: "toasts.updateErrorDescription",
+      color: "danger",
+    });
+    expect(screen.getByText("modal.titleEdit")).toBeInTheDocument();
   });
 
   it("calls deleteCategory and closes modal when confirming deletion", async () => {
@@ -134,6 +200,31 @@ describe("Categories", () => {
 
     await waitFor(() => expect(deleteCategory).toHaveBeenCalledWith("cat-1"));
     expect(refreshData).toHaveBeenCalled();
+    expect(addToast).toHaveBeenCalledWith({
+      description: "toasts.deleteSuccess",
+      color: "success",
+    });
     expect(screen.queryByText("modal.titleDelete")).not.toBeInTheDocument();
+  });
+
+  it("shows an error toast and keeps delete modal open when category deletion fails", async () => {
+    const deleteCategory = jest.fn(() => Promise.reject(new Error("delete failed")));
+    renderCategories({ deleteCategory });
+
+    await act(async () => {
+      fireEvent.click(screen.getAllByText("delete")[0].closest("button"));
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("modal.deleteButton"));
+    });
+
+    await waitFor(() => expect(deleteCategory).toHaveBeenCalledWith("cat-1"));
+    expect(addToast).toHaveBeenCalledWith({
+      title: "toasts.deleteErrorTitle",
+      description: "toasts.deleteErrorDescription",
+      color: "danger",
+    });
+    expect(screen.getByText("modal.titleDelete")).toBeInTheDocument();
   });
 });

--- a/client/src/components/pages/Store/Products/Categories/__tests__/DeleteCategoriesModal.test.jsx
+++ b/client/src/components/pages/Store/Products/Categories/__tests__/DeleteCategoriesModal.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 
 import { I18nProvider } from "@/i18n/I18nProvider";
 
@@ -46,6 +46,26 @@ describe("DeleteCategoriesModal", () => {
 
     fireEvent.click(screen.getByText("modal.deleteButton"));
     expect(onConfirm).toHaveBeenCalled();
+  });
+
+  it("prevents double confirm while deleting", async () => {
+    const onConfirm = jest.fn(() => new Promise(() => {}));
+    renderModal({ onConfirm });
+
+    fireEvent.click(screen.getByText("modal.deleteButton"));
+    fireEvent.click(screen.getByText("modal.deleteButton"));
+
+    await waitFor(() => expect(onConfirm).toHaveBeenCalledTimes(1));
+  });
+
+  it("disables action buttons while deleting", async () => {
+    const onConfirm = jest.fn(() => new Promise(() => {}));
+    renderModal({ onConfirm });
+
+    fireEvent.click(screen.getByText("modal.deleteButton"));
+
+    await waitFor(() => expect(screen.getByText("modal.deleteButton").closest("button")).toBeDisabled());
+    expect(screen.getByText("modal.cancelButton").closest("button")).toBeDisabled();
   });
 
   it("does not render when deleteCategoriesShowModal is false", () => {

--- a/client/src/components/pages/Store/Products/Categories/__tests__/EditCategoriesModal.test.jsx
+++ b/client/src/components/pages/Store/Products/Categories/__tests__/EditCategoriesModal.test.jsx
@@ -4,21 +4,21 @@ import { I18nProvider } from "@/i18n/I18nProvider";
 
 import { EditCategoriesModal } from "../EditCategoriesModal";
 
-const baseData = {
+const baseCategoryForm = {
   categoryId: "cat-1",
   categoryName: "Hardware",
 };
 
-const renderModal = (props = {}) => render(
+const renderModal = (modalProps = {}) => render(
   <I18nProvider>
     <EditCategoriesModal
-      data={baseData}
-      setData={jest.fn()}
+      categoryForm={baseCategoryForm}
+      setCategoryForm={jest.fn()}
       onChange={jest.fn()}
       updateCategory={jest.fn(() => Promise.resolve())}
       editCategoriesShowModal
       setEditCategoriesShowModal={jest.fn()}
-      {...props}
+      {...modalProps}
     />
   </I18nProvider>,
 );
@@ -47,18 +47,18 @@ describe("EditCategoriesModal", () => {
     expect(onChange).toHaveBeenCalledWith({ categoryName: "Hardware Updated" });
   });
 
-  it("resets data and closes modal when cancel is clicked", () => {
-    const setData = jest.fn();
+  it("resets category form and closes modal when cancel is clicked", () => {
+    const setCategoryForm = jest.fn();
     const setEditCategoriesShowModal = jest.fn();
-    renderModal({ setData, setEditCategoriesShowModal });
+    renderModal({ setCategoryForm, setEditCategoriesShowModal });
 
     fireEvent.click(screen.getByText("modal.cancelButton"));
 
-    expect(setData).toHaveBeenCalledWith({ categoryId: "", categoryName: "" });
+    expect(setCategoryForm).toHaveBeenCalledWith({ categoryId: "", categoryName: "" });
     expect(setEditCategoriesShowModal).toHaveBeenCalledWith(false);
   });
 
-  it("calls updateCategory with data on submit and closes modal", async () => {
+  it("calls updateCategory with category form on submit and closes modal", async () => {
     const updateCategory = jest.fn(() => Promise.resolve());
     const setEditCategoriesShowModal = jest.fn();
 
@@ -66,7 +66,7 @@ describe("EditCategoriesModal", () => {
 
     fireEvent.click(screen.getByText("modal.editButton"));
 
-    await waitFor(() => expect(updateCategory).toHaveBeenCalledWith(baseData));
+    await waitFor(() => expect(updateCategory).toHaveBeenCalledWith(baseCategoryForm));
     expect(setEditCategoriesShowModal).toHaveBeenCalledWith(false);
   });
 
@@ -78,7 +78,7 @@ describe("EditCategoriesModal", () => {
 
     fireEvent.click(screen.getByText("modal.editButton"));
 
-    await waitFor(() => expect(updateCategory).toHaveBeenCalledWith(baseData));
+    await waitFor(() => expect(updateCategory).toHaveBeenCalledWith(baseCategoryForm));
     expect(setEditCategoriesShowModal).not.toHaveBeenCalledWith(false);
   });
 

--- a/client/src/components/pages/Store/Products/Categories/__tests__/EditCategoriesModal.test.jsx
+++ b/client/src/components/pages/Store/Products/Categories/__tests__/EditCategoriesModal.test.jsx
@@ -70,6 +70,18 @@ describe("EditCategoriesModal", () => {
     expect(setEditCategoriesShowModal).toHaveBeenCalledWith(false);
   });
 
+  it("does not close when updateCategory fails", async () => {
+    const updateCategory = jest.fn(() => Promise.reject(new Error("update failed")));
+    const setEditCategoriesShowModal = jest.fn();
+
+    renderModal({ updateCategory, setEditCategoriesShowModal });
+
+    fireEvent.click(screen.getByText("modal.editButton"));
+
+    await waitFor(() => expect(updateCategory).toHaveBeenCalledWith(baseData));
+    expect(setEditCategoriesShowModal).not.toHaveBeenCalledWith(false);
+  });
+
   it("prevents double submit while submitting", () => {
     const updateCategory = jest.fn(() => new Promise(() => {}));
     renderModal({ updateCategory });

--- a/client/src/components/pages/Store/Products/Categories/locales/en.js
+++ b/client/src/components/pages/Store/Products/Categories/locales/en.js
@@ -28,6 +28,15 @@ const categoriesEn = {
     toasts: {
       genericErrorTitle: "Error",
       genericErrorDescription: "Could not complete the operation.",
+      createSuccess: "Category created successfully",
+      createErrorTitle: "Could not create category",
+      createErrorDescription: "Check the category name and try again.",
+      updateSuccess: "Category updated successfully",
+      updateErrorTitle: "Could not update category",
+      updateErrorDescription: "Check the category name and try again.",
+      deleteSuccess: "Category deleted successfully",
+      deleteErrorTitle: "Could not delete category",
+      deleteErrorDescription: "Try again or check whether this category is still in use.",
     },
   },
 };

--- a/client/src/components/pages/Store/Products/Categories/locales/es.js
+++ b/client/src/components/pages/Store/Products/Categories/locales/es.js
@@ -28,6 +28,15 @@ const categoriesEs = {
     toasts: {
       genericErrorTitle: "Error",
       genericErrorDescription: "No se pudo completar la operación.",
+      createSuccess: "Categoría creada correctamente",
+      createErrorTitle: "No se pudo crear la categoría",
+      createErrorDescription: "Revisa el nombre de la categoría e inténtalo de nuevo.",
+      updateSuccess: "Categoría actualizada correctamente",
+      updateErrorTitle: "No se pudo actualizar la categoría",
+      updateErrorDescription: "Revisa el nombre de la categoría e inténtalo de nuevo.",
+      deleteSuccess: "Categoría eliminada correctamente",
+      deleteErrorTitle: "No se pudo eliminar la categoría",
+      deleteErrorDescription: "Inténtalo de nuevo o revisa si esta categoría sigue en uso.",
     },
   },
 };

--- a/client/src/components/pages/Store/hooks/__tests__/useCategories.test.jsx
+++ b/client/src/components/pages/Store/hooks/__tests__/useCategories.test.jsx
@@ -16,8 +16,8 @@ jest.mock("@heroui/react", () => ({
 }));
 
 jest.mock("next-intl", () => {
-  const t = (key) => key;
-  return { useTranslations: () => t };
+  const categoryTranslations = (key) => key;
+  return { useTranslations: () => categoryTranslations };
 });
 
 const handlers = {};
@@ -173,6 +173,26 @@ describe("useCategories", () => {
     await waitFor(() => expect(screen.getByTestId("first-name")).toHaveTextContent("Hardware Updated"));
   });
 
+  it("throws when updating a category is rejected by the API", async () => {
+    httpClient.mockResolvedValueOnce({ ok: true });
+    parseJsonResponse.mockResolvedValueOnce([{ id: "cat-1", name: "Hardware" }]);
+    httpClient.mockResolvedValueOnce({ ok: false, status: 400 });
+
+    render(<TestComponent />);
+    await waitFor(() => expect(screen.getByTestId("count")).toHaveTextContent("1"));
+
+    let thrownError;
+    await act(async () => {
+      try {
+        await handlers.updateCategory({ categoryId: "cat-1", categoryName: "Hardware Updated" });
+      } catch (error) {
+        thrownError = error;
+      }
+    });
+
+    expect(thrownError?.status).toBe(400);
+  });
+
   it("deletes a category and refetches", async () => {
     httpClient.mockResolvedValue({ ok: true });
     parseJsonResponse.mockResolvedValueOnce([{ id: "cat-1", name: "Hardware" }]);
@@ -189,5 +209,25 @@ describe("useCategories", () => {
       method: "DELETE",
     });
     await waitFor(() => expect(screen.getByTestId("count")).toHaveTextContent("0"));
+  });
+
+  it("throws when deleting a category is rejected by the API", async () => {
+    httpClient.mockResolvedValueOnce({ ok: true });
+    parseJsonResponse.mockResolvedValueOnce([{ id: "cat-1", name: "Hardware" }]);
+    httpClient.mockResolvedValueOnce({ ok: false, status: 409 });
+
+    render(<TestComponent />);
+    await waitFor(() => expect(screen.getByTestId("count")).toHaveTextContent("1"));
+
+    let thrownError;
+    await act(async () => {
+      try {
+        await handlers.deleteCategory("cat-1");
+      } catch (error) {
+        thrownError = error;
+      }
+    });
+
+    expect(thrownError?.status).toBe(409);
   });
 });

--- a/client/src/components/pages/Store/hooks/__tests__/useCategories.test.jsx
+++ b/client/src/components/pages/Store/hooks/__tests__/useCategories.test.jsx
@@ -102,9 +102,9 @@ describe("useCategories", () => {
     render(<TestComponent />);
     await waitFor(() => expect(screen.getByTestId("count")).toHaveTextContent("0"));
 
-    let result;
+    let createdCategoryId;
     await act(async () => {
-      result = await handlers.createCategory("Electronics");
+      createdCategoryId = await handlers.createCategory("Electronics");
     });
 
     expect(httpClient).toHaveBeenCalledWith("/categories", {
@@ -113,7 +113,7 @@ describe("useCategories", () => {
       headers: { "Content-Type": "application/json" },
       notShowError: false,
     });
-    expect(result).toBe("cat-3");
+    expect(createdCategoryId).toBe("cat-3");
     await waitFor(() => expect(screen.getByTestId("count")).toHaveTextContent("1"));
   });
 
@@ -185,8 +185,8 @@ describe("useCategories", () => {
     await act(async () => {
       try {
         await handlers.updateCategory({ categoryId: "cat-1", categoryName: "Hardware Updated" });
-      } catch (error) {
-        thrownError = error;
+      } catch (updateCategoryError) {
+        thrownError = updateCategoryError;
       }
     });
 
@@ -223,8 +223,8 @@ describe("useCategories", () => {
     await act(async () => {
       try {
         await handlers.deleteCategory("cat-1");
-      } catch (error) {
-        thrownError = error;
+      } catch (deleteCategoryError) {
+        thrownError = deleteCategoryError;
       }
     });
 


### PR DESCRIPTION
  This PR improves toast notification coverage for the Categories workflow in Store Management.

  ## Changes

  - Adds localized toast messages for category create, update, and delete actions.
  - Shows success toasts when category create, update, and delete actions complete successfully.
  - Shows action-specific error toasts when category create, update, or delete fails.
  - Keeps add/edit/delete modals open when a mutation fails, so users do not lose context.
  - Adds submit/delete guards to prevent double submit, duplicate HTTP calls, and duplicate toasts.
  - Updates category API handling in `useCategories` so non-OK HTTP responses throw instead of being treated as successful.
  - Cleans up touched category files with descriptive variable names, including `categoryForm` / `setCategoryForm`.

  ## Testing

  - Added automated regression coverage for category toast behavior.
  - Covered success and failure feedback for category create, update, and delete actions.
  - Covered modal behavior to ensure failed mutations keep the modal open.
  - Covered duplicate-submit guards to prevent duplicate HTTP calls and duplicate toasts.

CI note: the failing `npm audit --audit-level=high` checks appear to be the current repo-wide dependency audit issue related to `.npmrc` `min-release-age`, as discussed by the team. This branch does not change `client/package*.json` or `electron/package*.json`.

<img width="605" height="487" alt="Screenshot From 2026-07-24 13-10-36" src="https://github.com/user-attachments/assets/bada2553-bee8-4247-a27f-5ef67817e9a1" />

<img width="605" height="487" alt="Screenshot From 2026-07-24 13-11-13" src="https://github.com/user-attachments/assets/ce5cdb4a-4e29-41df-ac2e-b21a38bf8e98" />

<img width="605" height="487" alt="Screenshot From 2026-07-24 13-11-24" src="https://github.com/user-attachments/assets/503d708a-b159-4d4d-acba-9e5fc2dba62a" />