### PR TITLE
Fix: Complete remaining feedback coverage

### DIFF
--- a/client/src/components/auth/WalletGuard.jsx
+++ b/client/src/components/auth/WalletGuard.jsx
@@ -36,12 +36,13 @@ export default function WalletGuard({
   onCancel,
 }) {
   const router = useRouter();
-  const tTour = useTranslations("walletTour");
+  const walletTourTranslations = useTranslations("walletTour");
   const [isOpen, setIsOpen] = useState(true);
   const [showPassword, setShowPassword] = useState(false);
   const [password, setPassword] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [authorized, setAuthorized] = useState(false);
+  const [passwordError, setPasswordError] = useState("");
 
   useEffect(() => () => {
     logoutWallet().catch(() => {});
@@ -73,11 +74,11 @@ export default function WalletGuard({
         {
           element: "#wallet-guard-anchor",
           popover: {
-            title: tTour("guardTitle"),
-            description: tTour("guardDescription"),
+            title: walletTourTranslations("guardTitle"),
+            description: walletTourTranslations("guardDescription"),
             side: "top",
             align: "center",
-            nextBtnText: tTour("guardButton"),
+            nextBtnText: walletTourTranslations("guardButton"),
             showButtons: ["next"],
           },
         },
@@ -101,18 +102,20 @@ export default function WalletGuard({
     },
   });
 
-  const handleSubmit = async (e) => {
-    e.preventDefault();
-    if (!password) return;
+  const handleSubmit = async (submitEvent) => {
+    submitEvent.preventDefault();
+    if (!password || submitting) return;
     setSubmitting(true);
+    setPasswordError("");
     try {
       await loginWallet(password);
-      await new Promise((r) => setTimeout(r, 150));
+      await new Promise((resolveLoginDelay) => setTimeout(resolveLoginDelay, 150));
       setAuthorized(true);
       setIsOpen(false);
       if (onAuthorized) onAuthorized();
-    } catch {}
-    finally {
+    } catch {
+      setPasswordError(walletTourTranslations("guardLoginError"));
+    } finally {
       setSubmitting(false);
       setPassword("");
     }
@@ -142,8 +145,13 @@ export default function WalletGuard({
                   label={passwordLabel}
                   type={showPassword ? "text" : "password"}
                   value={password}
-                  onChange={(e) => setPassword(e.target.value)}
+                  onChange={(changeEvent) => {
+                    setPassword(changeEvent.target.value);
+                    setPasswordError("");
+                  }}
                   isDisabled={submitting}
+                  isInvalid={Boolean(passwordError)}
+                  errorMessage={passwordError}
                   endContent={(
                     <button
                       type="button"
@@ -171,7 +179,7 @@ export default function WalletGuard({
               color="primary"
               type="submit"
               form="wallet-guard-form"
-              isDisabled={!password}
+              isDisabled={!password || submitting}
               isLoading={submitting}
             >
               {confirmText}

--- a/client/src/components/auth/__tests__/WalletGuard.test.jsx
+++ b/client/src/components/auth/__tests__/WalletGuard.test.jsx
@@ -1,4 +1,4 @@
-import { render, act } from "@testing-library/react";
+import { render, act, fireEvent, screen } from "@testing-library/react";
 import { driver } from "driver.js";
 
 import * as walletService from "@/services/walletService";
@@ -190,5 +190,25 @@ describe("WalletGuard — driver.js tour", () => {
     });
 
     expect(driver).not.toHaveBeenCalled();
+  });
+
+  it("shows a password error when wallet login fails", async () => {
+    walletService.loginWallet.mockRejectedValueOnce(new Error("Invalid password"));
+
+    await act(async () => {
+      renderWalletGuard();
+    });
+
+    fireEvent.change(screen.getByLabelText("Contraseña"), {
+      target: { value: "wrong-password" },
+    });
+
+    await act(async () => {
+      fireEvent.submit(document.getElementById("wallet-guard-form"));
+    });
+
+    expect(screen.getByText("guardLoginError")).toBeInTheDocument();
+    expect(walletService.loginWallet).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText("Protected content")).not.toBeInTheDocument();
   });
 });

--- a/client/src/components/locales/en.js
+++ b/client/src/components/locales/en.js
@@ -18,6 +18,7 @@ const componentsEn = {
     guardTitle: "Wallet Access",
     guardDescription: "This password protects your Bitcoin wallet. Enter it to access your Lightning channels.",
     guardButton: "Got it",
+    guardLoginError: "Could not unlock the wallet. Check the password and try again.",
     receiveAmountTitle: "Step 1: Amount in satoshis",
     receiveAmountDescription: "Enter <b>5000</b> as the amount. This covers the fee to open your Lightning channel.",
     receiveDescTitle: "Step 2: Description",

--- a/client/src/components/locales/es.js
+++ b/client/src/components/locales/es.js
@@ -18,6 +18,7 @@ const componentsEs = {
     guardTitle: "Acceso a la Billetera",
     guardDescription: "Esta contraseña protege tu billetera Bitcoin. Ingrésala para acceder a tus canales Lightning.",
     guardButton: "Entendido",
+    guardLoginError: "No se pudo desbloquear la billetera. Revisa la contraseña e intenta de nuevo.",
     receiveAmountTitle: "Paso 1: Monto en satoshis",
     receiveAmountDescription: "Ingresa <b>5000</b> como monto. Esta cantidad cubre la comisión para abrir tu canal Lightning.",
     receiveDescTitle: "Paso 2: Descripción",

--- a/client/src/components/pages/Auth/PinLogin/PinLogin.jsx
+++ b/client/src/components/pages/Auth/PinLogin/PinLogin.jsx
@@ -18,18 +18,18 @@ import { PinPad } from "./PinPad";
 const PIN_LENGTH = 4;
 
 export default function PinLogin() {
-  const t = useTranslations("pinLogin");
+  const pinLoginTranslations = useTranslations("pinLogin");
   const [pin, setPin] = useState("");
   const [selectedUser, setSelectedUser] = useState("");
   const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState("");
+  const [loginErrorMessage, setLoginErrorMessage] = useState("");
   const [lockedUntil, setLockedUntil] = useState(null);
 
   useEffect(() => {
-    const stored = localStorage.getItem("pinLockoutUntil");
-    if (!stored) return;
-    const ts = parseInt(stored, 10);
-    if (ts > Date.now()) setLockedUntil(ts);
+    const storedLockoutUntil = localStorage.getItem("pinLockoutUntil");
+    if (!storedLockoutUntil) return;
+    const lockoutUntilTimestamp = parseInt(storedLockoutUntil, 10);
+    if (lockoutUntilTimestamp > Date.now()) setLockedUntil(lockoutUntilTimestamp);
   }, []);
   const [employees, setEmployees] = useState([]);
   const router = useRouter();
@@ -52,51 +52,57 @@ export default function PinLogin() {
             avatar: user.name.slice(0, 2),
           })),
         );
-      } catch {}
+      } catch {
+        addToast({
+          title: pinLoginTranslations("errorMessages.loadEmployeesTitle"),
+          description: pinLoginTranslations("errorMessages.loadEmployeesDescription"),
+          color: "danger",
+        });
+      }
     }
     fetchEmployees();
-  }, []);
+  }, [pinLoginTranslations]);
 
   const handleNumberClick = (number) => {
     if (pin.length < PIN_LENGTH) {
       setPin((prev) => prev + number);
-      setError("");
+      setLoginErrorMessage("");
     }
   };
 
   const handleDelete = () => {
     setPin((prev) => prev.slice(0, -1));
-    setError("");
+    setLoginErrorMessage("");
   };
 
   const handleClear = () => {
     setPin("");
-    setError("");
+    setLoginErrorMessage("");
   };
 
   const handleLogin = async () => {
     if (lockedUntil && Date.now() < lockedUntil) return;
 
     if (!selectedUser) {
-      setError(t("errorMessages.selectEmployee"));
+      setLoginErrorMessage(pinLoginTranslations("errorMessages.selectEmployee"));
       return;
     }
 
     if (pin.length < PIN_LENGTH) {
-      setError(t("errorMessages.enterPin"));
+      setLoginErrorMessage(pinLoginTranslations("errorMessages.enterPin"));
       return;
     }
 
     setIsLoading(true);
-    setError("");
+    setLoginErrorMessage("");
 
-    const employee = employees.find((emp) => emp.id === selectedUser);
+    const employee = employees.find((currentEmployee) => currentEmployee.id === selectedUser);
 
     try {
       await login({ name: employee.name, pin });
       addToast({
-        title: t("successMessages.toastTitle"),
-        description: `${t("successMessages.firstMessage")} ${employee.name} ${t("successMessages.secondMessage")} ${employee.role}.`,
+        title: pinLoginTranslations("successMessages.toastTitle"),
+        description: `${pinLoginTranslations("successMessages.firstMessage")} ${employee.name} ${pinLoginTranslations("successMessages.secondMessage")} ${employee.role}.`,
         color: "success",
       });
       setPin("");
@@ -104,16 +110,16 @@ export default function PinLogin() {
       setLockedUntil(null);
       localStorage.removeItem("pinLockoutUntil");
       router.push("/");
-    } catch (error) {
-      if (error?.status === 429) {
-        const ts = Date.now() + (error.retryAfter ?? 180) * 1000;
-        setLockedUntil(ts);
-        localStorage.setItem("pinLockoutUntil", ts.toString());
-        setError("");
-      } else if (error?.message === "No assigned role for this user, contact Admin") {
-        setError(error.message);
+    } catch (loginError) {
+      if (loginError?.status === 429) {
+        const lockoutUntilTimestamp = Date.now() + (loginError.retryAfter ?? 180) * 1000;
+        setLockedUntil(lockoutUntilTimestamp);
+        localStorage.setItem("pinLockoutUntil", lockoutUntilTimestamp.toString());
+        setLoginErrorMessage("");
+      } else if (loginError?.message === "No assigned role for this user, contact Admin") {
+        setLoginErrorMessage(loginError.message);
       } else {
-        setError(t("errorMessages.incorrectPin"));
+        setLoginErrorMessage(pinLoginTranslations("errorMessages.incorrectPin"));
       }
       setPin("");
     } finally {
@@ -139,7 +145,7 @@ export default function PinLogin() {
           />
           <PinPad
             pin={pin}
-            error={error}
+            error={loginErrorMessage}
             isLoading={isLoading}
             lockedUntil={lockedUntil}
             onNumberClick={handleNumberClick}

--- a/client/src/components/pages/Auth/PinLogin/__tests__/PinLogin.test.jsx
+++ b/client/src/components/pages/Auth/PinLogin/__tests__/PinLogin.test.jsx
@@ -1,5 +1,6 @@
 import { useRouter } from "next/navigation";
 
+import { addToast } from "@heroui/react";
 import { act, render, screen, fireEvent } from "@testing-library/react";
 
 import { useAuth } from "@/hooks/auth/useAuth";
@@ -14,13 +15,18 @@ jest.mock("../EmployeeSelect", () => ({
     <div>
       <label>selectLabel</label>
       {employees.length > 0
-        ? employees.map((emp) => (
-          <button key={emp.id} onClick={() => onSelect(emp.id)}>{emp.name}</button>
+        ? employees.map((employee) => (
+          <button key={employee.id} onClick={() => onSelect(employee.id)}>{employee.name}</button>
         ))
         : <span>noEmployees</span>
       }
     </div>
   ),
+}));
+
+jest.mock("@heroui/react", () => ({
+  ...jest.requireActual("@heroui/react"),
+  addToast: jest.fn(),
 }));
 
 jest.mock("@/services/authService", () => ({ getUsers: jest.fn() }));
@@ -37,13 +43,13 @@ const employees = [
 ];
 
 const renderPinLogin = async () => {
-  const result = render(
+  const pinLoginScreen = render(
     <I18nProvider>
       <PinLogin />
     </I18nProvider>,
   );
   await act(async () => {});
-  return result;
+  return pinLoginScreen;
 };
 
 beforeEach(() => {
@@ -76,6 +82,18 @@ describe("PinLogin", () => {
     expect(screen.getByText("noEmployees")).toBeInTheDocument();
   });
 
+  it("shows an error toast when employees cannot be loaded", async () => {
+    getUsers.mockRejectedValueOnce(new Error("Users unavailable"));
+
+    await renderPinLogin();
+
+    expect(addToast).toHaveBeenCalledWith({
+      title: "errorMessages.loadEmployeesTitle",
+      description: "errorMessages.loadEmployeesDescription",
+      color: "danger",
+    });
+  });
+
   it("redirects to '/' when already authenticated", async () => {
     useAuth.mockReturnValue({ login: mockLogin, isAuth: true, isLoading: false });
     await renderPinLogin();
@@ -83,10 +101,10 @@ describe("PinLogin", () => {
   });
 
   it("shows lockout message after a 429 response from the server", async () => {
-    const error = new Error("Too many requests");
-    error.status = 429;
-    error.retryAfter = 180;
-    mockLogin.mockRejectedValue(error);
+    const rateLimitError = new Error("Too many requests");
+    rateLimitError.status = 429;
+    rateLimitError.retryAfter = 180;
+    mockLogin.mockRejectedValue(rateLimitError);
 
     await renderPinLogin();
 
@@ -123,8 +141,8 @@ describe("PinLogin", () => {
 
   it("shows the specific error message when the user's role is deleted", async () => {
     const specificMessage = "No assigned role for this user, contact Admin";
-    const error = new Error(specificMessage);
-    mockLogin.mockRejectedValue(error);
+    const missingRoleError = new Error(specificMessage);
+    mockLogin.mockRejectedValue(missingRoleError);
 
     await renderPinLogin();
 

--- a/client/src/components/pages/Auth/locales/en.js
+++ b/client/src/components/pages/Auth/locales/en.js
@@ -17,6 +17,8 @@ const authEn = {
       selectEmployee: "Please select an employee.",
       enterPin: "The PIN must be at least 4 digits long.",
       incorrectPin: "Incorrect PIN for the selected employee.",
+      loadEmployeesTitle: "Could not load employees",
+      loadEmployeesDescription: "Refresh the page or contact an administrator.",
     },
     successMessages: {
       toastTitle: "Successful login",

--- a/client/src/components/pages/Auth/locales/es.js
+++ b/client/src/components/pages/Auth/locales/es.js
@@ -17,6 +17,8 @@ const authEs = {
       selectEmployee: "Por favor selecciona un empleado",
       enterPin: "El PIN debe tener al menos 4 dígitos",
       incorrectPin: "PIN incorrecto para el empleado seleccionado.",
+      loadEmployeesTitle: "No se pudieron cargar los empleados",
+      loadEmployeesDescription: "Actualiza la página o contacta a un administrador.",
     },
     successMessages: {
       toastTitle: "Inicio de sesión exitoso",

--- a/client/src/components/pages/Onboarding/Onboarding.jsx
+++ b/client/src/components/pages/Onboarding/Onboarding.jsx
@@ -30,6 +30,7 @@ export function Onboarding() {
   const onboardingTranslations = useTranslations();
   const [step, setStep] = useState(1);
   const [setupStatus, setSetupStatus] = useState(null);
+  const [isSubmittingSetup, setIsSubmittingSetup] = useState(false);
   const [data, setData] = useState({
     businessType: "store",
     walletBackend: "phoenixd",
@@ -99,6 +100,9 @@ export function Onboarding() {
   };
 
   const handleComplete = async () => {
+    if (isSubmittingSetup) return;
+    setIsSubmittingSetup(true);
+
     try {
       if (needsBusinessType) {
         await submitInitialSetup({
@@ -159,10 +163,12 @@ export function Onboarding() {
       }
     } catch (error) {
       addToast({
-        title: "Error",
+        title: onboardingTranslations("submitOnboardingToast.errorTitle"),
         description: error.message,
         color: "danger",
       });
+    } finally {
+      setIsSubmittingSetup(false);
     }
   };
 
@@ -260,7 +266,8 @@ export function Onboarding() {
                 <Button
                   color="primary"
                   onPress={handleComplete}
-                  isDisabled={!data.businessType}
+                  isDisabled={!data.businessType || isSubmittingSetup}
+                  isLoading={isSubmittingSetup}
                   className="bg-green-800"
                 >
                   {onboardingTranslations("buttons.finish")}
@@ -290,6 +297,8 @@ export function Onboarding() {
                 <Button
                   color="primary"
                   onPress={handleComplete}
+                  isDisabled={isSubmittingSetup}
+                  isLoading={isSubmittingSetup}
                   className="bg-green-800"
                 >
                   {onboardingTranslations("buttons.finish")}

--- a/client/src/components/pages/Onboarding/Onboarding.jsx
+++ b/client/src/components/pages/Onboarding/Onboarding.jsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { Button, Divider, addToast } from "@heroui/react";
 import { useTranslations } from "next-intl";
@@ -31,6 +31,7 @@ export function Onboarding() {
   const [step, setStep] = useState(1);
   const [setupStatus, setSetupStatus] = useState(null);
   const [isSubmittingSetup, setIsSubmittingSetup] = useState(false);
+  const isSubmittingSetupRef = useRef(false);
   const [data, setData] = useState({
     businessType: "store",
     walletBackend: "phoenixd",
@@ -100,7 +101,8 @@ export function Onboarding() {
   };
 
   const handleComplete = async () => {
-    if (isSubmittingSetup) return;
+    if (isSubmittingSetupRef.current) return;
+    isSubmittingSetupRef.current = true;
     setIsSubmittingSetup(true);
 
     try {
@@ -168,6 +170,7 @@ export function Onboarding() {
         color: "danger",
       });
     } finally {
+      isSubmittingSetupRef.current = false;
       setIsSubmittingSetup(false);
     }
   };

--- a/client/src/components/pages/Onboarding/Onboarding.jsx
+++ b/client/src/components/pages/Onboarding/Onboarding.jsx
@@ -163,10 +163,10 @@ export function Onboarding() {
           onClose: () => window.location.reload(),
         });
       }
-    } catch (error) {
+    } catch (setupSubmissionError) {
       addToast({
         title: onboardingTranslations("submitOnboardingToast.errorTitle"),
-        description: error.message,
+        description: setupSubmissionError.message,
         color: "danger",
       });
     } finally {

--- a/client/src/components/pages/Onboarding/__tests__/Onboarding.test.jsx
+++ b/client/src/components/pages/Onboarding/__tests__/Onboarding.test.jsx
@@ -72,6 +72,32 @@ async function completeOnboardingWithNwcUri(user, nwcUri) {
   });
 }
 
+async function completeOnboardingWithPhoenixd() {
+  await act(async () => {
+    fireEvent.click(screen.getByText("buttons.next"));
+  });
+  await act(async () => {
+    fireEvent.click(screen.getByText("buttons.next"));
+  });
+
+  await act(async () => {
+    fireEvent.change(screen.getByPlaceholderText("step2.fields.userNamePlaceholder"), { target: { value: "testuser" } });
+    fireEvent.change(screen.getByPlaceholderText("step2.fields.userPinPlaceholder"), { target: { value: "0000" } });
+    fireEvent.change(screen.getByPlaceholderText("step2.fields.passwordPlaceholder"), { target: { value: "Abcd123$" } });
+    fireEvent.change(screen.getByPlaceholderText("step2.fields.confirmPasswordPlaceholder"), { target: { value: "Abcd123$" } });
+  });
+  await act(async () => {
+    fireEvent.click(screen.getByText("buttons.next"));
+  });
+
+  await act(async () => {
+    fireEvent.change(screen.getByPlaceholderText("step3.fields.businessNamePlaceholder"), { target: { value: "My Business" } });
+  });
+  await act(async () => {
+    fireEvent.click(screen.getByText("buttons.next"));
+  });
+}
+
 const originalError = console.error;
 const originalWarn = console.warn;
 
@@ -389,6 +415,54 @@ describe("Onboarding Wizard", () => {
         expect(addToast).toHaveBeenCalledWith(
           expect.objectContaining({ title: "submitOnboardingToast.nwcErrorTitle", color: "danger" }),
         );
+      });
+    });
+  });
+
+  describe("setup submit feedback", () => {
+    it("shows a localized error toast when setup submission fails", async () => {
+      submitInitialSetup.mockRejectedValueOnce(new Error("Server unavailable"));
+
+      await act(async () => {
+        renderOnboarding();
+      });
+      await completeOnboardingWithPhoenixd();
+
+      await act(async () => {
+        fireEvent.click(screen.getByText("buttons.finish"));
+      });
+
+      expect(addToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "submitOnboardingToast.errorTitle",
+          description: "Server unavailable",
+          color: "danger",
+        }),
+      );
+    });
+
+    it("prevents duplicate setup submissions while finish is pending", async () => {
+      let resolveSetupSubmission;
+      submitInitialSetup.mockImplementationOnce(() => new Promise((resolveSetup) => {
+        resolveSetupSubmission = resolveSetup;
+      }));
+
+      await act(async () => {
+        renderOnboarding();
+      });
+      await completeOnboardingWithPhoenixd();
+      submitInitialSetup.mockClear();
+
+      const finishButton = screen.getByText("buttons.finish");
+      await act(async () => {
+        fireEvent.click(finishButton);
+        fireEvent.click(finishButton);
+      });
+
+      expect(submitInitialSetup).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        resolveSetupSubmission({});
       });
     });
   });

--- a/client/src/components/pages/Onboarding/locales/en.js
+++ b/client/src/components/pages/Onboarding/locales/en.js
@@ -2,6 +2,7 @@ const onboardingEn = {
   submitOnboardingToast: {
     title: "Success",
     description: "The data is saved succesfully",
+    errorTitle: "Setup failed",
     nwcSavedTitle: "NWC backend activated",
     nwcSavedDescription: "NWC backend is now ready to use.",
     nwcErrorTitle: "Could not connect the NWC wallet",

--- a/client/src/components/pages/Onboarding/locales/es.js
+++ b/client/src/components/pages/Onboarding/locales/es.js
@@ -2,6 +2,7 @@ const onboardingEs = {
   submitOnboardingToast: {
     title: "Guardado Exitoso",
     description: "La información se almaceno correctamente",
+    errorTitle: "No se pudo completar la configuración",
     nwcSavedTitle: "Backend NWC activado",
     nwcSavedDescription: "El backend NWC está listo para usarse.",
     nwcErrorTitle: "No se pudo conectar la wallet NWC",


### PR DESCRIPTION
## Summary

  Completes the remaining user-facing feedback gaps outside the Store toast PR series.

  ## Changes

  - Improves Onboarding setup failure feedback:
    - replaces the hardcoded error toast title with localized copy
    - prevents duplicate setup submissions while Finish is pending
    - hardens the submit guard with a synchronous ref to block rapid repeated submits

  - Improves WalletGuard feedback:
    - failed wallet password unlocks now show inline password feedback instead of failing silently
    - keeps the modal open and ready for retry
    - clears the error when the password changes

  - Improves PinLogin feedback:
    - failed employee loading now shows a localized danger toast
    - keeps existing inline PIN/login validation behavior unchanged
    - existing inline PinLogin validation errors remain inline, not toast-based

  - Cleans up touched feedback code with descriptive error naming.

  ## Testing

  - Added focused regression coverage for:
    - Onboarding setup failure toast
    - Onboarding duplicate-submit protection
    - WalletGuard failed unlock feedback
    - PinLogin employee-load failure toast

<img width="464" height="274" alt="Screenshot From 2026-08-05 12-37-44" src="https://github.com/user-attachments/assets/12f2c49f-2b3a-422c-9a0d-05047dd5580f" />

<img width="892" height="596" alt="Screenshot From 2026-08-05 12-45-52" src="https://github.com/user-attachments/assets/1a8d1ea6-c871-495f-bb82-7b84a6eb0a9a" />