### PR TITLE
chore(deps): bump phoenixd to 0.9.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ CLIENT_INSTALL_DIR   := $(AMBROSIA_INSTALL_DIR)/client
 CLIENT_DIST_DIR      := /tmp/ambrosia-client-dist
 
 # --- External dependency versions ---
-PHOENIXD_TAG         := 0.7.2
+PHOENIXD_TAG         := 0.9.0
 PHOENIXD_INSTALL_DIR := /usr/local/bin
 JDK_VERSION          := 21.0.8-tem
 

--- a/electron/scripts/download-phoenixd.js
+++ b/electron/scripts/download-phoenixd.js
@@ -6,7 +6,7 @@ const path = require('path');
 const { getBuildPlatform } = require('./platform-utils');
 const { verifySha256, fetchSha256SumsChecksum } = require('./verify-checksum');
 
-const PHOENIXD_VERSION = '0.7.2';
+const PHOENIXD_VERSION = '0.9.0';
 const RESOURCES_DIR = path.join(__dirname, '..', 'resources', 'phoenixd');
 
 const GITHUB_BASE = `https://github.com/ACINQ/phoenixd/releases/download/v${PHOENIXD_VERSION}`;

--- a/electron/scripts/verify-checksum.js
+++ b/electron/scripts/verify-checksum.js
@@ -121,7 +121,7 @@ async function fetchAdoptiumChecksum(assetsApiUrl) {
  * the hash for a specific filename.
  * Format per line: "<hash> *<filename>"
  * @param {string} sha256sumsUrl - URL of the SHA256SUMS.asc file
- * @param {string} filename - The filename to look up (e.g. "phoenixd-0.7.2-macos-arm64.zip")
+ * @param {string} filename - The filename to look up (e.g. "phoenixd-0.9.0-macos-arm64.zip")
  * @returns {Promise<string>} - The SHA256 hex hash
  */
 async function fetchSha256SumsChecksum(sha256sumsUrl, filename) {

--- a/electron/utils/constants.js
+++ b/electron/utils/constants.js
@@ -30,7 +30,7 @@ module.exports = {
   // Downloads
   DOWNLOAD: {
     MAX_REDIRECTS: 5,
-    PHOENIXD_VERSION: '0.7.2',
+    PHOENIXD_VERSION: '0.9.0',
     JRE_VERSION: 21,
   },
 };

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -80,7 +80,7 @@ print_header() {
 
 # --- Phoenixd Installation Logic ---
 
-PHOENIXD_TAG="0.7.2"
+PHOENIXD_TAG="0.9.0"
 PHOENIXD_RELEASE_BASE_URL="https://github.com/ACINQ/phoenixd/releases/download/v${PHOENIXD_TAG}"
 PHOENIXD_INSTALL_DIR="/usr/local/bin"
 PHOENIXD_OS=""


### PR DESCRIPTION
## Summary
- Bump Phoenixd from `0.7.2` to `0.9.0` across all installation/bundling paths.
- Updated files:
  - `Makefile` — `PHOENIXD_TAG`
  - `scripts/install.sh` — `PHOENIXD_TAG`
  - `electron/scripts/download-phoenixd.js` — `PHOENIXD_VERSION` (GitHub release URL)
  - `electron/utils/constants.js` — `DOWNLOAD.PHOENIXD_VERSION`
  - `electron/scripts/verify-checksum.js` — docstring example filename

Only version constants change; no runtime logic touched. Checksums are fetched from the ACINQ release's `SHA256SUMS.asc` at download time, so no hardcoded hashes needed updating.

## Test plan
- [x] Electron download script resolves the `v0.9.0` release assets and passes SHA256 verification
- [x] `scripts/install.sh` installs phoenixd `0.9.0` on Linux/macOS
- [x] `make build` succeeds