### PR TITLE
Feature/daily sales report

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -14809,9 +14809,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "funding": [
         {
           "type": "github",

--- a/client/src/components/pages/Store/Reports/Filters/PeriodFilter.jsx
+++ b/client/src/components/pages/Store/Reports/Filters/PeriodFilter.jsx
@@ -7,7 +7,7 @@ import { useTranslations } from "next-intl";
 
 import { useDateRangeFilters } from "../hooks/useFilters";
 
-const PERIODS = ["week", "month", "year"];
+const PERIODS = ["day", "week", "month", "year"];
 
 export function PeriodFilter({ filters, onFiltersChange, disabled }) {
   const reportsTranslations = useTranslations("reports");
@@ -53,7 +53,7 @@ export function PeriodFilter({ filters, onFiltersChange, disabled }) {
             <p className="text-xs text-default-500">{reportsTranslations("dates.subtitle")}</p>
           </div>
 
-          <div className="grid grid-cols-3 gap-2">
+          <div className="grid grid-cols-4 gap-2">
             {PERIODS.map((period) => (
               <Button
                 key={period}

--- a/client/src/components/pages/Store/Reports/Filters/__tests__/PeriodFilter.test.jsx
+++ b/client/src/components/pages/Store/Reports/Filters/__tests__/PeriodFilter.test.jsx
@@ -73,6 +73,11 @@ describe("PeriodFilter", () => {
     buttons.forEach((button) => expect(button).toBeDisabled());
   });
 
+  it("renders the day period button", () => {
+    render(<PeriodFilter filters={DEFAULT_FILTERS} onFiltersChange={onFiltersChange} />);
+    expect(screen.getByText("dates.period.day")).toBeInTheDocument();
+  });
+
   it("shows custom date range as label when no activePeriod", () => {
     render(
       <PeriodFilter

--- a/client/src/components/pages/Store/Reports/hooks/__tests__/useFilters.test.js
+++ b/client/src/components/pages/Store/Reports/hooks/__tests__/useFilters.test.js
@@ -1,3 +1,4 @@
+import { getLocalTimeZone, startOfMonth, startOfWeek, startOfYear, today } from "@internationalized/date";
 import { act, renderHook } from "@testing-library/react";
 
 import { defaultFilters, useDateRangeFilters, useFiltersState } from "../useFilters";
@@ -24,29 +25,37 @@ describe("useFiltersState", () => {
     expect(filtersStateHook.current.filters).toEqual(defaultFilters);
   });
 
-  it("auto-fetches with default period on mount", async () => {
+  it("auto-fetches the computed date range for the default period on mount", async () => {
     renderHook(() => useFiltersState(mockFetch));
     await act(async () => {});
-    expect(mockFetch).toHaveBeenCalledWith(
-      expect.objectContaining({ period: defaultFilters.activePeriod }),
-    );
+    const endDate = today(getLocalTimeZone());
+    const startDate = startOfMonth(endDate);
+    expect(mockFetch).toHaveBeenCalledWith({
+      startDate: startDate.toString(),
+      endDate: endDate.toString(),
+      utcOffsetMinutes: expect.any(Number),
+    });
   });
 
-  it("handleFilters with activePeriod fetches immediately", async () => {
+  it("handleFilters with activePeriod and computed dates fetches immediately", async () => {
     const { result: filtersStateHook } = await setupHook();
 
     await act(async () => {
-      filtersStateHook.current.handleFilters({ activePeriod: "week", startDate: "", endDate: "" });
+      filtersStateHook.current.handleFilters({ activePeriod: "week", startDate: "2026-08-03", endDate: "2026-08-07" });
     });
 
-    expect(mockFetch).toHaveBeenCalledWith(expect.objectContaining({ period: "week" }));
+    expect(mockFetch).toHaveBeenCalledWith({
+      startDate: "2026-08-03",
+      endDate: "2026-08-07",
+      utcOffsetMinutes: expect.any(Number),
+    });
   });
 
   it("handleFilters with activePeriod updates filters state", async () => {
     const { result: filtersStateHook } = await setupHook();
 
     await act(async () => {
-      filtersStateHook.current.handleFilters({ activePeriod: "year", startDate: "", endDate: "" });
+      filtersStateHook.current.handleFilters({ activePeriod: "year", startDate: "2026-01-01", endDate: "2026-08-07" });
     });
 
     expect(filtersStateHook.current.filters.activePeriod).toBe("year");
@@ -91,7 +100,7 @@ describe("useFiltersState", () => {
     const { result: filtersStateHook } = await setupHook();
 
     await act(async () => {
-      filtersStateHook.current.handleFilters({ activePeriod: "year", startDate: "", endDate: "" });
+      filtersStateHook.current.handleFilters({ activePeriod: "year", startDate: "2026-01-01", endDate: "2026-08-07" });
     });
     jest.clearAllMocks();
 
@@ -99,7 +108,11 @@ describe("useFiltersState", () => {
       filtersStateHook.current.refetch();
     });
 
-    expect(mockFetch).toHaveBeenCalledWith(expect.objectContaining({ period: "year" }));
+    expect(mockFetch).toHaveBeenCalledWith({
+      startDate: "2026-01-01",
+      endDate: "2026-08-07",
+      utcOffsetMinutes: expect.any(Number),
+    });
   });
 });
 
@@ -118,11 +131,52 @@ describe("useDateRangeFilters", () => {
     expect(dateRangeFiltersHook.current.dateRangeValue.end.toString()).toBe("2024-01-31");
   });
 
-  it("handlePeriodChange calls onFiltersChange with period and clears dates", () => {
+  it("handlePeriodChange calls onFiltersChange with activePeriod and the computed date range", () => {
     const onFiltersChange = jest.fn();
     const { result: dateRangeFiltersHook } = renderHook(() => useDateRangeFilters(baseFilters, onFiltersChange));
+    const endDate = today(getLocalTimeZone());
+    const startDate = startOfWeek(endDate, "en-US", "mon");
+
     dateRangeFiltersHook.current.handlePeriodChange("week");
-    expect(onFiltersChange).toHaveBeenCalledWith({ activePeriod: "week", startDate: "", endDate: "" });
+
+    expect(onFiltersChange).toHaveBeenCalledWith({
+      activePeriod: "week",
+      startDate: startDate.toString(),
+      endDate: endDate.toString(),
+    });
+  });
+
+  it("handlePeriodChange with 'year' computes a range from the first day of the current year", () => {
+    const onFiltersChange = jest.fn();
+    const { result: dateRangeFiltersHook } = renderHook(() => useDateRangeFilters(baseFilters, onFiltersChange));
+    const endDate = today(getLocalTimeZone());
+    const startDate = startOfYear(endDate);
+
+    dateRangeFiltersHook.current.handlePeriodChange("year");
+
+    expect(onFiltersChange).toHaveBeenCalledWith({
+      activePeriod: "year",
+      startDate: startDate.toString(),
+      endDate: endDate.toString(),
+    });
+  });
+
+  it("handlePeriodChange with 'day' computes a range where start equals end", () => {
+    const onFiltersChange = jest.fn();
+    const { result: dateRangeFiltersHook } = renderHook(() => useDateRangeFilters(baseFilters, onFiltersChange));
+    const todayDate = today(getLocalTimeZone()).toString();
+
+    dateRangeFiltersHook.current.handlePeriodChange("day");
+
+    expect(onFiltersChange).toHaveBeenCalledWith({ activePeriod: "day", startDate: todayDate, endDate: todayDate });
+  });
+
+  it("dateRangeValue is null when activePeriod is set, even with dates present", () => {
+    const { result: dateRangeFiltersHook } = renderHook(() => useDateRangeFilters(
+      { ...baseFilters, activePeriod: "month", startDate: "2024-01-01", endDate: "2024-01-31" },
+      jest.fn(),
+    ));
+    expect(dateRangeFiltersHook.current.dateRangeValue).toBeNull();
   });
 
   it("handleDateRangeChange with a range calls onFiltersChange with stringified dates", () => {

--- a/client/src/components/pages/Store/Reports/hooks/__tests__/useReports.test.js
+++ b/client/src/components/pages/Store/Reports/hooks/__tests__/useReports.test.js
@@ -37,136 +37,136 @@ describe("useReports — fetch", () => {
   });
 
   it("exposes fetchReport as a function", async () => {
-    const { result } = renderHook(() => useReports());
+    const { result: reportsHook } = renderHook(() => useReports());
     await act(async () => {});
-    expect(typeof result.current.fetchReport).toBe("function");
+    expect(typeof reportsHook.current.fetchReport).toBe("function");
   });
 
   it("loading=false and error=null after initial auto-fetch completes", async () => {
-    const { result } = renderHook(() => useReports());
+    const { result: reportsHook } = renderHook(() => useReports());
     await act(async () => {});
-    expect(result.current.loading).toBe(false);
-    expect(result.current.error).toBeNull();
+    expect(reportsHook.current.loading).toBe(false);
+    expect(reportsHook.current.error).toBeNull();
   });
 
   it("loading=true during explicit fetch and false when done", async () => {
     let resolveHttp;
-    const { result } = await setupHook();
+    const { result: reportsHook } = await setupHook();
     httpClient.mockReturnValueOnce(new Promise((r) => { resolveHttp = r; }));
     parseJsonResponse.mockResolvedValue(successReport);
 
     act(() => {
-      result.current.fetchReport({ period: "month" });
+      reportsHook.current.fetchReport({ period: "month" });
     });
 
-    expect(result.current.loading).toBe(true);
+    expect(reportsHook.current.loading).toBe(true);
 
     await act(async () => {
       resolveHttp({});
     });
 
-    expect(result.current.loading).toBe(false);
+    expect(reportsHook.current.loading).toBe(false);
   });
 
   it("error is set when fetchReport throws an exception", async () => {
-    const { result } = await setupHook();
+    const { result: reportsHook } = await setupHook();
     const networkError = new Error("Network error");
     httpClient.mockRejectedValueOnce(networkError);
 
     await act(async () => {
-      await result.current.fetchReport({ period: "month" }).catch(() => {});
+      await reportsHook.current.fetchReport({ period: "month" }).catch(() => {});
     });
 
-    expect(result.current.error).toBe(networkError);
-    expect(result.current.loading).toBe(false);
+    expect(reportsHook.current.error).toBe(networkError);
+    expect(reportsHook.current.loading).toBe(false);
   });
 
   it("error is cleared when a new successful fetch starts", async () => {
-    const { result } = await setupHook();
+    const { result: reportsHook } = await setupHook();
     httpClient.mockRejectedValueOnce(new Error("fail"));
 
     await act(async () => {
-      await result.current.fetchReport({ period: "month" }).catch(() => {});
+      await reportsHook.current.fetchReport({ period: "month" }).catch(() => {});
     });
-    expect(result.current.error).not.toBeNull();
+    expect(reportsHook.current.error).not.toBeNull();
 
     httpClient.mockResolvedValueOnce({});
     await act(async () => {
-      await result.current.fetchReport({ period: "week" });
+      await reportsHook.current.fetchReport({ period: "week" });
     });
-    expect(result.current.error).toBeNull();
+    expect(reportsHook.current.error).toBeNull();
   });
 
   it("fetchReport re-throws the error for the caller to handle", async () => {
-    const { result } = await setupHook();
+    const { result: reportsHook } = await setupHook();
     httpClient.mockRejectedValueOnce(new Error("fail"));
 
     await expect(
-      act(async () => result.current.fetchReport({ period: "month" })),
+      act(async () => reportsHook.current.fetchReport({ period: "month" })),
     ).rejects.toThrow("fail");
   });
 
   it("reportData is set with the server response after a successful fetch", async () => {
-    const { result } = await setupHook();
+    const { result: reportsHook } = await setupHook();
     const mockReport = { totalRevenueCents: 5000, totalItemsSold: 3, sales: [] };
     parseJsonResponse.mockResolvedValueOnce(mockReport);
 
     await act(async () => {
-      await result.current.fetchReport({ period: "month" });
+      await reportsHook.current.fetchReport({ period: "month" });
     });
 
-    expect(result.current.reportData).toEqual(mockReport);
+    expect(reportsHook.current.reportData).toEqual(mockReport);
   });
 
   it("fetchReport returns the same value it stores in reportData", async () => {
-    const { result } = await setupHook();
+    const { result: reportsHook } = await setupHook();
     const mockReport = { totalRevenueCents: 5000, totalItemsSold: 3, sales: [] };
     parseJsonResponse.mockResolvedValueOnce(mockReport);
     let returned;
 
     await act(async () => {
-      returned = await result.current.fetchReport({ period: "month" });
+      returned = await reportsHook.current.fetchReport({ period: "month" });
     });
 
     expect(returned).toEqual(mockReport);
-    expect(result.current.reportData).toEqual(mockReport);
+    expect(reportsHook.current.reportData).toEqual(mockReport);
   });
 
   it("fetchReport with period sends ?period=month", async () => {
-    const { result } = await setupHook();
+    const { result: reportsHook } = await setupHook();
 
     await act(async () => {
-      await result.current.fetchReport({ period: "month" });
+      await reportsHook.current.fetchReport({ period: "month" });
     });
 
     expect(httpClient).toHaveBeenCalledWith("/reports?period=month");
   });
 
   it("fetchReport with period=week sends ?period=week", async () => {
-    const { result } = await setupHook();
+    const { result: reportsHook } = await setupHook();
 
     await act(async () => {
-      await result.current.fetchReport({ period: "week" });
+      await reportsHook.current.fetchReport({ period: "week" });
     });
 
     expect(httpClient).toHaveBeenCalledWith("/reports?period=week");
   });
 
   it("fetchReport with period=year sends ?period=year", async () => {
-    const { result } = await setupHook();
+    const { result: reportsHook } = await setupHook();
 
     await act(async () => {
-      await result.current.fetchReport({ period: "year" });
+      await reportsHook.current.fetchReport({ period: "year" });
     });
 
     expect(httpClient).toHaveBeenCalledWith("/reports?period=year");
   });
 
   it("fetchReport with startDate and endDate includes both in the URL", async () => {
-    const { result } = await setupHook();
+    const { result: reportsHook } = await setupHook();
 
     await act(async () => {
-      await result.current.fetchReport({ startDate: "2024-01-01", endDate: "2024-01-31" });
+      await reportsHook.current.fetchReport({ startDate: "2024-01-01", endDate: "2024-01-31" });
     });
 
     const url = httpClient.mock.calls[0][0];
@@ -175,50 +175,50 @@ describe("useReports — fetch", () => {
   });
 
   it("fetchReport with no parameters calls /reports without query string", async () => {
-    const { result } = await setupHook();
+    const { result: reportsHook } = await setupHook();
 
     await act(async () => {
-      await result.current.fetchReport({});
+      await reportsHook.current.fetchReport({});
     });
 
     expect(httpClient).toHaveBeenCalledWith("/reports");
   });
 
   it("fetchReport with no arguments calls /reports without query string", async () => {
-    const { result } = await setupHook();
+    const { result: reportsHook } = await setupHook();
 
     await act(async () => {
-      await result.current.fetchReport();
+      await reportsHook.current.fetchReport();
     });
 
     expect(httpClient).toHaveBeenCalledWith("/reports");
   });
 
   it("fetchReport with empty productName does not include it in the URL", async () => {
-    const { result } = await setupHook();
+    const { result: reportsHook } = await setupHook();
 
     await act(async () => {
-      await result.current.fetchReport({ productName: "   " });
+      await reportsHook.current.fetchReport({ productName: "   " });
     });
 
     expect(httpClient).toHaveBeenCalledWith("/reports");
   });
 
   it("fetchReport with empty paymentMethod does not include it in the URL", async () => {
-    const { result } = await setupHook();
+    const { result: reportsHook } = await setupHook();
 
     await act(async () => {
-      await result.current.fetchReport({ paymentMethod: "" });
+      await reportsHook.current.fetchReport({ paymentMethod: "" });
     });
 
     expect(httpClient).toHaveBeenCalledWith("/reports");
   });
 
   it("fetchReport with multiple filters builds the URL correctly", async () => {
-    const { result } = await setupHook();
+    const { result: reportsHook } = await setupHook();
 
     await act(async () => {
-      await result.current.fetchReport({
+      await reportsHook.current.fetchReport({
         period: "month",
         startDate: "2024-01-01",
         endDate: "2024-01-31",
@@ -231,11 +231,31 @@ describe("useReports — fetch", () => {
     expect(url).toContain("endDate=2024-01-31");
   });
 
-  it("GAP: fetchReport does not send userId even though the server supports it", async () => {
-    const { result } = await setupHook();
+  it("fetchReport with utcOffsetMinutes includes it in the URL", async () => {
+    const { result: reportsHook } = await setupHook();
 
     await act(async () => {
-      await result.current.fetchReport({ period: "month" });
+      await reportsHook.current.fetchReport({ startDate: "2024-01-01", endDate: "2024-01-31", utcOffsetMinutes: 360 });
+    });
+
+    expect(httpClient).toHaveBeenCalledWith("/reports?startDate=2024-01-01&endDate=2024-01-31&utcOffsetMinutes=360");
+  });
+
+  it("fetchReport with utcOffsetMinutes=0 still includes it in the URL", async () => {
+    const { result: reportsHook } = await setupHook();
+
+    await act(async () => {
+      await reportsHook.current.fetchReport({ startDate: "2024-01-01", endDate: "2024-01-31", utcOffsetMinutes: 0 });
+    });
+
+    expect(httpClient).toHaveBeenCalledWith("/reports?startDate=2024-01-01&endDate=2024-01-31&utcOffsetMinutes=0");
+  });
+
+  it("GAP: fetchReport does not send userId even though the server supports it", async () => {
+    const { result: reportsHook } = await setupHook();
+
+    await act(async () => {
+      await reportsHook.current.fetchReport({ period: "month" });
     });
 
     const url = httpClient.mock.calls[0][0];

--- a/client/src/components/pages/Store/Reports/hooks/useFilters.js
+++ b/client/src/components/pages/Store/Reports/hooks/useFilters.js
@@ -1,7 +1,7 @@
 "use client";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-import { parseDate } from "@internationalized/date";
+import { getLocalTimeZone, parseDate, startOfMonth, startOfWeek, startOfYear, today } from "@internationalized/date";
 
 export const defaultFilters = {
   activePeriod: "month",
@@ -9,13 +9,28 @@ export const defaultFilters = {
   endDate: "",
 };
 
+function getUtcOffsetMinutes() {
+  return new Date().getTimezoneOffset();
+}
+
+function resolvePeriodRange(period) {
+  const endDate = today(getLocalTimeZone());
+  const startDateByPeriod = {
+    day: endDate,
+    week: startOfWeek(endDate, "en-US", "mon"),
+    month: startOfMonth(endDate),
+    year: startOfYear(endDate),
+  };
+  return { startDate: startDateByPeriod[period].toString(), endDate: endDate.toString() };
+}
+
 export function useDateRangeFilters(filters, onFiltersChange) {
   const dateRangeValue = useMemo(() => {
-    if (!filters.startDate || !filters.endDate) return null;
+    if (filters.activePeriod || !filters.startDate || !filters.endDate) return null;
     return { start: parseDate(filters.startDate), end: parseDate(filters.endDate) };
-  }, [filters.startDate, filters.endDate]);
+  }, [filters.activePeriod, filters.startDate, filters.endDate]);
 
-  const handlePeriodChange = (period) => onFiltersChange({ activePeriod: period, startDate: "", endDate: "" });
+  const handlePeriodChange = (period) => onFiltersChange({ activePeriod: period, ...resolvePeriodRange(period) });
 
   const handleDateRangeChange = (range) => onFiltersChange({
     startDate: range?.start?.toString() ?? "",
@@ -33,7 +48,7 @@ export function useFiltersState(fetchReport) {
   useEffect(() => { latestFiltersRef.current = filters; }, [filters]);
 
   useEffect(() => {
-    fetchReport({ period: defaultFilters.activePeriod });
+    fetchReport({ ...resolvePeriodRange(defaultFilters.activePeriod), utcOffsetMinutes: getUtcOffsetMinutes() });
   }, [fetchReport]);
 
   const handleFiltersChange = useCallback(
@@ -42,24 +57,23 @@ export function useFiltersState(fetchReport) {
       const next = { ...prev, ...patch };
       setFilters(next);
 
-      if ("activePeriod" in patch && patch.activePeriod) {
-        return fetchReport({ period: next.activePeriod });
-      }
-
-      if ("startDate" in patch || "endDate" in patch) {
-        if (!next.startDate || !next.endDate) return;
-        return fetchReport({ startDate: next.startDate, endDate: next.endDate });
-      }
+      if (!next.startDate || !next.endDate) return;
+      return fetchReport({
+        startDate: next.startDate,
+        endDate: next.endDate,
+        utcOffsetMinutes: getUtcOffsetMinutes(),
+      });
     },
     [fetchReport],
   );
 
   const refetch = useCallback(() => {
     const snapshotFilters = latestFiltersRef.current;
-    fetchReport({
-      period: snapshotFilters.activePeriod || undefined,
-      startDate: snapshotFilters.activePeriod ? undefined : snapshotFilters.startDate || undefined,
-      endDate: snapshotFilters.activePeriod ? undefined : snapshotFilters.endDate || undefined,
+    if (!snapshotFilters.startDate || !snapshotFilters.endDate) return;
+    return fetchReport({
+      startDate: snapshotFilters.startDate,
+      endDate: snapshotFilters.endDate,
+      utcOffsetMinutes: getUtcOffsetMinutes(),
     });
   }, [fetchReport]);
 

--- a/client/src/components/pages/Store/Reports/hooks/useReports.js
+++ b/client/src/components/pages/Store/Reports/hooks/useReports.js
@@ -8,6 +8,9 @@ function buildReportsQueryString(filters = {}) {
   if (filters.period) params.set("period", filters.period);
   if (filters.startDate) params.set("startDate", filters.startDate);
   if (filters.endDate) params.set("endDate", filters.endDate);
+  if (typeof filters.utcOffsetMinutes === "number") {
+    params.set("utcOffsetMinutes", String(filters.utcOffsetMinutes));
+  }
   const query = params.toString();
   return `/reports${query ? `?${query}` : ""}`;
 }

--- a/client/src/components/pages/Store/Reports/locales/en.js
+++ b/client/src/components/pages/Store/Reports/locales/en.js
@@ -8,6 +8,7 @@ const reportsEn = {
       title: "Select Period",
       subtitle: "Filter and analyze your sales by period and product",
       period: {
+        day: "Today",
         week: "This Week",
         month: "This Month",
         year: "This Year",

--- a/client/src/components/pages/Store/Reports/locales/es.js
+++ b/client/src/components/pages/Store/Reports/locales/es.js
@@ -8,6 +8,7 @@ const reportsEs = {
       title: "Seleccionar Período",
       subtitle: "Filtra y analiza tus ventas por período y producto",
       period: {
+        day: "Hoy",
         week: "Esta Semana",
         month: "Este Mes",
         year: "Este Año",

--- a/server/app/src/main/kotlin/pos/ambrosia/api/Reports.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/api/Reports.kt
@@ -48,6 +48,7 @@ fun Route.reports(reportService: ReportService) {
             val productName = call.request.queryParameters["productName"]?.takeIf { it.isNotBlank() }
             val userId = call.request.queryParameters["userId"]?.takeIf { it.isNotBlank() }
             val paymentMethod = call.request.queryParameters["paymentMethod"]?.takeIf { it.isNotBlank() }
+            val utcOffsetMinutes = call.request.queryParameters["utcOffsetMinutes"]?.toIntOrNull()
 
             val startDate: String?
             val endDate: String?
@@ -77,6 +78,7 @@ fun Route.reports(reportService: ReportService) {
                         productName = productName,
                         userId = userId,
                         paymentMethod = paymentMethod,
+                        utcOffsetMinutes = utcOffsetMinutes,
                     )
                 } catch (exception: IllegalArgumentException) {
                     call.respond(HttpStatusCode.BadRequest, Message(exception.message ?: "Invalid query parameters"))

--- a/server/app/src/main/kotlin/pos/ambrosia/services/ReportService.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/services/ReportService.kt
@@ -10,6 +10,7 @@ import org.jetbrains.exposed.v1.core.dao.id.EntityID
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.core.greaterEq
 import org.jetbrains.exposed.v1.core.inList
+import org.jetbrains.exposed.v1.core.less
 import org.jetbrains.exposed.v1.core.lessEq
 import org.jetbrains.exposed.v1.core.like
 import org.jetbrains.exposed.v1.jdbc.andWhere
@@ -189,6 +190,29 @@ class ReportService {
         return null
     }
 
+    private fun resolveDateTimeRange(
+        startDate: String?,
+        endDate: String?,
+        utcOffsetMinutes: Int?,
+    ): Pair<String, String>? {
+        if (startDate == null || endDate == null || utcOffsetMinutes == null) return null
+        val localZoneOffset = ZoneOffset.ofTotalSeconds(-utcOffsetMinutes * 60)
+        val start =
+            LocalDate
+                .parse(startDate)
+                .atStartOfDay(localZoneOffset)
+                .withZoneSameInstant(ZoneOffset.UTC)
+                .toLocalDateTime()
+        val end =
+            LocalDate
+                .parse(endDate)
+                .plusDays(1)
+                .atStartOfDay(localZoneOffset)
+                .withZoneSameInstant(ZoneOffset.UTC)
+                .toLocalDateTime()
+        return Pair(start.toString(), end.toString())
+    }
+
     private fun validateOrdersWithPaymentFilters(filters: OrderWithPaymentFilters) {
         filters.status?.let { status ->
             if (!isValidStatus(status)) {
@@ -220,9 +244,11 @@ class ReportService {
         productName: String?,
         userId: String?,
         paymentMethod: String?,
+        utcOffsetMinutes: Int? = null,
     ): ProductSalesReport =
         transaction {
             val dateRange = resolveDateRange(period, startDate, endDate)
+            val preciseDateRange = resolveDateTimeRange(startDate, endDate, utcOffsetMinutes)
 
             val join =
                 OrderProductsTable
@@ -239,9 +265,15 @@ class ReportService {
                     .selectAll()
                     .where { (OrdersTable.status inList listOf("paid", "refunded")) and (OrdersTable.isDeleted eq false) }
 
-            dateRange?.let { (start, end) ->
-                query = query.andWhere { dateFunc(OrdersTable.createdAt) greaterEq start }
-                query = query.andWhere { dateFunc(OrdersTable.createdAt) lessEq end }
+            if (preciseDateRange != null) {
+                val (start, end) = preciseDateRange
+                query = query.andWhere { OrdersTable.createdAt greaterEq start }
+                query = query.andWhere { OrdersTable.createdAt less end }
+            } else {
+                dateRange?.let { (start, end) ->
+                    query = query.andWhere { dateFunc(OrdersTable.createdAt) greaterEq start }
+                    query = query.andWhere { dateFunc(OrdersTable.createdAt) lessEq end }
+                }
             }
             productName?.let { name ->
                 query = query.andWhere { ProductsTable.name like "%$name%" }
@@ -285,7 +317,7 @@ class ReportService {
                     .sumOf { it.satoshiAmount!! }
 
             val (totalRefundedCents, totalRefundedSatoshis, refundCount) =
-                getRefundTotals(dateRange, productName, userId, paymentMethod)
+                getRefundTotals(dateRange, preciseDateRange, productName, userId, paymentMethod)
 
             ProductSalesReport(
                 totalRevenueCents = sales.sumOf { it.priceAtOrder.toLong() * it.quantity },
@@ -306,6 +338,7 @@ class ReportService {
 
     private fun getRefundTotals(
         dateRange: Pair<String, String>?,
+        preciseDateRange: Pair<String, String>?,
         productName: String?,
         userId: String?,
         paymentMethod: String?,
@@ -321,9 +354,15 @@ class ReportService {
                 .join(PaymentMethodsTable, JoinType.INNER, PaymentMethodsTable.id, PaymentsTable.methodId)
 
         var query = join.selectAll()
-        dateRange?.let { (start, end) ->
-            query = query.andWhere { dateFunc(RefundsTable.refundedAt) greaterEq start }
-            query = query.andWhere { dateFunc(RefundsTable.refundedAt) lessEq end }
+        if (preciseDateRange != null) {
+            val (start, end) = preciseDateRange
+            query = query.andWhere { RefundsTable.refundedAt greaterEq start }
+            query = query.andWhere { RefundsTable.refundedAt less end }
+        } else {
+            dateRange?.let { (start, end) ->
+                query = query.andWhere { dateFunc(RefundsTable.refundedAt) greaterEq start }
+                query = query.andWhere { dateFunc(RefundsTable.refundedAt) lessEq end }
+            }
         }
         productName?.let { name -> query = query.andWhere { ProductsTable.name like "%$name%" } }
         userId?.let { uid -> query = query.andWhere { OrdersTable.userId eq EntityID(UUID.fromString(uid), UsersTable) } }

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/ReportServiceTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/ReportServiceTest.kt
@@ -221,6 +221,84 @@ class ReportServiceTest {
     }
 
     @Test
+    fun `utcOffsetMinutes includes an order whose UTC created_at date is the next local day`() {
+        val sale = seedSale(createdAt = "2024-06-16T04:00:00")
+        addOrderProduct(sale.orderId)
+
+        val report =
+            service.getProductSalesReport(
+                period = null,
+                startDate = "2024-06-15",
+                endDate = "2024-06-15",
+                productName = null,
+                userId = null,
+                paymentMethod = null,
+                utcOffsetMinutes = 360,
+            )
+
+        assertEquals(1, report.sales.size)
+        assertEquals(sale.orderId, report.sales[0].orderId)
+    }
+
+    @Test
+    fun `utcOffsetMinutes excludes an order that falls just outside the local day boundary`() {
+        val sale = seedSale(createdAt = "2024-06-16T06:00:01")
+        addOrderProduct(sale.orderId)
+
+        val report =
+            service.getProductSalesReport(
+                period = null,
+                startDate = "2024-06-15",
+                endDate = "2024-06-15",
+                productName = null,
+                userId = null,
+                paymentMethod = null,
+                utcOffsetMinutes = 360,
+            )
+
+        assertTrue(report.sales.isEmpty())
+    }
+
+    @Test
+    fun `without utcOffsetMinutes, an order just after local midnight is still excluded by date-only comparison`() {
+        val sale = seedSale(createdAt = "2024-06-16T04:00:00")
+        addOrderProduct(sale.orderId)
+
+        val report =
+            service.getProductSalesReport(
+                period = null,
+                startDate = "2024-06-15",
+                endDate = "2024-06-15",
+                productName = null,
+                userId = null,
+                paymentMethod = null,
+            )
+
+        assertTrue(report.sales.isEmpty())
+    }
+
+    @Test
+    fun `utcOffsetMinutes includes a refund whose UTC refunded_at date is the next local day`() {
+        val sale = seedSale(orderStatus = "refunded", total = 30.0, createdAt = "2024-06-15T12:00:00")
+        addOrderProduct(sale.orderId, quantity = 1, priceAtOrder = 3000)
+        ExposedTestDb.seedRefund(sale.orderId, refundedAt = "2024-06-16T04:00:00")
+
+        val report =
+            service.getProductSalesReport(
+                period = null,
+                startDate = "2024-06-15",
+                endDate = "2024-06-15",
+                productName = null,
+                userId = null,
+                paymentMethod = null,
+                utcOffsetMinutes = 360,
+            )
+
+        assertEquals(1, report.refundCount)
+        assertEquals(3000L, report.totalRefundedCents)
+    }
+
+    @Test
     fun `productName filters with case-insensitive LIKE`() {
         val widget = seedSale()
         addOrderProduct(widget.orderId, productName = "Widget")


### PR DESCRIPTION
## Changes:

- Add a "Daily" period option to the Reports date filter, computing date ranges for all periods (day/week/month/year) on the client instead of relying on server-side period resolution.
- Make Reports date-range comparisons timezone-aware: the client sends its UTC offset with every request, and the server compares against precise UTC instants instead of calendar dates, so orders placed late at night no longer disappear from "Today"/"This Week".

**Related Issues**:

https://github.com/olympus-btc/ambrosia/issues/645

**Screenshots**:

<img width="1822" height="424" alt="imagen" src="https://github.com/user-attachments/assets/b1209f0b-70bb-432e-b5c2-22949bc6746a" />

<img width="2538" height="630" alt="imagen" src="https://github.com/user-attachments/assets/88495475-d48b-4473-997e-5dc752a8c30b" />
