### PR TITLE
Fix(orders): Prevent duplicate refund actions

### DIFF
--- a/client/src/components/pages/Store/Orders/RefundModal.jsx
+++ b/client/src/components/pages/Store/Orders/RefundModal.jsx
@@ -57,6 +57,8 @@ export function RefundModal({ order, isOpen, onClose, onRefunded, formatAmount }
   }
 
   async function handleRefund() {
+    if (loading) return;
+
     if (isBtcOrder) {
       const errorMessage = getInvoiceErrorMessage(invoice, ordersTranslations);
       if (errorMessage) {
@@ -94,6 +96,8 @@ export function RefundModal({ order, isOpen, onClose, onRefunded, formatAmount }
   }
 
   function handleClose() {
+    if (loading) return;
+
     setInvoice("");
     setInvoiceError("");
     setCashGiven(0);

--- a/client/src/components/pages/Store/Orders/__tests__/RefundModal.test.jsx
+++ b/client/src/components/pages/Store/Orders/__tests__/RefundModal.test.jsx
@@ -1,5 +1,5 @@
 import { addToast } from "@heroui/react";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
 
 import { httpClient, parseJsonResponse } from "@/lib/http";
 
@@ -198,6 +198,51 @@ describe("RefundModal", () => {
       expect.objectContaining({ color: "danger", description: "Order has already been refunded" }),
     ));
     expect(onRefunded).not.toHaveBeenCalled();
+  });
+
+  it("does not submit a refund twice while the first request is pending", async () => {
+    let resolveRefundRequest;
+    httpClient.mockReturnValueOnce(new Promise((resolve) => {
+      resolveRefundRequest = resolve;
+    }));
+    const onRefunded = jest.fn();
+    const order = { id: "order-1", total: 10 };
+
+    render(<RefundModal order={order} isOpen onClose={jest.fn()} onRefunded={onRefunded} />);
+
+    acknowledgeCardRefundAndConfirm();
+    fireEvent.click(screen.getByText("details.refundConfirm"));
+
+    expect(httpClient).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveRefundRequest({ ok: true });
+    });
+
+    await waitFor(() => expect(onRefunded).toHaveBeenCalledTimes(1));
+  });
+
+  it("does not close the modal while a refund request is pending", async () => {
+    let resolveRefundRequest;
+    httpClient.mockReturnValueOnce(new Promise((resolve) => {
+      resolveRefundRequest = resolve;
+    }));
+    const onClose = jest.fn();
+    const onRefunded = jest.fn();
+    const order = { id: "order-1", total: 10 };
+
+    render(<RefundModal order={order} isOpen onClose={onClose} onRefunded={onRefunded} />);
+
+    acknowledgeCardRefundAndConfirm();
+    fireEvent.click(screen.getByText("details.close"));
+
+    expect(onClose).not.toHaveBeenCalled();
+
+    await act(async () => {
+      resolveRefundRequest({ ok: true });
+    });
+
+    await waitFor(() => expect(onRefunded).toHaveBeenCalledTimes(1));
   });
 
   it("falls back to the translated error message when a failed response has no body", async () => {


### PR DESCRIPTION
  ## Summary

  Prevents duplicate refund requests and duplicate toast notifications in the Orders refund flow.

  ## Changes

  - Guards the refund handler against repeated submissions while a refund request is pending.
  - Prevents the refund modal from closing or resetting during an active request.
  - Ensures the refund success callback and success toast are triggered only once.
  - Adds regression tests covering duplicate submissions and attempted modal closure during a pending refund.