### PR TITLE
fix(store): base bundle price reference on component prices

### DIFF
--- a/client/src/components/pages/Store/Products/BundleProductSelector.jsx
+++ b/client/src/components/pages/Store/Products/BundleProductSelector.jsx
@@ -7,7 +7,10 @@ import { useTranslations } from "next-intl";
 
 import { useCurrency } from "@/components/hooks/useCurrency";
 import { useProductVariants } from "@/components/pages/Store/hooks/useProductVariants";
-import { variantIsActive } from "@/components/pages/Store/utils/productVariantAvailability";
+import {
+  calculateComponentsPriceCents,
+  resolveActiveComponentVariants,
+} from "@/components/pages/Store/utils/bundleComponentsPrice";
 import { deriveVariantDisplayName } from "@/components/pages/Store/utils/productVariantOptionValues";
 import { DeleteButton } from "@/components/shared/DeleteButton";
 
@@ -36,8 +39,8 @@ export function BundleProductSelector({ selectedProducts, allProducts, onCompone
 
   const resolveProduct = useCallback((productId) => productById.get(productId), [productById]);
   const activeVariantsForProduct = (productId) => (
-    componentDetailByProductId[productId]?.variants ?? []
-  ).filter(variantIsActive);
+    resolveActiveComponentVariants(componentDetailByProductId[productId])
+  );
 
   const variantLabel = (productId, variant) => {
     const componentDetail = componentDetailByProductId[productId];
@@ -69,17 +72,15 @@ export function BundleProductSelector({ selectedProducts, allProducts, onCompone
     };
   }, [componentDetailByProductId, fetchProductDetail, resolveProduct, selectedProducts]);
 
-  const bundleCostCents = selectedProducts.reduce((accumulatedCents, selectedProduct) => {
-    const product = resolveProduct(selectedProduct.productId);
-    const selectedVariant = activeVariantsForProduct(selectedProduct.productId)
-      .find((variant) => variant.id === selectedProduct.variantId);
-    const componentCostCents = selectedVariant?.costCents ?? product?.costCents ?? 0;
-    return accumulatedCents + componentCostCents * selectedProduct.quantity;
-  }, 0);
+  const componentsPriceCents = calculateComponentsPriceCents(
+    selectedProducts,
+    productById,
+    componentDetailByProductId,
+  );
 
   const handleAddProduct = async (product) => {
     const productDetail = product.hasVariants ? await fetchProductDetail(product.id) : null;
-    const activeVariants = (productDetail?.variants ?? []).filter(variantIsActive);
+    const activeVariants = resolveActiveComponentVariants(productDetail);
     if (productDetail) {
       setComponentDetailByProductId((previousComponentDetails) => ({
         ...previousComponentDetails,
@@ -216,7 +217,7 @@ export function BundleProductSelector({ selectedProducts, allProducts, onCompone
             );
           })}
           <p className="text-xs text-gray-500 text-right pt-2">
-            {productsTranslation("modal.bundleCostReference")} {formatAmount(bundleCostCents)}
+            {productsTranslation("modal.bundleComponentsPriceReference")} {formatAmount(componentsPriceCents)}
           </p>
         </div>
       )}

--- a/client/src/components/pages/Store/Products/__tests__/BundleProductSelector.test.jsx
+++ b/client/src/components/pages/Store/Products/__tests__/BundleProductSelector.test.jsx
@@ -62,16 +62,16 @@ jest.mock("@/components/shared/DeleteButton", () => ({
   ),
 }));
 
-const productA = { id: "prod-a", name: "Arduino Nano", SKU: "ARD-NANO", costCents: 500, isBundle: false };
-const productB = { id: "prod-b", name: "Breadboard", SKU: "BB-400", costCents: 300, isBundle: false };
-const variantProduct = { id: "prod-variant", name: "T-Shirt", SKU: "TSHIRT", costCents: 700, hasVariants: true, isBundle: false };
-const bundleProduct = { id: "prod-bundle", name: "Starter Kit", SKU: "KIT-1", costCents: 1000, isBundle: true };
+const productA = { id: "prod-a", name: "Arduino Nano", SKU: "ARD-NANO", priceCents: 1500, costCents: 500, isBundle: false };
+const productB = { id: "prod-b", name: "Breadboard", SKU: "BB-400", priceCents: 900, costCents: 300, isBundle: false };
+const variantProduct = { id: "prod-variant", name: "T-Shirt", SKU: "TSHIRT", priceCents: 1200, costCents: 0, hasVariants: true, isBundle: false };
+const bundleProduct = { id: "prod-bundle", name: "Starter Kit", SKU: "KIT-1", priceCents: 3000, costCents: 1000, isBundle: true };
 
 const variantProductDetail = {
   variants: [
-    { id: "variant-red", optionValueIds: ["red"], costCents: 800, priceCents: 1200, quantity: 4, isActive: true },
-    { id: "variant-blue", optionValueIds: ["blue"], costCents: 900, priceCents: 1400, quantity: 3, isActive: true },
-    { id: "variant-inactive", optionValueIds: ["inactive"], costCents: 100, priceCents: 100, quantity: 3, isActive: false },
+    { id: "variant-red", optionValueIds: ["red"], costCents: null, priceCents: 1200, quantity: 4, isActive: true },
+    { id: "variant-blue", optionValueIds: ["blue"], costCents: null, priceCents: 1400, quantity: 3, isActive: true },
+    { id: "variant-inactive", optionValueIds: ["inactive"], costCents: null, priceCents: 100, quantity: 3, isActive: false },
   ],
   options: [
     {
@@ -253,7 +253,7 @@ describe("BundleProductSelector", () => {
     expect(onChange).toHaveBeenCalledWith([{ productId: "prod-a", quantity: 1 }]);
   });
 
-  it("displays the cost reference based on selected product costs and quantities", () => {
+  it("displays the price reference based on selected product prices and quantities", () => {
     renderSelector({
       selectedProducts: [
         { productId: "prod-a", quantity: 2 },
@@ -261,19 +261,33 @@ describe("BundleProductSelector", () => {
       ],
     });
 
-    const costLine = screen.getByText(/modal\.bundleCostReference/, { selector: "p" });
-    expect(costLine).toBeInTheDocument();
-    expect(costLine).toHaveTextContent("$13.00");
+    const priceLine = screen.getByText(/modal\.bundleComponentsPriceReference/, { selector: "p" });
+    expect(priceLine).toBeInTheDocument();
+    expect(priceLine).toHaveTextContent("$39.00");
   });
 
-  it("uses selected variant cost in the cost reference", async () => {
+  it("uses selected variant price in the price reference", async () => {
     renderSelector({
       selectedProducts: [{ productId: "prod-variant", variantId: "variant-blue", quantity: 2 }],
     });
 
     await screen.findByLabelText("modal.bundleComponentVariantLabel");
-    const costLine = screen.getByText(/modal\.bundleCostReference/, { selector: "p" });
+    const priceLine = screen.getByText(/modal\.bundleComponentsPriceReference/, { selector: "p" });
 
-    expect(costLine).toHaveTextContent("$18.00");
+    expect(priceLine).toHaveTextContent("$28.00");
+  });
+
+  it("counts variant components that carry no cost data in the price reference", async () => {
+    renderSelector({
+      selectedProducts: [
+        { productId: "prod-a", quantity: 1 },
+        { productId: "prod-variant", variantId: "variant-red", quantity: 1 },
+      ],
+    });
+
+    await screen.findByLabelText("modal.bundleComponentVariantLabel");
+    const priceLine = screen.getByText(/modal\.bundleComponentsPriceReference/, { selector: "p" });
+
+    expect(priceLine).toHaveTextContent("$27.00");
   });
 });

--- a/client/src/components/pages/Store/Products/locales/en.js
+++ b/client/src/components/pages/Store/Products/locales/en.js
@@ -66,7 +66,7 @@ const productsEn = {
       bundleComponentsNotFound: "No products found.",
       bundleComponentsEmpty: "No components yet. Search and add products above.",
       bundleComponentsRequired: "Add at least one component before saving this bundle.",
-      bundleCostReference: "Components cost:",
+      bundleComponentsPriceReference: "Components price:",
       bundleComponentQuantityLabel: "Quantity",
       bundleComponentVariantLabel: "Variant",
       confirmBundleConversionTitle: "Convert variant product to bundle?",

--- a/client/src/components/pages/Store/Products/locales/es.js
+++ b/client/src/components/pages/Store/Products/locales/es.js
@@ -66,7 +66,7 @@ const productsEs = {
       bundleComponentsNotFound: "No se encontraron productos.",
       bundleComponentsEmpty: "Sin componentes. Busca y agrega productos arriba.",
       bundleComponentsRequired: "Agrega al menos un componente antes de guardar este paquete.",
-      bundleCostReference: "Costo de componentes:",
+      bundleComponentsPriceReference: "Precio de componentes:",
       bundleComponentQuantityLabel: "Cantidad",
       bundleComponentVariantLabel: "Variante",
       confirmBundleConversionTitle: "¿Convertir producto con variantes a paquete?",

--- a/client/src/components/pages/Store/utils/__tests__/bundleComponentsPrice.test.js
+++ b/client/src/components/pages/Store/utils/__tests__/bundleComponentsPrice.test.js
@@ -1,0 +1,95 @@
+import {
+  calculateComponentsPriceCents,
+  resolveActiveComponentVariants,
+} from "../bundleComponentsPrice";
+
+const SIMPLE_PRODUCT = { id: "prod-a", name: "Arduino Nano", priceCents: 1500, costCents: 500 };
+const OTHER_SIMPLE_PRODUCT = { id: "prod-b", name: "Breadboard", priceCents: 900, costCents: 300 };
+const VARIANT_PRODUCT = { id: "prod-variant", name: "T-Shirt", priceCents: 1200, costCents: 0, hasVariants: true };
+const PRODUCT_WITHOUT_PRICE = { id: "prod-no-price", name: "Sticker" };
+
+const VARIANT_PRODUCT_DETAIL = {
+  variants: [
+    { id: "variant-red", priceCents: 1200, costCents: null, isActive: true },
+    { id: "variant-blue", priceCents: 1400, costCents: null, isActive: true },
+    { id: "variant-retired", priceCents: 100, costCents: null, isActive: false },
+  ],
+};
+
+const CATALOG = new Map([
+  [SIMPLE_PRODUCT.id, SIMPLE_PRODUCT],
+  [OTHER_SIMPLE_PRODUCT.id, OTHER_SIMPLE_PRODUCT],
+  [VARIANT_PRODUCT.id, VARIANT_PRODUCT],
+  [PRODUCT_WITHOUT_PRICE.id, PRODUCT_WITHOUT_PRICE],
+]);
+
+const LOADED_COMPONENT_DETAILS = { [VARIANT_PRODUCT.id]: VARIANT_PRODUCT_DETAIL };
+
+describe("resolveActiveComponentVariants", () => {
+  it("returns only the active variants", () => {
+    expect(resolveActiveComponentVariants(VARIANT_PRODUCT_DETAIL).map((variant) => variant.id))
+      .toEqual(["variant-red", "variant-blue"]);
+  });
+
+  it("returns an empty list when the component detail has not loaded", () => {
+    expect(resolveActiveComponentVariants(undefined)).toEqual([]);
+    expect(resolveActiveComponentVariants({})).toEqual([]);
+  });
+});
+
+describe("calculateComponentsPriceCents", () => {
+  it("returns zero for an empty component list", () => {
+    expect(calculateComponentsPriceCents([], CATALOG, {})).toBe(0);
+  });
+
+  it("sums price times quantity for simple components", () => {
+    const bundleComponents = [
+      { productId: "prod-a", quantity: 2 },
+      { productId: "prod-b", quantity: 1 },
+    ];
+
+    expect(calculateComponentsPriceCents(bundleComponents, CATALOG, {})).toBe(3900);
+  });
+
+  it("uses the selected variant price once the component detail is loaded", () => {
+    const bundleComponents = [{ productId: "prod-variant", variantId: "variant-blue", quantity: 2 }];
+
+    expect(calculateComponentsPriceCents(bundleComponents, CATALOG, LOADED_COMPONENT_DETAILS)).toBe(2800);
+  });
+
+  it("falls back to the product price while the variant detail is still loading", () => {
+    const bundleComponents = [{ productId: "prod-variant", variantId: "variant-blue", quantity: 2 }];
+
+    expect(calculateComponentsPriceCents(bundleComponents, CATALOG, {})).toBe(2400);
+  });
+
+  it("falls back to the product price when the pinned variant is no longer active", () => {
+    const bundleComponents = [{ productId: "prod-variant", variantId: "variant-retired", quantity: 1 }];
+
+    expect(calculateComponentsPriceCents(bundleComponents, CATALOG, LOADED_COMPONENT_DETAILS)).toBe(1200);
+  });
+
+  it("skips components whose product is no longer in the catalog", () => {
+    const bundleComponents = [
+      { productId: "prod-deleted", quantity: 3 },
+      { productId: "prod-b", quantity: 1 },
+    ];
+
+    expect(calculateComponentsPriceCents(bundleComponents, CATALOG, {})).toBe(900);
+  });
+
+  it("treats a missing price as zero", () => {
+    const bundleComponents = [{ productId: "prod-no-price", quantity: 4 }];
+
+    expect(calculateComponentsPriceCents(bundleComponents, CATALOG, {})).toBe(0);
+  });
+
+  it("counts variant components that carry no cost data", () => {
+    const bundleComponents = [
+      { productId: "prod-a", quantity: 1 },
+      { productId: "prod-variant", variantId: "variant-red", quantity: 1 },
+    ];
+
+    expect(calculateComponentsPriceCents(bundleComponents, CATALOG, LOADED_COMPONENT_DETAILS)).toBe(2700);
+  });
+});

--- a/client/src/components/pages/Store/utils/bundleComponentsPrice.js
+++ b/client/src/components/pages/Store/utils/bundleComponentsPrice.js
@@ -1,0 +1,25 @@
+import { variantIsActive } from "./productVariantAvailability";
+
+export function resolveActiveComponentVariants(componentDetail) {
+  return (componentDetail?.variants ?? []).filter(variantIsActive);
+}
+
+function resolveComponentPriceCents(bundleComponent, product, componentDetail) {
+  const selectedVariant = resolveActiveComponentVariants(componentDetail)
+    .find((variant) => variant.id === bundleComponent.variantId);
+  return selectedVariant?.priceCents ?? product.priceCents ?? 0;
+}
+
+export function calculateComponentsPriceCents(bundleComponents, productById, componentDetailByProductId) {
+  return bundleComponents.reduce((accumulatedCents, bundleComponent) => {
+    const product = productById.get(bundleComponent.productId);
+    if (!product) return accumulatedCents;
+
+    const componentPriceCents = resolveComponentPriceCents(
+      bundleComponent,
+      product,
+      componentDetailByProductId[bundleComponent.productId],
+    );
+    return accumulatedCents + componentPriceCents * bundleComponent.quantity;
+  }, 0);
+}


### PR DESCRIPTION
## Summary
- El estimado del paquete sumaba `costCents`, un dato roto en dos direcciones: las variantes quedan con `cost_cents = NULL` (`VariantManager.buildVariantRequest` nunca lo envía) y por eso aportaban $0.00, mientras que los productos simples guardan `costCents = priceCents`, o sea su precio de venta disfrazado de costo.
- El cálculo pasa a sumar `priceCents`: precio de la variante seleccionada, con fallback al precio del producto mientras el detalle de variantes no ha cargado o si la variante fijada dejó de estar activa.
- Nuevo util puro `utils/bundleComponentsPrice.js` con el cálculo fuera del componente, más `resolveActiveComponentVariants` que elimina el filtro de variantes activas duplicado en `BundleProductSelector`.
- Clave i18n `bundleCostReference` → `bundleComponentsPriceReference` ("Precio de componentes:" / "Components price:").
- Tests nuevos del util (10 casos) y fixtures del selector ajustados para que `priceCents ≠ costCents` y las variantes lleven `costCents: null`: los asserts de la línea de referencia pasan de $13.00/$0.00 a $39.00/$28.00.

Nota fuera de alcance: `ProductVariantService.kt:340` sobreescribe `costCents` con NULL en cada update de variante porque el cliente no lo manda. Esta PR ya no depende de ese dato, pero el costo real de las variantes sigue sin persistirse.

## Test plan
- [x] Client tests pass (`npm test`) — 261 suites, 2466 tests
- [x] Server tests pass (`./gradlew test`)
- [x] ESLint passes (`npm run lint`)
- [x] ktlint passes (`./gradlew ktlintCheck`)
- [x] Ruff passes (`ruff check .`)
- [x] Build succeeds (`make build`)