### PR TITLE
Feat: Add CSV export failure toasts

### DIFF
--- a/client/src/components/pages/Store/Reports/hooks/__tests__/useOrdersDetailData.test.js
+++ b/client/src/components/pages/Store/Reports/hooks/__tests__/useOrdersDetailData.test.js
@@ -4,6 +4,11 @@ import { useOrdersDetailData } from "../useOrdersDetailData";
 
 jest.mock("@lib/formatDate", () => jest.fn((date) => date));
 
+const mockAddToast = jest.fn();
+jest.mock("@heroui/react", () => ({
+  addToast: (...toastArguments) => mockAddToast(...toastArguments),
+}));
+
 const makeOrders = (count) => (
   Array.from({ length: count }, (_, i) => ({
     shortId: `SH${i}`,
@@ -22,6 +27,7 @@ describe("useOrdersDetailData", () => {
   const OriginalBlob = global.Blob;
 
   beforeEach(() => {
+    jest.clearAllMocks();
     global.URL.createObjectURL = jest.fn(() => "blob:mock-url");
     global.URL.revokeObjectURL = jest.fn();
   });
@@ -31,67 +37,80 @@ describe("useOrdersDetailData", () => {
   });
 
   it("starts at page 1 with rowsPerPage 10", () => {
-    const { result } = renderHook(() => useOrdersDetailData([], formatCurrency));
-    expect(result.current.page).toBe(1);
-    expect(result.current.rowsPerPage).toBe(10);
+    const { result: ordersDetailDataHook } = renderHook(() => useOrdersDetailData([], formatCurrency));
+    expect(ordersDetailDataHook.current.page).toBe(1);
+    expect(ordersDetailDataHook.current.rowsPerPage).toBe(10);
   });
 
   it("totalPages is ceil(orders.length / rowsPerPage)", () => {
-    const { result } = renderHook(() => useOrdersDetailData(makeOrders(25), formatCurrency));
-    expect(result.current.totalPages).toBe(3);
+    const { result: ordersDetailDataHook } = renderHook(() => useOrdersDetailData(makeOrders(25), formatCurrency));
+    expect(ordersDetailDataHook.current.totalPages).toBe(3);
   });
 
   it("paginatedOrders returns first rowsPerPage items on page 1", () => {
     const orders = makeOrders(15);
-    const { result } = renderHook(() => useOrdersDetailData(orders, formatCurrency));
-    expect(result.current.paginatedOrders).toHaveLength(10);
-    expect(result.current.paginatedOrders[0].shortId).toBe("SH0");
+    const { result: ordersDetailDataHook } = renderHook(() => useOrdersDetailData(orders, formatCurrency));
+    expect(ordersDetailDataHook.current.paginatedOrders).toHaveLength(10);
+    expect(ordersDetailDataHook.current.paginatedOrders[0].shortId).toBe("SH0");
   });
 
   it("paginatedOrders returns correct slice when page changes", () => {
     const orders = makeOrders(15);
-    const { result } = renderHook(() => useOrdersDetailData(orders, formatCurrency));
-    act(() => result.current.setPage(2));
-    expect(result.current.paginatedOrders).toHaveLength(5);
-    expect(result.current.paginatedOrders[0].shortId).toBe("SH10");
+    const { result: ordersDetailDataHook } = renderHook(() => useOrdersDetailData(orders, formatCurrency));
+    act(() => ordersDetailDataHook.current.setPage(2));
+    expect(ordersDetailDataHook.current.paginatedOrders).toHaveLength(5);
+    expect(ordersDetailDataHook.current.paginatedOrders[0].shortId).toBe("SH10");
   });
 
   it("handleRowsPerPageChange updates rowsPerPage and resets page to 1", () => {
     const orders = makeOrders(20);
-    const { result } = renderHook(() => useOrdersDetailData(orders, formatCurrency));
-    act(() => result.current.setPage(2));
-    act(() => result.current.handleRowsPerPageChange(5));
-    expect(result.current.rowsPerPage).toBe(5);
-    expect(result.current.page).toBe(1);
+    const { result: ordersDetailDataHook } = renderHook(() => useOrdersDetailData(orders, formatCurrency));
+    act(() => ordersDetailDataHook.current.setPage(2));
+    act(() => ordersDetailDataHook.current.handleRowsPerPageChange(5));
+    expect(ordersDetailDataHook.current.rowsPerPage).toBe(5);
+    expect(ordersDetailDataHook.current.page).toBe(1);
   });
 
   it("resets page to 1 when orders reference changes", () => {
     const orders1 = makeOrders(20);
     const orders2 = makeOrders(20);
-    const { result, rerender } = renderHook(
+    const { result: ordersDetailDataHook, rerender } = renderHook(
       ({ orders }) => useOrdersDetailData(orders, formatCurrency),
       { initialProps: { orders: orders1 } },
     );
-    act(() => result.current.setPage(2));
+    act(() => ordersDetailDataHook.current.setPage(2));
     rerender({ orders: orders2 });
-    expect(result.current.page).toBe(1);
+    expect(ordersDetailDataHook.current.page).toBe(1);
   });
 
   it("exportToCsv with empty orders does not call URL.createObjectURL", () => {
-    const { result } = renderHook(() => useOrdersDetailData([], formatCurrency));
-    act(() => result.current.exportToCsv());
+    const { result: ordersDetailDataHook } = renderHook(() => useOrdersDetailData([], formatCurrency));
+    act(() => ordersDetailDataHook.current.exportToCsv());
     expect(global.URL.createObjectURL).not.toHaveBeenCalled();
   });
 
   it("exportToCsv with orders calls URL.createObjectURL", () => {
-    const { result } = renderHook(() => useOrdersDetailData(makeOrders(1), formatCurrency));
-    act(() => result.current.exportToCsv());
+    const { result: ordersDetailDataHook } = renderHook(() => useOrdersDetailData(makeOrders(1), formatCurrency));
+    act(() => ordersDetailDataHook.current.exportToCsv());
     expect(global.URL.createObjectURL).toHaveBeenCalledWith(expect.any(Blob));
   });
 
+  it("exportToCsv shows an error toast when CSV download creation fails", () => {
+    global.URL.createObjectURL = jest.fn(() => {
+      throw new Error("Blob URL failed");
+    });
+    const { result: ordersDetailDataHook } = renderHook(() => useOrdersDetailData(makeOrders(1), formatCurrency));
+
+    act(() => ordersDetailDataHook.current.exportToCsv());
+
+    expect(mockAddToast).toHaveBeenCalledWith(
+      expect.objectContaining({ color: "danger", description: "export.error" }),
+    );
+  });
+
   it("exportToCsv revokes the object URL after download", () => {
-    const { result } = renderHook(() => useOrdersDetailData(makeOrders(1), formatCurrency));
-    act(() => result.current.exportToCsv());
+    const { result: ordersDetailDataHook } = renderHook(() => useOrdersDetailData(makeOrders(1), formatCurrency));
+    act(() => ordersDetailDataHook.current.exportToCsv());
     expect(global.URL.revokeObjectURL).toHaveBeenCalledWith("blob:mock-url");
   });
 
@@ -105,8 +124,8 @@ describe("useOrdersDetailData", () => {
       { shortId: "SH0", date: "2024-01-01", userName: "alice", paymentMethod: "Cash", total: 1000, itemCount: 1, items: [{ productName: "Widget", quantity: 1 }], refunded: true },
       { shortId: "SH1", date: "2024-01-01", userName: "alice", paymentMethod: "Cash", total: 2000, itemCount: 1, items: [{ productName: "Gadget", quantity: 1 }], refunded: false },
     ];
-    const { result } = renderHook(() => useOrdersDetailData(orders, formatCurrency));
-    act(() => result.current.exportToCsv());
+    const { result: ordersDetailDataHook } = renderHook(() => useOrdersDetailData(orders, formatCurrency));
+    act(() => ordersDetailDataHook.current.exportToCsv());
 
     expect(capturedCsv).toContain("status.refunded");
     expect(capturedCsv).toContain("status.paid");
@@ -122,8 +141,8 @@ describe("useOrdersDetailData", () => {
       { shortId: "SH0", date: "2024-01-01", userName: "alice", paymentMethod: "Cash", total: 1000, itemCount: 1, items: [{ productName: "Widget", quantity: 1 }], refunded: true },
       { shortId: "SH1", date: "2024-01-01", userName: "alice", paymentMethod: "Cash", total: 2000, itemCount: 1, items: [{ productName: "Gadget", quantity: 1 }], refunded: false },
     ];
-    const { result } = renderHook(() => useOrdersDetailData(orders, formatCurrency));
-    act(() => result.current.exportToCsv());
+    const { result: ordersDetailDataHook } = renderHook(() => useOrdersDetailData(orders, formatCurrency));
+    act(() => ordersDetailDataHook.current.exportToCsv());
 
     expect(capturedCsv).toContain("summary.revenue");
     expect(capturedCsv).toContain("$3000");

--- a/client/src/components/pages/Store/Reports/hooks/__tests__/useSalesData.test.js
+++ b/client/src/components/pages/Store/Reports/hooks/__tests__/useSalesData.test.js
@@ -4,6 +4,11 @@ import { useSalesData } from "../useSalesData";
 
 jest.mock("@lib/formatDate", () => jest.fn((date) => date));
 
+const mockAddToast = jest.fn();
+jest.mock("@heroui/react", () => ({
+  addToast: (...toastArguments) => mockAddToast(...toastArguments),
+}));
+
 const makeSales = (count) => (
   Array.from({ length: count }, (_, i) => ({
     productName: `Product ${i}`,
@@ -21,6 +26,7 @@ describe("useSalesData", () => {
   const OriginalBlob = global.Blob;
 
   beforeEach(() => {
+    jest.clearAllMocks();
     global.URL.createObjectURL = jest.fn(() => "blob:mock-url");
     global.URL.revokeObjectURL = jest.fn();
   });
@@ -30,67 +36,80 @@ describe("useSalesData", () => {
   });
 
   it("starts at page 1 with rowsPerPage 10", () => {
-    const { result } = renderHook(() => useSalesData([], formatCurrency));
-    expect(result.current.page).toBe(1);
-    expect(result.current.rowsPerPage).toBe(10);
+    const { result: salesDataHook } = renderHook(() => useSalesData([], formatCurrency));
+    expect(salesDataHook.current.page).toBe(1);
+    expect(salesDataHook.current.rowsPerPage).toBe(10);
   });
 
   it("totalPages is ceil(sales.length / rowsPerPage)", () => {
-    const { result } = renderHook(() => useSalesData(makeSales(25), formatCurrency));
-    expect(result.current.totalPages).toBe(3);
+    const { result: salesDataHook } = renderHook(() => useSalesData(makeSales(25), formatCurrency));
+    expect(salesDataHook.current.totalPages).toBe(3);
   });
 
   it("paginatedSales returns first rowsPerPage items on page 1", () => {
     const sales = makeSales(15);
-    const { result } = renderHook(() => useSalesData(sales, formatCurrency));
-    expect(result.current.paginatedSales).toHaveLength(10);
-    expect(result.current.paginatedSales[0].productName).toBe("Product 0");
+    const { result: salesDataHook } = renderHook(() => useSalesData(sales, formatCurrency));
+    expect(salesDataHook.current.paginatedSales).toHaveLength(10);
+    expect(salesDataHook.current.paginatedSales[0].productName).toBe("Product 0");
   });
 
   it("paginatedSales returns correct slice when page changes", () => {
     const sales = makeSales(15);
-    const { result } = renderHook(() => useSalesData(sales, formatCurrency));
-    act(() => result.current.setPage(2));
-    expect(result.current.paginatedSales).toHaveLength(5);
-    expect(result.current.paginatedSales[0].productName).toBe("Product 10");
+    const { result: salesDataHook } = renderHook(() => useSalesData(sales, formatCurrency));
+    act(() => salesDataHook.current.setPage(2));
+    expect(salesDataHook.current.paginatedSales).toHaveLength(5);
+    expect(salesDataHook.current.paginatedSales[0].productName).toBe("Product 10");
   });
 
   it("handleRowsPerPageChange updates rowsPerPage and resets page to 1", () => {
     const sales = makeSales(20);
-    const { result } = renderHook(() => useSalesData(sales, formatCurrency));
-    act(() => result.current.setPage(2));
-    act(() => result.current.handleRowsPerPageChange(5));
-    expect(result.current.rowsPerPage).toBe(5);
-    expect(result.current.page).toBe(1);
+    const { result: salesDataHook } = renderHook(() => useSalesData(sales, formatCurrency));
+    act(() => salesDataHook.current.setPage(2));
+    act(() => salesDataHook.current.handleRowsPerPageChange(5));
+    expect(salesDataHook.current.rowsPerPage).toBe(5);
+    expect(salesDataHook.current.page).toBe(1);
   });
 
   it("resets page to 1 when sales reference changes", () => {
     const sales1 = makeSales(20);
     const sales2 = makeSales(20);
-    const { result, rerender } = renderHook(
+    const { result: salesDataHook, rerender } = renderHook(
       ({ sales }) => useSalesData(sales, formatCurrency),
       { initialProps: { sales: sales1 } },
     );
-    act(() => result.current.setPage(2));
+    act(() => salesDataHook.current.setPage(2));
     rerender({ sales: sales2 });
-    expect(result.current.page).toBe(1);
+    expect(salesDataHook.current.page).toBe(1);
   });
 
   it("exportToCsv with empty sales does not call URL.createObjectURL", () => {
-    const { result } = renderHook(() => useSalesData([], formatCurrency));
-    act(() => result.current.exportToCsv());
+    const { result: salesDataHook } = renderHook(() => useSalesData([], formatCurrency));
+    act(() => salesDataHook.current.exportToCsv());
     expect(global.URL.createObjectURL).not.toHaveBeenCalled();
   });
 
   it("exportToCsv with sales calls URL.createObjectURL", () => {
-    const { result } = renderHook(() => useSalesData(makeSales(1), formatCurrency));
-    act(() => result.current.exportToCsv());
+    const { result: salesDataHook } = renderHook(() => useSalesData(makeSales(1), formatCurrency));
+    act(() => salesDataHook.current.exportToCsv());
     expect(global.URL.createObjectURL).toHaveBeenCalledWith(expect.any(Blob));
   });
 
+  it("exportToCsv shows an error toast when CSV download creation fails", () => {
+    global.URL.createObjectURL = jest.fn(() => {
+      throw new Error("Blob URL failed");
+    });
+    const { result: salesDataHook } = renderHook(() => useSalesData(makeSales(1), formatCurrency));
+
+    act(() => salesDataHook.current.exportToCsv());
+
+    expect(mockAddToast).toHaveBeenCalledWith(
+      expect.objectContaining({ color: "danger", description: "export.error" }),
+    );
+  });
+
   it("exportToCsv revokes the object URL after download", () => {
-    const { result } = renderHook(() => useSalesData(makeSales(1), formatCurrency));
-    act(() => result.current.exportToCsv());
+    const { result: salesDataHook } = renderHook(() => useSalesData(makeSales(1), formatCurrency));
+    act(() => salesDataHook.current.exportToCsv());
     expect(global.URL.revokeObjectURL).toHaveBeenCalledWith("blob:mock-url");
   });
 
@@ -104,8 +123,8 @@ describe("useSalesData", () => {
       { productName: "Widget", userName: "alice", quantity: 1, priceAtOrder: 1000, paymentMethod: "Cash", saleDate: "2024-01-01", refunded: true },
       { productName: "Gadget", userName: "alice", quantity: 1, priceAtOrder: 2000, paymentMethod: "Cash", saleDate: "2024-01-01", refunded: false },
     ];
-    const { result } = renderHook(() => useSalesData(sales, formatCurrency));
-    act(() => result.current.exportToCsv());
+    const { result: salesDataHook } = renderHook(() => useSalesData(sales, formatCurrency));
+    act(() => salesDataHook.current.exportToCsv());
 
     expect(capturedCsv).toContain("status.refunded");
     expect(capturedCsv).toContain("status.paid");
@@ -121,8 +140,8 @@ describe("useSalesData", () => {
       { productName: "Widget", userName: "alice", quantity: 1, priceAtOrder: 1000, paymentMethod: "Cash", saleDate: "2024-01-01", refunded: true },
       { productName: "Gadget", userName: "alice", quantity: 1, priceAtOrder: 2000, paymentMethod: "Cash", saleDate: "2024-01-01", refunded: false },
     ];
-    const { result } = renderHook(() => useSalesData(sales, formatCurrency));
-    act(() => result.current.exportToCsv());
+    const { result: salesDataHook } = renderHook(() => useSalesData(sales, formatCurrency));
+    act(() => salesDataHook.current.exportToCsv());
 
     expect(capturedCsv).toContain("summary.revenue");
     expect(capturedCsv).toContain("$3000");

--- a/client/src/components/pages/Store/Reports/hooks/useOrdersDetailData.js
+++ b/client/src/components/pages/Store/Reports/hooks/useOrdersDetailData.js
@@ -1,6 +1,7 @@
 "use client";
 import { useCallback, useMemo, useState } from "react";
 
+import { addToast } from "@heroui/react";
 import { useTranslations } from "next-intl";
 
 import formatDate from "@lib/formatDate";
@@ -34,40 +35,44 @@ export function useOrdersDetailData(orders, formatCurrency) {
 
   const exportToCsv = useCallback(() => {
     if (!orders.length) return;
-    const headers = [
-      reportsTranslations("orders.shortId"), reportsTranslations("sales.date"), reportsTranslations("sales.user"),
-      reportsTranslations("orders.products"), reportsTranslations("sales.quantity"), reportsTranslations("sales.total"), reportsTranslations("sales.paymentMethod"),
-      reportsTranslations("orders.statusLabel"),
-    ];
-    const rows = orders.map((order) => [
-      order.shortId,
-      order.date ? formatDate(order.date) : "",
-      order.userName ?? "",
-      order.items.map((item) => `${item.productName} x${item.quantity}`).join("; "),
-      order.itemCount,
-      formatCurrency(order.total),
-      order.paymentMethod ?? "",
-      statusTranslations(`status.${refundedToStatus(order.refunded)}`),
-    ]);
+    try {
+      const headers = [
+        reportsTranslations("orders.shortId"), reportsTranslations("sales.date"), reportsTranslations("sales.user"),
+        reportsTranslations("orders.products"), reportsTranslations("sales.quantity"), reportsTranslations("sales.total"), reportsTranslations("sales.paymentMethod"),
+        reportsTranslations("orders.statusLabel"),
+      ];
+      const rows = orders.map((order) => [
+        order.shortId,
+        order.date ? formatDate(order.date) : "",
+        order.userName ?? "",
+        order.items.map((item) => `${item.productName} x${item.quantity}`).join("; "),
+        order.itemCount,
+        formatCurrency(order.total),
+        order.paymentMethod ?? "",
+        statusTranslations(`status.${refundedToStatus(order.refunded)}`),
+      ]);
 
-    const totalRevenue = orders.reduce((sum, order) => sum + order.total, 0);
-    const totalRefunded = orders.filter((order) => order.refunded).reduce((sum, order) => sum + order.total, 0);
-    const summaryRows = [
-      [],
-      [reportsTranslations("summary.revenue"), formatCurrency(totalRevenue)],
-      [reportsTranslations("summary.netRevenue"), formatCurrency(totalRevenue - totalRefunded)],
-      [reportsTranslations("summary.totalRefunded"), formatCurrency(totalRefunded)],
-    ];
+      const totalRevenue = orders.reduce((sum, order) => sum + order.total, 0);
+      const totalRefunded = orders.filter((order) => order.refunded).reduce((sum, order) => sum + order.total, 0);
+      const summaryRows = [
+        [],
+        [reportsTranslations("summary.revenue"), formatCurrency(totalRevenue)],
+        [reportsTranslations("summary.netRevenue"), formatCurrency(totalRevenue - totalRefunded)],
+        [reportsTranslations("summary.totalRefunded"), formatCurrency(totalRefunded)],
+      ];
 
-    const csv = [headers, ...rows, ...summaryRows]
-      .map((row) => row.map((cell) => `"${String(cell).replace(/"/g, '""')}"`).join(","))
-      .join("\n");
-    const url = URL.createObjectURL(new Blob([csv], { type: "text/csv;charset=utf-8;" }));
-    const link = document.createElement("a");
-    link.href = url;
-    link.download = `orders-report-${new Date().toISOString().slice(0, 10)}.csv`;
-    link.click();
-    URL.revokeObjectURL(url);
+      const csv = [headers, ...rows, ...summaryRows]
+        .map((row) => row.map((cell) => `"${String(cell).replace(/"/g, '""')}"`).join(","))
+        .join("\n");
+      const csvDownloadUrl = URL.createObjectURL(new Blob([csv], { type: "text/csv;charset=utf-8;" }));
+      const downloadLink = document.createElement("a");
+      downloadLink.href = csvDownloadUrl;
+      downloadLink.download = `orders-report-${new Date().toISOString().slice(0, 10)}.csv`;
+      downloadLink.click();
+      URL.revokeObjectURL(csvDownloadUrl);
+    } catch {
+      addToast({ color: "danger", description: reportsTranslations("export.error") });
+    }
   }, [orders, formatCurrency, reportsTranslations, statusTranslations]);
 
   return { paginatedOrders, totalPages, page, setPage, rowsPerPage, handleRowsPerPageChange, exportToCsv };

--- a/client/src/components/pages/Store/Reports/hooks/useSalesData.js
+++ b/client/src/components/pages/Store/Reports/hooks/useSalesData.js
@@ -1,6 +1,7 @@
 "use client";
 import { useCallback, useMemo, useState } from "react";
 
+import { addToast } from "@heroui/react";
 import { useTranslations } from "next-intl";
 
 import formatDate from "@lib/formatDate";
@@ -34,42 +35,46 @@ export function useSalesData(sales, formatCurrency) {
 
   const exportToCsv = useCallback(() => {
     if (!sales.length) return;
-    const headers = [
-      reportsTranslations("sales.product"), reportsTranslations("sales.user"), reportsTranslations("sales.quantity"),
-      reportsTranslations("sales.price"), reportsTranslations("sales.total"), reportsTranslations("sales.paymentMethod"), reportsTranslations("sales.date"),
-      reportsTranslations("orders.statusLabel"),
-    ];
-    const rows = sales.map((sale) => [
-      sale.productName,
-      sale.userName ?? "",
-      sale.quantity,
-      formatCurrency(sale.priceAtOrder),
-      formatCurrency(sale.priceAtOrder * sale.quantity),
-      sale.paymentMethod ?? "",
-      sale.saleDate ? formatDate(sale.saleDate) : "",
-      statusTranslations(`status.${refundedToStatus(sale.refunded)}`),
-    ]);
+    try {
+      const headers = [
+        reportsTranslations("sales.product"), reportsTranslations("sales.user"), reportsTranslations("sales.quantity"),
+        reportsTranslations("sales.price"), reportsTranslations("sales.total"), reportsTranslations("sales.paymentMethod"), reportsTranslations("sales.date"),
+        reportsTranslations("orders.statusLabel"),
+      ];
+      const rows = sales.map((sale) => [
+        sale.productName,
+        sale.userName ?? "",
+        sale.quantity,
+        formatCurrency(sale.priceAtOrder),
+        formatCurrency(sale.priceAtOrder * sale.quantity),
+        sale.paymentMethod ?? "",
+        sale.saleDate ? formatDate(sale.saleDate) : "",
+        statusTranslations(`status.${refundedToStatus(sale.refunded)}`),
+      ]);
 
-    const totalRevenue = sales.reduce((sum, sale) => sum + sale.priceAtOrder * sale.quantity, 0);
-    const totalRefunded = sales
-      .filter((sale) => sale.refunded)
-      .reduce((sum, sale) => sum + sale.priceAtOrder * sale.quantity, 0);
-    const summaryRows = [
-      [],
-      [reportsTranslations("summary.revenue"), formatCurrency(totalRevenue)],
-      [reportsTranslations("summary.netRevenue"), formatCurrency(totalRevenue - totalRefunded)],
-      [reportsTranslations("summary.totalRefunded"), formatCurrency(totalRefunded)],
-    ];
+      const totalRevenue = sales.reduce((sum, sale) => sum + sale.priceAtOrder * sale.quantity, 0);
+      const totalRefunded = sales
+        .filter((sale) => sale.refunded)
+        .reduce((sum, sale) => sum + sale.priceAtOrder * sale.quantity, 0);
+      const summaryRows = [
+        [],
+        [reportsTranslations("summary.revenue"), formatCurrency(totalRevenue)],
+        [reportsTranslations("summary.netRevenue"), formatCurrency(totalRevenue - totalRefunded)],
+        [reportsTranslations("summary.totalRefunded"), formatCurrency(totalRefunded)],
+      ];
 
-    const csv = [headers, ...rows, ...summaryRows]
-      .map((row) => row.map((cell) => `"${String(cell).replace(/"/g, '""')}"`).join(","))
-      .join("\n");
-    const url = URL.createObjectURL(new Blob([csv], { type: "text/csv;charset=utf-8;" }));
-    const link = document.createElement("a");
-    link.href = url;
-    link.download = `sales-report-${new Date().toISOString().slice(0, 10)}.csv`;
-    link.click();
-    URL.revokeObjectURL(url);
+      const csv = [headers, ...rows, ...summaryRows]
+        .map((row) => row.map((cell) => `"${String(cell).replace(/"/g, '""')}"`).join(","))
+        .join("\n");
+      const csvDownloadUrl = URL.createObjectURL(new Blob([csv], { type: "text/csv;charset=utf-8;" }));
+      const downloadLink = document.createElement("a");
+      downloadLink.href = csvDownloadUrl;
+      downloadLink.download = `sales-report-${new Date().toISOString().slice(0, 10)}.csv`;
+      downloadLink.click();
+      URL.revokeObjectURL(csvDownloadUrl);
+    } catch {
+      addToast({ color: "danger", description: reportsTranslations("export.error") });
+    }
   }, [sales, formatCurrency, reportsTranslations, statusTranslations]);
 
   return { paginatedSales, totalPages, page, setPage, rowsPerPage, handleRowsPerPageChange, exportToCsv };

--- a/client/src/components/pages/Store/Reports/locales/en.js
+++ b/client/src/components/pages/Store/Reports/locales/en.js
@@ -35,6 +35,9 @@ const reportsEn = {
       orders: "Orders",
       products: "Products",
     },
+    export: {
+      error: "Could not export the CSV report",
+    },
     summary: {
       title: "Summary",
       subtitle: "Consolidated totals for the selected period",

--- a/client/src/components/pages/Store/Reports/locales/es.js
+++ b/client/src/components/pages/Store/Reports/locales/es.js
@@ -35,6 +35,9 @@ const reportsEs = {
       orders: "Órdenes",
       products: "Productos",
     },
+    export: {
+      error: "No se pudo exportar el reporte CSV",
+    },
     summary: {
       title: "Resumen",
       subtitle: "Totales consolidados del período seleccionado",


### PR DESCRIPTION
  ## Summary

  Adds failure feedback for Reports CSV export actions.

  ## Changes

  - Shows a localized danger toast when Sales CSV export fails.
  - Shows a localized danger toast when Orders CSV export fails.
  - Keeps successful CSV downloads silent because the downloaded file is already the success feedback.
  - Adds English and Spanish copy for CSV export failure.
  - Keeps report generation errors as inline UI feedback.

  ## Testing

  - Added focused coverage for Sales CSV export failure feedback.
  - Added focused coverage for Orders CSV export failure feedback.
  - Confirmed existing successful export behavior still works.