### PR TITLE
Fix: Disable CSV export when filters have no results

### DIFF
--- a/client/src/components/pages/Store/Reports/Orders/OrdersDetailCard.jsx
+++ b/client/src/components/pages/Store/Reports/Orders/OrdersDetailCard.jsx
@@ -53,7 +53,7 @@ export function OrdersDetailCard({ orders, formatCurrency, disabled, currentRate
             size="sm"
             className="border border-green-800 text-green-800"
             startContent={<Download aria-hidden="true" className="w-3.5 h-3.5" />}
-            isDisabled={!orders.length}
+            isDisabled={!filteredOrders.length}
             onPress={exportToCsv}
           >
             {reportsTranslations("orders.export")}

--- a/client/src/components/pages/Store/Reports/Orders/__tests__/OrdersDetailCard.test.jsx
+++ b/client/src/components/pages/Store/Reports/Orders/__tests__/OrdersDetailCard.test.jsx
@@ -21,7 +21,12 @@ jest.mock("../../hooks/useOrdersDetailData", () => ({
 }));
 
 jest.mock("../OrdersFilters", () => ({
-  OrdersFilters: () => <div data-testid="orders-filters" />,
+  OrdersFilters: ({ onSearchChange }) => (
+    <input
+      data-testid="orders-search"
+      onChange={(changeEvent) => onSearchChange(changeEvent.target.value)}
+    />
+  ),
 }));
 
 jest.mock("../OrdersList", () => ({
@@ -110,6 +115,14 @@ describe("OrdersDetailCard", () => {
     expect(screen.getByTestId("export-button")).not.toBeDisabled();
   });
 
+  it("export button is disabled when filters have no matching orders", () => {
+    render(<OrdersDetailCard orders={ORDERS} formatCurrency={formatCurrency} />);
+
+    fireEvent.change(screen.getByTestId("orders-search"), { target: { value: "no matches" } });
+
+    expect(screen.getByTestId("export-button")).toBeDisabled();
+  });
+
   it("export button calls exportToCsv", () => {
     render(<OrdersDetailCard orders={ORDERS} formatCurrency={formatCurrency} />);
     fireEvent.click(screen.getByTestId("export-button"));
@@ -129,7 +142,7 @@ describe("OrdersDetailCard", () => {
 
   it("renders OrdersFilters and ReportsOrdersList", () => {
     render(<OrdersDetailCard orders={ORDERS} formatCurrency={formatCurrency} />);
-    expect(screen.getByTestId("orders-filters")).toBeInTheDocument();
+    expect(screen.getByTestId("orders-search")).toBeInTheDocument();
     expect(screen.getByTestId("orders-list")).toBeInTheDocument();
   });
 });

--- a/client/src/components/pages/Store/Reports/Sales/SalesDetailCard.jsx
+++ b/client/src/components/pages/Store/Reports/Sales/SalesDetailCard.jsx
@@ -52,7 +52,7 @@ export function SalesDetailCard({ sales, formatCurrency, disabled, currentRate }
             size="sm"
             className="border border-green-800 text-green-800"
             startContent={<Download aria-hidden="true" className="w-3.5 h-3.5" />}
-            isDisabled={!sales.length}
+            isDisabled={!filteredSales.length}
             onPress={exportToCsv}
           >
             {reportsTranslations("sales.export")}

--- a/client/src/components/pages/Store/Reports/Sales/__tests__/SalesDetailCard.test.jsx
+++ b/client/src/components/pages/Store/Reports/Sales/__tests__/SalesDetailCard.test.jsx
@@ -21,7 +21,12 @@ jest.mock("../../hooks/useSalesData", () => ({
 }));
 
 jest.mock("../SalesFilters", () => ({
-  SalesFilters: () => <div data-testid="sales-filters" />,
+  SalesFilters: ({ onSearchChange }) => (
+    <input
+      data-testid="sales-search"
+      onChange={(changeEvent) => onSearchChange(changeEvent.target.value)}
+    />
+  ),
 }));
 
 jest.mock("../SalesList", () => ({
@@ -102,6 +107,14 @@ describe("SalesDetailCard", () => {
     expect(screen.getByTestId("export-button")).not.toBeDisabled();
   });
 
+  it("export button is disabled when filters have no matching sales", () => {
+    render(<SalesDetailCard sales={SALES} formatCurrency={formatCurrency} />);
+
+    fireEvent.change(screen.getByTestId("sales-search"), { target: { value: "no matches" } });
+
+    expect(screen.getByTestId("export-button")).toBeDisabled();
+  });
+
   it("export button calls exportToCsv", () => {
     render(<SalesDetailCard sales={SALES} formatCurrency={formatCurrency} />);
     fireEvent.click(screen.getByTestId("export-button"));
@@ -121,7 +134,7 @@ describe("SalesDetailCard", () => {
 
   it("renders SalesFilters and SalesList", () => {
     render(<SalesDetailCard sales={SALES} formatCurrency={formatCurrency} />);
-    expect(screen.getByTestId("sales-filters")).toBeInTheDocument();
+    expect(screen.getByTestId("sales-search")).toBeInTheDocument();
     expect(screen.getByTestId("sales-list")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
  ## Summary

  Updates the Reports CSV export buttons so they match the currently visible filtered results.

  ## Changes

  - Disables the Sales CSV export button when the active filters leave zero matching sales.
  - Disables the Orders CSV export button when the active filters leave zero matching orders.
  - Keeps export behavior unchanged when filtered results exist.

  ## Testing

  - Added focused coverage for Sales export disabled state after filters produce no results.
  - Added focused coverage for Orders export disabled state after filters produce no results.

<img width="1019" height="455" alt="Screenshot From 2026-07-31 16-36-24" src="https://github.com/user-attachments/assets/88d5848e-116a-412c-8b6e-1d605ca5b76e" />

<img width="1019" height="455" alt="Screenshot From 2026-07-31 16-36-29" src="https://github.com/user-attachments/assets/ad89366b-6ba2-4381-b134-e8d683fdb639" />

<img width="1019" height="455" alt="Screenshot From 2026-07-31 16-36-54" src="https://github.com/user-attachments/assets/94a290ba-0912-46aa-ba05-826f161ced53" />

<img width="1019" height="455" alt="Screenshot From 2026-07-31 16-36-59" src="https://github.com/user-attachments/assets/c50dcd3c-593e-4bc2-a19c-382a7a7163c0" />