### PR TITLE
Fix: Update active category filter state in cart

### DIFF
--- a/client/src/components/pages/Store/Cart/SearchProducts.jsx
+++ b/client/src/components/pages/Store/Cart/SearchProducts.jsx
@@ -15,8 +15,8 @@ export function SearchProducts({ products, onAddProduct, categories }) {
   const filteredProducts = products.filter((product) => {
     const categoryIds = product.categoryIds ?? [];
     const categoryNames = categories
-      .filter((cat) => categoryIds.includes(cat.id))
-      .map((cat) => cat.name)
+      .filter((category) => categoryIds.includes(category.id))
+      .map((category) => category.name)
       .join(" ");
 
     const searchMatch = product.name.toLowerCase().includes(search.toLowerCase())
@@ -41,29 +41,37 @@ export function SearchProducts({ products, onAddProduct, categories }) {
         }
         value={search}
         onClear={() => setSearch("")}
-        onChange={(e) => setSearch(e.target.value)}
+        onChange={(event) => setSearch(event.target.value)}
       />
 
       <div className="mb-4 flex flex-wrap gap-2">
         <Button
-          color="primary"
+          color={categoryFilter === null ? "primary" : undefined}
+          className={categoryFilter === null ? "" : "bg-slate-100"}
           radius="full"
           size="sm"
+          aria-pressed={categoryFilter === null}
           onPress={() => setCategoryFilter(null)}
         >
           {cartTranslations("search.filterAll")}
         </Button>
-        {categories.map((category) => (
-          <Button
-            key={category.id}
-            onPress={() => setCategoryFilter(category.id)}
-            className="bg-slate-100"
-            radius="full"
-            size="sm"
-          >
-            {category.name}
-          </Button>
-        ))
+        {categories.map((category) => {
+          const isSelectedCategory = categoryFilter === category.id;
+
+          return (
+            <Button
+              key={category.id}
+              color={isSelectedCategory ? "primary" : undefined}
+              className={isSelectedCategory ? "" : "bg-slate-100"}
+              radius="full"
+              size="sm"
+              aria-pressed={isSelectedCategory}
+              onPress={() => setCategoryFilter(category.id)}
+            >
+              {category.name}
+            </Button>
+          );
+        })
 
         }
       </div>

--- a/client/src/components/pages/Store/Cart/__tests__/SearchProducts.test.jsx
+++ b/client/src/components/pages/Store/Cart/__tests__/SearchProducts.test.jsx
@@ -135,4 +135,34 @@ describe("SearchProducts", () => {
     fireEvent.click(screen.getByText("search.filterAll"));
     expect(screen.getByTestId("product-list").textContent).toContain("Jade Wallet");
   });
+
+  it("updates the selected category filter button", () => {
+    render(
+      <SearchProducts
+        products={products}
+        categories={categories}
+        onAddProduct={jest.fn()}
+      />,
+    );
+
+    const allFilterButton = screen.getByRole("button", { name: "search.filterAll" });
+    const hardwareFilterButton = screen.getByRole("button", { name: "Hardware" });
+    const gadgetsFilterButton = screen.getByRole("button", { name: "Gadgets" });
+
+    expect(allFilterButton).toHaveAttribute("aria-pressed", "true");
+    expect(hardwareFilterButton).toHaveAttribute("aria-pressed", "false");
+    expect(gadgetsFilterButton).toHaveAttribute("aria-pressed", "false");
+
+    fireEvent.click(hardwareFilterButton);
+
+    expect(allFilterButton).toHaveAttribute("aria-pressed", "false");
+    expect(hardwareFilterButton).toHaveAttribute("aria-pressed", "true");
+    expect(gadgetsFilterButton).toHaveAttribute("aria-pressed", "false");
+
+    fireEvent.click(allFilterButton);
+
+    expect(allFilterButton).toHaveAttribute("aria-pressed", "true");
+    expect(hardwareFilterButton).toHaveAttribute("aria-pressed", "false");
+    expect(gadgetsFilterButton).toHaveAttribute("aria-pressed", "false");
+  });
 });


### PR DESCRIPTION
  ## Summary

  Fixes the cart/sales product category filter so the active pill reflects the selected category instead of always showing “All” as active.

  ## Changes

  - Updates the “All” filter button to show active styling only when no category filter is selected.
  - Updates category filter buttons to show active styling when their category is selected.
  - Adds `aria-pressed` to the filter buttons so the selected state is reflected in the DOM.
  - Cleans up touched callback variable names in `SearchProducts.jsx`.

  ## Testing

  - Added regression coverage for the category filter selected state.
  - Verified that selecting a category moves the active state from “All” to that category.
  - Verified that selecting “All” restores the active state to “All”.

<img width="702" height="562" alt="Screenshot From 2026-08-07 09-38-45" src="https://github.com/user-attachments/assets/dc164568-2ba7-4390-9c2c-404eca97ab41" />

<img width="303" height="577" alt="Screenshot From 2026-08-07 09-39-01" src="https://github.com/user-attachments/assets/fa213a61-6ed3-4fe9-866f-cfe5db93f483" />

<img width="303" height="577" alt="Screenshot From 2026-08-07 09-39-07" src="https://github.com/user-attachments/assets/85035e38-4b77-46b6-a638-f68189e361df" />

CI note: the Electron npm audit failure is unrelated to this PR. This branch only changes the Store cart category filter UI snd its focused test. The audit failure comes from existing Electron/js-yaml dependency advisories and should be handled in a separate dependency PR.