### PR TITLE
Fix: Improve checkout failure feedback

### DIFF
--- a/client/src/components/pages/Store/Cart/hooks/__tests__/paymentFlows.test.js
+++ b/client/src/components/pages/Store/Cart/hooks/__tests__/paymentFlows.test.js
@@ -1,0 +1,72 @@
+import { httpClient, parseJsonResponse as parseSharedJsonResponse } from "@/lib/http";
+import { parseJsonResponse as parseCheckoutJsonResponse } from "@/lib/http/parseJsonResponse";
+
+import { processCheckout } from "../paymentFlows";
+
+jest.mock("@/lib/http", () => ({
+  httpClient: jest.fn(),
+  parseJsonResponse: jest.fn(),
+}));
+
+jest.mock("@/lib/http/parseJsonResponse", () => ({
+  parseJsonResponse: jest.fn(),
+}));
+
+function buildCheckoutArgs(overrides = {}) {
+  return {
+    cartItems: [{ id: "product-1", variantId: "variant-1", quantity: 2, price: 1500 }],
+    paymentAmounts: { amountFiat: 30, discountAmount: 0 },
+    selectedPaymentMethod: "cash",
+    currencyId: "currency-1",
+    user: { userId: "user-1" },
+    ...overrides,
+  };
+}
+
+describe("processCheckout", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns pending when checkout returns 202", async () => {
+    httpClient.mockResolvedValueOnce({ ok: true, status: 202 });
+
+    await expect(processCheckout(buildCheckoutArgs())).resolves.toEqual({ pending: true });
+
+    expect(parseCheckoutJsonResponse).not.toHaveBeenCalled();
+    expect(parseSharedJsonResponse).not.toHaveBeenCalled();
+  });
+
+  it("throws a parsed HTTP error when checkout returns a failed response", async () => {
+    const failedCheckoutResponse = { ok: false, status: 500 };
+    httpClient.mockResolvedValueOnce(failedCheckoutResponse);
+    parseSharedJsonResponse.mockResolvedValueOnce({ message: "Checkout server error" });
+
+    await expect(processCheckout(buildCheckoutArgs())).rejects.toMatchObject({
+      message: "errors.checkout",
+      status: 500,
+      responseMessage: "Checkout server error",
+    });
+
+    expect(parseSharedJsonResponse).toHaveBeenCalledWith(failedCheckoutResponse, null);
+    expect(parseCheckoutJsonResponse).not.toHaveBeenCalled();
+  });
+
+  it("returns checkout result when checkout succeeds with an order id", async () => {
+    const successfulCheckoutResponse = { ok: true, status: 200 };
+    const storeCheckoutResult = { orderId: "order-1", ticketId: "ticket-1" };
+    httpClient.mockResolvedValueOnce(successfulCheckoutResponse);
+    parseCheckoutJsonResponse.mockResolvedValueOnce(storeCheckoutResult);
+
+    await expect(processCheckout(buildCheckoutArgs())).resolves.toEqual(storeCheckoutResult);
+
+    expect(parseCheckoutJsonResponse).toHaveBeenCalledWith(successfulCheckoutResponse, null);
+  });
+
+  it("throws checkout fallback when successful response has no order id", async () => {
+    httpClient.mockResolvedValueOnce({ ok: true, status: 200 });
+    parseCheckoutJsonResponse.mockResolvedValueOnce({ ticketId: "ticket-1" });
+
+    await expect(processCheckout(buildCheckoutArgs())).rejects.toThrow("errors.checkout");
+  });
+});

--- a/client/src/components/pages/Store/Cart/hooks/__tests__/useCustomerReceipt.test.jsx
+++ b/client/src/components/pages/Store/Cart/hooks/__tests__/useCustomerReceipt.test.jsx
@@ -1,3 +1,4 @@
+import { addToast } from "@heroui/react";
 import { renderHook } from "@testing-library/react";
 
 import { useCustomerReceipt } from "../useCustomerReceipt";
@@ -5,6 +6,14 @@ import { useCustomerReceipt } from "../useCustomerReceipt";
 let mockPrinterConfigs;
 let mockLoadingConfigs;
 const mockPrintTicket = jest.fn(() => Promise.resolve());
+
+jest.mock("@heroui/react", () => ({
+  addToast: jest.fn(),
+}));
+
+jest.mock("next-intl", () => ({
+  useTranslations: () => (translationKey) => translationKey,
+}));
 
 jest.mock("../../../hooks/usePrinter", () => ({
   usePrinters: () => ({
@@ -16,15 +25,21 @@ jest.mock("../../../hooks/usePrinter", () => ({
 
 beforeEach(() => {
   mockPrintTicket.mockClear();
+  addToast.mockClear();
   mockPrinterConfigs = [{ id: "cfg-1", printerType: "CUSTOMER", enabled: true }];
   mockLoadingConfigs = false;
+  jest.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  console.error.mockRestore();
 });
 
 describe("useCustomerReceipt", () => {
   it("prints a CUSTOMER ticket with mapped item data", async () => {
-    const { result } = renderHook(() => useCustomerReceipt());
+    const { result: receiptHook } = renderHook(() => useCustomerReceipt());
 
-    await result.current.printCustomerReceipt({
+    await receiptHook.current.printCustomerReceipt({
       items: [{ name: "Jade", price: 100, quantity: 2 }],
       totalCents: 200,
       ticketId: 42,
@@ -49,19 +64,35 @@ describe("useCustomerReceipt", () => {
 
   it("does not print when there is no enabled customer printer", async () => {
     mockPrinterConfigs = [{ id: "cfg-1", printerType: "KITCHEN", enabled: true }];
-    const { result } = renderHook(() => useCustomerReceipt());
+    const { result: receiptHook } = renderHook(() => useCustomerReceipt());
 
-    await result.current.printCustomerReceipt({ items: [], totalCents: 0, ticketId: 1 });
+    await receiptHook.current.printCustomerReceipt({ items: [], totalCents: 0, ticketId: 1 });
 
     expect(mockPrintTicket).not.toHaveBeenCalled();
   });
 
   it("does not print while printer configs are still loading", async () => {
     mockLoadingConfigs = true;
-    const { result } = renderHook(() => useCustomerReceipt());
+    const { result: receiptHook } = renderHook(() => useCustomerReceipt());
 
-    await result.current.printCustomerReceipt({ items: [], totalCents: 0, ticketId: 1 });
+    await receiptHook.current.printCustomerReceipt({ items: [], totalCents: 0, ticketId: 1 });
 
     expect(mockPrintTicket).not.toHaveBeenCalled();
+  });
+
+  it("shows a warning toast when customer receipt printing fails", async () => {
+    mockPrintTicket.mockRejectedValueOnce(new Error("printer offline"));
+    const { result: receiptHook } = renderHook(() => useCustomerReceipt());
+
+    await receiptHook.current.printCustomerReceipt({
+      items: [{ name: "Jade", price: 100, quantity: 2 }],
+      totalCents: 200,
+      ticketId: 42,
+    });
+
+    expect(addToast).toHaveBeenCalledWith({
+      color: "warning",
+      description: "errors.printCustomer",
+    });
   });
 });

--- a/client/src/components/pages/Store/Cart/hooks/paymentFlows.js
+++ b/client/src/components/pages/Store/Cart/hooks/paymentFlows.js
@@ -1,3 +1,4 @@
+import { buildParsedHttpError } from "@/components/pages/Store/utils/buildHttpError";
 import { httpClient } from "@/lib/http";
 import { parseJsonResponse } from "@/lib/http/parseJsonResponse";
 
@@ -40,6 +41,10 @@ export async function processCheckout({
 
   if (checkoutHttpResponse.status === 202) {
     return { pending: true };
+  }
+
+  if (checkoutHttpResponse.ok === false) {
+    throw await buildParsedHttpError(checkoutHttpResponse, "errors.checkout");
   }
 
   const storeCheckoutResult = await parseJsonResponse(checkoutHttpResponse, null);

--- a/client/src/components/pages/Store/Cart/hooks/paymentHandlers.js
+++ b/client/src/components/pages/Store/Cart/hooks/paymentHandlers.js
@@ -61,8 +61,8 @@ export function buildHandlePay({
         userId: user?.userId,
         currencyId: currency?.id,
       });
-    } catch (err) {
-      notifyError(err.message);
+    } catch (cartValidationError) {
+      notifyError(cartValidationError.message);
       return;
     }
 
@@ -145,9 +145,9 @@ export function buildHandlePay({
       notifySuccess("success.paid");
       onResetCart?.();
       onPay?.({ items: cartItems, ...paymentAmounts, paymentMethod: selectedPaymentMethod, ...storeCheckoutResult });
-    } catch (err) {
-      console.error("Error processing payment:", err);
-      notifyError(err?.message || "errors.process");
+    } catch (paymentProcessingError) {
+      console.error("Error processing payment:", paymentProcessingError);
+      notifyError(paymentProcessingError?.message || "errors.process");
     } finally {
       dispatch({ type: "stop" });
     }
@@ -233,9 +233,9 @@ async function runDeferredCheckout({
     onPay?.(buildOnPayPayload(storeCheckoutResult));
     onResetCart?.();
     notifySuccess(successKey);
-  } catch (err) {
-    console.error("Error completing payment:", err);
-    notifyError(err?.message || errorKey);
+  } catch (paymentCompletionError) {
+    console.error("Error completing payment:", paymentCompletionError);
+    notifyError(paymentCompletionError?.message || errorKey);
   } finally {
     finalize();
     dispatch({ type: "stop" });

--- a/client/src/components/pages/Store/Cart/hooks/useCustomerReceipt.jsx
+++ b/client/src/components/pages/Store/Cart/hooks/useCustomerReceipt.jsx
@@ -43,8 +43,8 @@ export function useCustomerReceipt() {
           printerType: "CUSTOMER",
           broadcast: false,
         });
-      } catch (err) {
-        console.error("Error printing customer ticket:", err);
+      } catch (customerReceiptPrintError) {
+        console.error("Error printing customer ticket:", customerReceiptPrintError);
         addToast({
           color: "warning",
           description: paymentTranslations("errors.printCustomer"),

--- a/client/src/components/pages/Store/Cart/locales/en.js
+++ b/client/src/components/pages/Store/Cart/locales/en.js
@@ -58,7 +58,7 @@ const cartEn = {
         btcComplete: "Error completing the BTC payment",
         cashComplete: "Error completing the cash payment",
         cardComplete: "Error completing the card payment",
-        printCustomer: "Ticket printed failed. Check printer settings.",
+        printCustomer: "Could not print the receipt. Check printer settings.",
       },
       success: {
         paid: "Payment registered successfully",


### PR DESCRIPTION
  ## Summary

  Improves Cart/Sales checkout feedback by making failed checkout HTTP responses surface as proper payment errors and by
  clarifying receipt print warning feedback.

  ## Changes

  - Handles non-OK `/store/orders/checkout` responses in `processCheckout` with the shared Store HTTP error helper.
  - Preserves existing `202` pending checkout behavior for background BTC confirmation.
  - Keeps the existing fallback checkout error when a successful response is missing an `orderId`.
  - Renames generic checkout/receipt error variables in touched files to action-specific names.
  - Clarifies the English receipt print warning copy.

  ## Testing

  - Added focused coverage for checkout pending, failed HTTP, successful checkout, and missing-`orderId` fallback paths.
  - Added coverage for customer receipt print warning toast behavior.
  - Ran focused Cart/Sales tests successfully:
    - `paymentFlows.test.js`
    - `useCustomerReceipt.test.jsx`
    - `paymentHandlers.test.js`

  Manual screenshots added for:
  - Successful checkout toast still working.
  - Checkout failure feedback.

  Automated coverage also verifies non-OK checkout responses and receipt print warning behavior.

<img width="580" height="456" alt="Screenshot From 2026-07-28 14-43-10" src="https://github.com/user-attachments/assets/ba7daaba-0f9a-466c-a656-0493446c7bf9" />

<img width="364" height="456" alt="Screenshot From 2026-07-28 14-43-38" src="https://github.com/user-attachments/assets/1fa26de7-79f0-486a-afc4-88c897608675" />

<img width="364" height="502" alt="Screenshot From 2026-07-28 14-44-31" src="https://github.com/user-attachments/assets/18ba5cc6-25ec-40a6-80f5-10f7eb19d167" />