### PR TITLE
Refactor: Share HTTP error handling for failed requests

### DIFF
--- a/client/src/components/pages/Store/Orders/RefundModal.jsx
+++ b/client/src/components/pages/Store/Orders/RefundModal.jsx
@@ -15,18 +15,11 @@ import {
 } from "@heroui/react";
 import { useTranslations } from "next-intl";
 
-import { httpClient, parseJsonResponse } from "@/lib/http";
+import { buildParsedHttpError } from "@/components/pages/Store/utils/buildHttpError";
+import { httpClient } from "@/lib/http";
 import { getBolt11ValidationErrorCode } from "@/utils/validateBolt11Invoice";
 
 import { CashRefundFields } from "./CashRefundFields";
-
-async function buildHttpRequestError(response, fallbackMessage) {
-  const responsePayload = await parseJsonResponse(response, null);
-  const requestError = new Error(fallbackMessage);
-  requestError.status = response.status;
-  requestError.responseMessage = responsePayload?.message;
-  return requestError;
-}
 
 function getInvoiceErrorMessage(invoiceValue, translate) {
   const hasFormatError = getBolt11ValidationErrorCode(invoiceValue) !== "";
@@ -81,7 +74,7 @@ export function RefundModal({ order, isOpen, onClose, onRefunded, formatAmount }
       });
 
       if (refundResponse.ok === false) {
-        throw await buildHttpRequestError(refundResponse, ordersTranslations("details.refundError"));
+        throw await buildParsedHttpError(refundResponse, ordersTranslations("details.refundError"));
       }
 
       addToast({
@@ -90,10 +83,10 @@ export function RefundModal({ order, isOpen, onClose, onRefunded, formatAmount }
       });
       setInvoice("");
       onRefunded();
-    } catch (error) {
+    } catch (refundError) {
       addToast({
         color: "danger",
-        description: error?.responseMessage || error?.message || ordersTranslations("details.refundError"),
+        description: refundError?.responseMessage || refundError?.message || ordersTranslations("details.refundError"),
       });
     } finally {
       setLoading(false);

--- a/client/src/components/pages/Store/hooks/__tests__/useCategories.test.jsx
+++ b/client/src/components/pages/Store/hooks/__tests__/useCategories.test.jsx
@@ -135,6 +135,24 @@ describe("useCategories", () => {
     }));
   });
 
+  it("rejects when category creation returns a failed response", async () => {
+    httpClient.mockResolvedValueOnce({ ok: true });
+    parseJsonResponse.mockResolvedValueOnce([]);
+    httpClient.mockResolvedValueOnce({ ok: false, status: 409 });
+    parseJsonResponse.mockResolvedValueOnce({ message: "Category already exists" });
+
+    render(<TestComponent />);
+    await waitFor(() => expect(screen.getByTestId("count")).toHaveTextContent("0"));
+
+    await expect(handlers.createCategory("Electronics")).rejects.toMatchObject({
+      message: "Error creating category",
+      status: 409,
+      responseMessage: "Category already exists",
+    });
+
+    expect(httpClient).toHaveBeenCalledTimes(2);
+  });
+
   it("updates a category and refetches", async () => {
     httpClient.mockResolvedValue({ ok: true });
     parseJsonResponse.mockResolvedValueOnce([{ id: "cat-1", name: "Hardware" }]);

--- a/client/src/components/pages/Store/hooks/useCategories.jsx
+++ b/client/src/components/pages/Store/hooks/useCategories.jsx
@@ -5,6 +5,8 @@ import { toArray } from "@/components/utils/array";
 import { httpClient, parseJsonResponse } from "@/lib/http";
 import { useFetchList } from "@/lib/http/useFetchList";
 
+import { buildParsedHttpError } from "../utils/buildHttpError";
+
 export function useCategories(type = "product") {
   const { fetchList } = useFetchList();
   const [categories, setCategories] = useState([]);
@@ -19,9 +21,9 @@ export function useCategories(type = "product") {
       const categoryList = await fetchList(`/categories?type=${type}`);
       if (categoryList === null) return;
       setCategories(toArray(categoryList));
-    } catch (error) {
-      console.error("Error fetching categories:", error);
-      setError(error);
+    } catch (categoryLoadError) {
+      console.error("Error fetching categories:", categoryLoadError);
+      setError(categoryLoadError);
     } finally {
       setLoading(false);
     }
@@ -37,6 +39,9 @@ export function useCategories(type = "product") {
         },
         notShowError: false,
       });
+      if (createCategoryResponse.ok === false) {
+        throw await buildParsedHttpError(createCategoryResponse, "Error creating category");
+      }
       const createdCategory = await parseJsonResponse(createCategoryResponse, {});
 
       await fetchCategories();
@@ -47,13 +52,16 @@ export function useCategories(type = "product") {
 
   const updateCategory = useCallback(
     async (category) => {
-      await httpClient(`/categories/${category.categoryId}`, {
+      const updateCategoryResponse = await httpClient(`/categories/${category.categoryId}`, {
         method: "PUT",
         body: JSON.stringify({ name: category.categoryName, type: "product" }),
         headers: {
           "Content-Type": "application/json",
         },
       });
+      if (updateCategoryResponse.ok === false) {
+        throw await buildParsedHttpError(updateCategoryResponse, "Error updating category");
+      }
 
       await fetchCategories();
     },
@@ -62,9 +70,12 @@ export function useCategories(type = "product") {
 
   const deleteCategory = useCallback(
     async (categoryId) => {
-      await httpClient(`/categories/${categoryId}?type=${type}`, {
+      const deleteCategoryResponse = await httpClient(`/categories/${categoryId}?type=${type}`, {
         method: "DELETE",
       });
+      if (deleteCategoryResponse.ok === false) {
+        throw await buildParsedHttpError(deleteCategoryResponse, "Error deleting category");
+      }
 
       await fetchCategories();
     },

--- a/client/src/components/pages/Store/hooks/useProducts.jsx
+++ b/client/src/components/pages/Store/hooks/useProducts.jsx
@@ -49,10 +49,12 @@ export function useProducts() {
     });
   };
 
-  const ensureSuccess = async (response) => {
-    const responseBody = await parseJsonResponse(response, null);
-    if (!response.ok) throw buildHttpError(response, responseBody);
-    return responseBody;
+  const ensureSuccess = async (productMutationResponse) => {
+    const parsedProductMutationBody = await parseJsonResponse(productMutationResponse, null);
+    if (!productMutationResponse.ok) {
+      throw buildHttpError(productMutationResponse, "Request failed", parsedProductMutationBody);
+    }
+    return parsedProductMutationBody;
   };
 
   const buildDefaultVariantPayload = (productForm) => {

--- a/client/src/components/pages/Store/hooks/useRoles.jsx
+++ b/client/src/components/pages/Store/hooks/useRoles.jsx
@@ -6,17 +6,7 @@ import { usePermission } from "@/hooks/usePermission";
 import { httpClient, parseJsonResponse } from "@/lib/http";
 import { useFetchList } from "@/lib/http/useFetchList";
 
-function createHttpStatusError(response, errorMessage) {
-  const requestError = new Error(errorMessage);
-  requestError.status = response.status;
-  return requestError;
-}
-
-function ensureSuccessfulResponse(response, errorMessage) {
-  if (response.ok === false) {
-    throw createHttpStatusError(response, errorMessage);
-  }
-}
+import { buildHttpError } from "../utils/buildHttpError";
 
 export function useRoles() {
   const { fetchList } = useFetchList();
@@ -34,8 +24,8 @@ export function useRoles() {
       const rolesData = await fetchList("/roles");
       if (rolesData === null) return;
       setRoles(toArray(rolesData));
-    } catch (error) {
-      console.error("Error fetching roles:", error);
+    } catch (roleLoadError) {
+      console.error("Error fetching roles:", roleLoadError);
     } finally {
       setLoading(false);
     }
@@ -50,11 +40,13 @@ export function useRoles() {
         },
         body: JSON.stringify(role),
       });
-      ensureSuccessfulResponse(updateRoleRequest, "Error updating role");
+      if (updateRoleRequest.ok === false) {
+        throw buildHttpError(updateRoleRequest, "Error updating role");
+      }
       return updateRoleRequest;
-    } catch (error) {
-      console.error("Error updating role:", error);
-      throw error;
+    } catch (updateRoleError) {
+      console.error("Error updating role:", updateRoleError);
+      throw updateRoleError;
     }
   }, []);
 
@@ -68,9 +60,9 @@ export function useRoles() {
         },
         body: JSON.stringify({ permissions }),
       });
-    } catch (error) {
-      console.error("Error assigning permissions:", error);
-      throw error;
+    } catch (assignPermissionsError) {
+      console.error("Error assigning permissions:", assignPermissionsError);
+      throw assignPermissionsError;
     }
   }, []);
 
@@ -86,7 +78,9 @@ export function useRoles() {
           },
           body: JSON.stringify(roleRequestBody),
         });
-        ensureSuccessfulResponse(createRoleRequest, "Error creating role");
+        if (createRoleRequest.ok === false) {
+          throw buildHttpError(createRoleRequest, "Error creating role");
+        }
         const createdRoleData = await parseJsonResponse(createRoleRequest, []);
         const createdRoleId = createdRoleData?.id || createdRoleData?.roleId;
         if (permissions.length > 0) {
@@ -94,9 +88,9 @@ export function useRoles() {
         }
         await fetchRoles();
         return createdRoleId;
-      } catch (error) {
-        console.error("Error creating role:", error);
-        throw error;
+      } catch (createRoleError) {
+        console.error("Error creating role:", createRoleError);
+        throw createRoleError;
       }
     },
     [assignPermissions, fetchRoles],
@@ -118,7 +112,9 @@ export function useRoles() {
 
   const deleteRole = useCallback(async (roleId) => {
     const deleteRoleResponse = await httpClient(`/roles/${roleId}`, { method: "DELETE" });
-    ensureSuccessfulResponse(deleteRoleResponse, "Error deleting role");
+    if (deleteRoleResponse.ok === false) {
+      throw buildHttpError(deleteRoleResponse, "Error deleting role");
+    }
     await fetchRoles();
   }, [fetchRoles]);
 
@@ -130,9 +126,9 @@ export function useRoles() {
       const rolePermissionsData = await parseJsonResponse(rolePermissionsResponse);
 
       return toArray(rolePermissionsData, []);
-    } catch (error) {
-      console.error("Error fetching role permissions:", error);
-      throw error;
+    } catch (rolePermissionsError) {
+      console.error("Error fetching role permissions:", rolePermissionsError);
+      throw rolePermissionsError;
     }
   }, []);
 

--- a/client/src/components/pages/Store/hooks/useUsers.jsx
+++ b/client/src/components/pages/Store/hooks/useUsers.jsx
@@ -8,13 +8,7 @@ import { toArray } from "@/components/utils/array";
 import { httpClient, parseJsonResponse } from "@/lib/http";
 import { useFetchList } from "@/lib/http/useFetchList";
 
-async function buildHttpRequestError(httpResponse, fallbackMessage) {
-  const responsePayload = await parseJsonResponse(httpResponse, null);
-  const requestError = new Error(fallbackMessage);
-  requestError.status = httpResponse.status;
-  requestError.responseMessage = responsePayload?.message;
-  return requestError;
-}
+import { buildParsedHttpError } from "../utils/buildHttpError";
 
 function isLastAdminConflict(requestError) {
   return requestError?.status === 409 && requestError?.responseMessage?.includes("last admin");
@@ -83,7 +77,7 @@ export function useUsers() {
       });
 
       if (updateUserResponse.ok === false) {
-        throw await buildHttpRequestError(updateUserResponse, "Error updating user");
+        throw await buildParsedHttpError(updateUserResponse, "Error updating user");
       }
 
       await fetchUsers();
@@ -123,7 +117,7 @@ export function useUsers() {
       });
 
       if (createUserResponse.ok === false) {
-        throw await buildHttpRequestError(createUserResponse, "Error adding user");
+        throw await buildParsedHttpError(createUserResponse, "Error adding user");
       }
 
       await fetchUsers();
@@ -150,7 +144,7 @@ export function useUsers() {
       });
 
       if (deleteUserResponse.ok === false) {
-        throw await buildHttpRequestError(deleteUserResponse, "Error deleting user");
+        throw await buildParsedHttpError(deleteUserResponse, "Error deleting user");
       }
 
       await fetchUsers();

--- a/client/src/components/pages/Store/utils/__tests__/buildHttpError.test.js
+++ b/client/src/components/pages/Store/utils/__tests__/buildHttpError.test.js
@@ -1,0 +1,50 @@
+import { parseJsonResponse } from "@/lib/http";
+
+import { buildHttpError, buildParsedHttpError } from "../buildHttpError";
+
+jest.mock("@/lib/http", () => ({
+  parseJsonResponse: jest.fn(),
+}));
+
+describe("buildHttpError", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("creates an Error with status and backend response message", () => {
+    const httpRequestError = buildHttpError(
+      { status: 409 },
+      "Error creating role",
+      { message: "Role already exists" },
+    );
+
+    expect(httpRequestError).toBeInstanceOf(Error);
+    expect(httpRequestError.message).toBe("Error creating role");
+    expect(httpRequestError.status).toBe(409);
+    expect(httpRequestError.responseMessage).toBe("Role already exists");
+  });
+
+  it("creates an Error without a backend response message", () => {
+    const httpRequestError = buildHttpError({ status: 500 }, "Request failed");
+
+    expect(httpRequestError).toBeInstanceOf(Error);
+    expect(httpRequestError.message).toBe("Request failed");
+    expect(httpRequestError.status).toBe(500);
+    expect(httpRequestError.responseMessage).toBeUndefined();
+  });
+
+  it("parses the response body before creating an Error", async () => {
+    const failedHttpResponse = { status: 422 };
+    parseJsonResponse.mockResolvedValueOnce({ message: "Invalid refund invoice" });
+
+    const httpRequestError = await buildParsedHttpError(failedHttpResponse, "Refund failed");
+
+    expect(parseJsonResponse).toHaveBeenCalledWith(failedHttpResponse, null);
+    expect(httpRequestError).toMatchObject({
+      message: "Refund failed",
+      status: 422,
+      responseMessage: "Invalid refund invoice",
+    });
+    expect(httpRequestError).toBeInstanceOf(Error);
+  });
+});

--- a/client/src/components/pages/Store/utils/buildHttpError.js
+++ b/client/src/components/pages/Store/utils/buildHttpError.js
@@ -1,4 +1,13 @@
-export const buildHttpError = (response, errorBody) => ({
-  status: response.status,
-  message: errorBody?.message || "Request failed",
-});
+import { parseJsonResponse } from "@/lib/http";
+
+export function buildHttpError(httpResponse, fallbackMessage = "Request failed", parsedResponseBody = null) {
+  const requestError = new Error(fallbackMessage);
+  requestError.status = httpResponse?.status;
+  requestError.responseMessage = parsedResponseBody?.message;
+  return requestError;
+}
+
+export async function buildParsedHttpError(httpResponse, fallbackMessage = "Request failed") {
+  const parsedResponseBody = await parseJsonResponse(httpResponse, null);
+  return buildHttpError(httpResponse, fallbackMessage, parsedResponseBody);
+}


### PR DESCRIPTION
  ## Summary

  Extracts shared Store HTTP error handling so failed API responses use one consistent Error shape across Store workflows.

  ## Changes

  - Updates `buildHttpError` to return real `Error` objects with `status` and `responseMessage`.
  - Adds `buildParsedHttpError` for failed responses that need backend error messages parsed from JSON.
  - Replaces duplicated local HTTP error builders in Users, Roles, and Refunds.
  - Updates Products to use the new shared helper signature.
  - Adds failed-response handling to Categories mutations so failed create/update/delete responses throw instead of continuing
  as successful.
  - Adds regression coverage for the shared helper and category creation failure behavior.
