### PR TITLE
Fix(client): user auth admin escalation

### DIFF
--- a/client/src/components/pages/Store/Users/Roles/Roles.jsx
+++ b/client/src/components/pages/Store/Users/Roles/Roles.jsx
@@ -73,10 +73,15 @@ export function Roles({ roles, createRole, deleteRole, loading: loadingRoles, up
       setShowModal(false);
       addToast({ title: roleTranslations("roles.actions.createSuccess"), color: "success" });
     } catch (error) {
+      const adminRequired = error?.status === 403 && form.isAdmin;
       addToast({
-        title: error?.status === 409 ? roleTranslations("roles.actions.createConflictTitle") : roleTranslations("roles.actions.createErrorTitle"),
-        description: error?.status === 409 ? roleTranslations("roles.actions.createConflictDescription") : roleTranslations("roles.actions.createErrorDescription"),
-        color: error?.status === 409 ? "warning" : "danger",
+        title: adminRequired
+          ? roleTranslations("roles.actions.adminRequiredTitle")
+          : error?.status === 409 ? roleTranslations("roles.actions.createConflictTitle") : roleTranslations("roles.actions.createErrorTitle"),
+        description: adminRequired
+          ? roleTranslations("roles.actions.adminRequiredDescription")
+          : error?.status === 409 ? roleTranslations("roles.actions.createConflictDescription") : roleTranslations("roles.actions.createErrorDescription"),
+        color: adminRequired || error?.status === 409 ? "warning" : "danger",
       });
     } finally {
       creatingRef.current = false;
@@ -117,10 +122,15 @@ export function Roles({ roles, createRole, deleteRole, loading: loadingRoles, up
       setForm({ name: "", password: "", isAdmin: false, permissions: [] });
       addToast({ title: roleTranslations("roles.actions.saveSuccess"), color: "success" });
     } catch (error) {
+      const adminRequired = error?.status === 403 && form.isAdmin;
       addToast({
-        title: error?.status === 409 ? roleTranslations("roles.actions.lastAdminErrorTitle") : roleTranslations("roles.actions.saveErrorTitle"),
-        description: error?.status === 409 ? roleTranslations("roles.actions.lastAdminErrorDescription") : roleTranslations("roles.actions.saveErrorDescription"),
-        color: error?.status === 409 ? "warning" : "danger",
+        title: adminRequired
+          ? roleTranslations("roles.actions.adminRequiredTitle")
+          : error?.status === 409 ? roleTranslations("roles.actions.lastAdminErrorTitle") : roleTranslations("roles.actions.saveErrorTitle"),
+        description: adminRequired
+          ? roleTranslations("roles.actions.adminRequiredDescription")
+          : error?.status === 409 ? roleTranslations("roles.actions.lastAdminErrorDescription") : roleTranslations("roles.actions.saveErrorDescription"),
+        color: adminRequired || error?.status === 409 ? "warning" : "danger",
       });
     } finally {
       updatingRef.current = false;

--- a/client/src/components/pages/Store/Users/Roles/__tests__/Roles.test.jsx
+++ b/client/src/components/pages/Store/Users/Roles/__tests__/Roles.test.jsx
@@ -53,6 +53,9 @@ jest.mock("../CreateRoleModal", () => ({
         <button type="button" onClick={() => setForm((currentForm) => ({ ...currentForm, name: "cashier" }))}>
           set role name
         </button>
+        <button type="button" onClick={() => setForm((currentForm) => ({ ...currentForm, isAdmin: true }))}>
+          set admin role
+        </button>
         <button type="button" onClick={onSubmit}>
           roles.actions.create
         </button>
@@ -84,6 +87,9 @@ jest.mock("../EditRoleModal", () => ({
         <span data-testid="edit-role-name">{form.name}</span>
         <button type="button" onClick={() => setForm((currentForm) => ({ ...currentForm, name: "manager" }))}>
           set edit role name
+        </button>
+        <button type="button" onClick={() => setForm((currentForm) => ({ ...currentForm, isAdmin: true }))}>
+          set edit admin role
         </button>
         <button type="button" onClick={onSubmit}>
           roles.actions.save
@@ -189,6 +195,53 @@ describe("Roles", () => {
       color: "warning",
     });
     expect(screen.getByText("roles.create.title")).toBeInTheDocument();
+  });
+
+  it("shows admin-required feedback when admin role creation is forbidden", async () => {
+    const adminRequiredError = new Error("admin required");
+    adminRequiredError.status = 403;
+    const createRole = jest.fn(() => Promise.reject(adminRequiredError));
+
+    renderRoles({ createRole });
+
+    fireEvent.click(screen.getByText("roles.actions.new"));
+    fireEvent.click(screen.getByText("set role name"));
+    fireEvent.click(screen.getByText("set admin role"));
+    fireEvent.click(screen.getByText("roles.actions.create"));
+
+    await waitFor(() => expect(createRole).toHaveBeenCalledWith(expect.objectContaining({ isAdmin: true })));
+    expect(addToast).toHaveBeenCalledWith({
+      title: "roles.actions.adminRequiredTitle",
+      description: "roles.actions.adminRequiredDescription",
+      color: "warning",
+    });
+  });
+
+  it("shows admin-required feedback when admin role promotion is forbidden", async () => {
+    const adminRequiredError = new Error("admin required");
+    adminRequiredError.status = 403;
+    const updateRoleWithPermissions = jest.fn(() => Promise.reject(adminRequiredError));
+
+    renderRoles({
+      roles: [{ id: "role-id", role: "cashier", isAdmin: false }],
+      updateRoleWithPermissions,
+      getRolePermissions: jest.fn(() => Promise.resolve([])),
+    });
+
+    fireEvent.click(screen.getByText("edit role"));
+    await waitFor(() => expect(screen.getByText("roles.edit.title")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("set edit admin role"));
+    fireEvent.click(screen.getByText("roles.actions.save"));
+
+    await waitFor(() => expect(updateRoleWithPermissions).toHaveBeenCalledWith(
+      "role-id",
+      expect.objectContaining({ isAdmin: true }),
+    ));
+    expect(addToast).toHaveBeenCalledWith({
+      title: "roles.actions.adminRequiredTitle",
+      description: "roles.actions.adminRequiredDescription",
+      color: "warning",
+    });
   });
 
   it("does not create a role twice while creation is pending", async () => {

--- a/client/src/components/pages/Store/Users/Roles/locales/en.js
+++ b/client/src/components/pages/Store/Users/Roles/locales/en.js
@@ -18,6 +18,8 @@ const rolesEn = {
       saveSuccess: "Role updated successfully",
       saveErrorTitle: "Error",
       saveErrorDescription: "Could not update the role",
+      adminRequiredTitle: "Admin privileges required",
+      adminRequiredDescription: "Only an administrator can create or grant an admin role.",
       cancel: "Cancel",
       deleteConfirmTitle: "Delete role",
       deleteConfirmBody: "Are you sure you want to delete the role {name}? Users with this role will have no role assigned.",

--- a/client/src/components/pages/Store/Users/Roles/locales/es.js
+++ b/client/src/components/pages/Store/Users/Roles/locales/es.js
@@ -18,6 +18,8 @@ const rolesEs = {
       saveSuccess: "Rol actualizado correctamente",
       saveErrorTitle: "Error",
       saveErrorDescription: "No se pudo actualizar el rol",
+      adminRequiredTitle: "Se requieren privilegios de administrador",
+      adminRequiredDescription: "Solo un administrador puede crear u otorgar un rol de administrador.",
       cancel: "Cancelar",
       deleteConfirmTitle: "Eliminar rol",
       deleteConfirmBody: "¿Estás seguro de que quieres eliminar el rol {name}? Los usuarios con este rol quedarán sin rol asignado.",

--- a/client/src/components/pages/Store/Users/locales/en.js
+++ b/client/src/components/pages/Store/Users/locales/en.js
@@ -45,6 +45,8 @@ const usersEn = {
       duplicateNameDescription: "A user with that name already exists.",
       genericErrorTitle: "Error",
       genericErrorDescription: "Could not complete the operation.",
+      adminRequiredTitle: "Admin privileges required",
+      adminRequiredDescription: "Only an administrator can assign an admin role.",
       lastUserTitle: "Not allowed",
       lastUserDescription: "You cannot delete the only existing user.",
       lastAdminTitle: "Not allowed",

--- a/client/src/components/pages/Store/Users/locales/es.js
+++ b/client/src/components/pages/Store/Users/locales/es.js
@@ -45,6 +45,8 @@ const usersEs = {
       duplicateNameDescription: "Ya existe un usuario con ese nombre.",
       genericErrorTitle: "Error",
       genericErrorDescription: "No se pudo completar la operación.",
+      adminRequiredTitle: "Se requieren privilegios de administrador",
+      adminRequiredDescription: "Solo un administrador puede asignar un rol de administrador.",
       lastUserTitle: "No permitido",
       lastUserDescription: "No puedes eliminar el único usuario existente.",
       lastAdminTitle: "No permitido",

--- a/client/src/components/pages/Store/hooks/__tests__/useUsers.test.jsx
+++ b/client/src/components/pages/Store/hooks/__tests__/useUsers.test.jsx
@@ -262,4 +262,30 @@ describe("useUsers", () => {
       color: "danger",
     });
   });
+
+  it("shows admin-required toast when assigning an admin role is forbidden", async () => {
+    httpClient.mockResolvedValueOnce({ ok: true });
+    parseJsonResponse.mockResolvedValueOnce([{ id: 3, name: "Paula" }]);
+    httpClient.mockResolvedValueOnce({ ok: false, status: 403 });
+    parseJsonResponse.mockResolvedValueOnce({ message: "Admin privileges required" });
+
+    render(<TestComponent />);
+
+    await waitFor(() => expect(screen.getByTestId("count")).toHaveTextContent("1"));
+
+    await expect(handlers.updateUser({
+      userId: 3,
+      userName: "Paula",
+      userRole: "admin-role-id",
+      userEmail: "paula@example.com",
+      userPhone: "555-0202",
+      userPin: "",
+    })).rejects.toMatchObject({ status: 403 });
+
+    expect(addToast).toHaveBeenCalledWith({
+      title: "toasts.adminRequiredTitle",
+      description: "toasts.adminRequiredDescription",
+      color: "warning",
+    });
+  });
 });

--- a/client/src/components/pages/Store/hooks/useUsers.jsx
+++ b/client/src/components/pages/Store/hooks/useUsers.jsx
@@ -14,6 +14,10 @@ function isLastAdminConflict(requestError) {
   return requestError?.status === 409 && requestError?.responseMessage?.includes("last admin");
 }
 
+function isAdminPrivilegesRequired(requestError) {
+  return requestError?.status === 403 && requestError?.responseMessage === "Admin privileges required";
+}
+
 export function useUsers() {
   const usersTranslations = useTranslations("users");
   const { fetchList } = useFetchList();
@@ -26,6 +30,14 @@ export function useUsers() {
       title: usersTranslations("toasts.genericErrorTitle"),
       description: usersTranslations("toasts.genericErrorDescription"),
       color: "danger",
+    });
+  }, [usersTranslations]);
+
+  const showAdminRequiredToast = useCallback(() => {
+    addToast({
+      title: usersTranslations("toasts.adminRequiredTitle"),
+      description: usersTranslations("toasts.adminRequiredDescription"),
+      color: "warning",
     });
   }, [usersTranslations]);
 
@@ -86,6 +98,10 @@ export function useUsers() {
 
       return updatedUserData;
     } catch (requestError) {
+      if (isAdminPrivilegesRequired(requestError)) {
+        showAdminRequiredToast();
+        throw requestError;
+      }
       if (requestError?.status === 409) {
         showUserConflictToast(requestError, {
           title: usersTranslations("toasts.duplicateNameTitle"),
@@ -123,6 +139,10 @@ export function useUsers() {
       await fetchUsers();
       return createUserResponse;
     } catch (requestError) {
+      if (isAdminPrivilegesRequired(requestError)) {
+        showAdminRequiredToast();
+        throw requestError;
+      }
       if (requestError?.status === 409) {
         showUserConflictToast(requestError, {
           title: usersTranslations("toasts.duplicateNameTitle"),

--- a/server/app/src/main/kotlin/pos/ambrosia/api/Roles.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/api/Roles.kt
@@ -18,6 +18,7 @@ import pos.ambrosia.models.RolePermissionsUpdateResult
 import pos.ambrosia.services.PermissionsService
 import pos.ambrosia.services.RolesService
 import pos.ambrosia.utils.authorizePermission
+import pos.ambrosia.utils.requireAdmin
 
 fun Application.configureRoles() {
     val roleService = RolesService(environment)
@@ -74,6 +75,9 @@ fun Route.roles(
     authorizePermission("roles_create") {
         post("") {
             val user = call.receive<Role>()
+            if (user.isAdmin == true) {
+                call.requireAdmin()
+            }
             val id = roleService.addRole(user)
             if (id == null) {
                 call.respond(HttpStatusCode.BadRequest, "Invalid role data")
@@ -97,6 +101,9 @@ fun Route.roles(
             if (updatedRole.role.isBlank()) {
                 call.respond(HttpStatusCode.BadRequest, "Invalid role data")
                 return@put
+            }
+            if (updatedRole.isAdmin == true) {
+                call.requireAdmin()
             }
             val isUpdated = roleService.updateRole(id, updatedRole)
 

--- a/server/app/src/main/kotlin/pos/ambrosia/api/Users.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/api/Users.kt
@@ -21,6 +21,7 @@ import pos.ambrosia.services.PermissionsService
 import pos.ambrosia.services.TokenService
 import pos.ambrosia.services.UsersService
 import pos.ambrosia.utils.authorizePermission
+import pos.ambrosia.utils.requireAdmin
 
 fun Application.configureUsers() {
     val userService = UsersService(environment)
@@ -42,20 +43,22 @@ fun Route.users(
         }
         call.respond(HttpStatusCode.OK, users)
     }
-    get("/{id}") {
-        val id = call.parameters["id"]
-        if (id == null) {
-            call.respond(HttpStatusCode.BadRequest, "Missing or malformed ID")
-            return@get
-        }
+    authorizePermission("users_read") {
+        get("/{id}") {
+            val id = call.parameters["id"]
+            if (id == null) {
+                call.respond(HttpStatusCode.BadRequest, "Missing or malformed ID")
+                return@get
+            }
 
-        val user = userService.getUserById(id)
-        if (user == null) {
-            call.respond(HttpStatusCode.NotFound, "User not found")
-            return@get
-        }
+            val user = userService.getUserById(id)
+            if (user == null) {
+                call.respond(HttpStatusCode.NotFound, "User not found")
+                return@get
+            }
 
-        call.respond(HttpStatusCode.OK, user)
+            call.respond(HttpStatusCode.OK, user)
+        }
     }
 
     authenticate("auth-jwt") {
@@ -114,6 +117,9 @@ fun Route.users(
                 call.respond(HttpStatusCode.BadRequest, "Failed to add user, pin must be at least 4 characters long")
                 return@post
             }
+            if (user.role?.let(userService::isRoleAdmin) == true) {
+                call.requireAdmin()
+            }
             val result = userService.addUser(user)
             if (result == null) {
                 call.respond(HttpStatusCode.BadRequest, "Failed to add user")
@@ -152,6 +158,9 @@ fun Route.users(
             if (updatedUser.pin != null && updatedUser.pin.isNotBlank() && updatedUser.pin.length < 4) {
                 call.respond(HttpStatusCode.BadRequest, "Failed to update user, pin must be at least 4 characters long")
                 return@put
+            }
+            if (updatedUser.roleId?.let(userService::isRoleAdmin) == true) {
+                call.requireAdmin()
             }
 
             val isUpdated = userService.updateUser(id, updatedUser)

--- a/server/app/src/main/kotlin/pos/ambrosia/services/UsersService.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/services/UsersService.kt
@@ -125,13 +125,15 @@ class UsersService(
                 id = user.id.value.toString(),
                 name = user.name,
                 pin = "****",
-                refreshToken = user.refreshToken,
+                refreshToken = "****",
                 role = role?.role,
                 isAdmin = role?.isAdmin ?: false,
                 email = user.email,
                 phone = user.phone,
             )
         }
+
+    fun isRoleAdmin(roleId: String): Boolean = adminGuard.isRoleAdmin(roleId) == true
 
     fun updateUser(
         id: String?,

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/UserPrivilegeEscalationRouteTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/UserPrivilegeEscalationRouteTest.kt
@@ -1,0 +1,153 @@
+package pos.ambrosia.utest
+
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.put
+import io.ktor.client.request.setBody
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.install
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.testing.testApplication
+import org.junit.After
+import org.junit.Before
+import pos.ambrosia.api.configureRoles
+import pos.ambrosia.api.configureUsers
+import pos.ambrosia.api.handler
+import pos.ambrosia.services.PermissionsService
+import pos.ambrosia.utils.ExposedTestDb
+import pos.ambrosia.utils.installAdminAuth
+import pos.ambrosia.utils.installNonAdminAuth
+import pos.ambrosia.utils.withAuthCookies
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class UserPrivilegeEscalationRouteTest {
+    private lateinit var databaseFile: File
+
+    @Before
+    fun setUp() {
+        databaseFile = ExposedTestDb.connect()
+    }
+
+    @After
+    fun tearDown() {
+        ExposedTestDb.cleanup(databaseFile)
+    }
+
+    @Test
+    fun `user list remains public while user by id requires authentication`() =
+        testApplication {
+            installAdminAuth()
+            val targetRoleId = ExposedTestDb.seedRole("target-role")
+            val targetUserId = ExposedTestDb.seedUser("target-user", targetRoleId)
+            application {
+                install(ContentNegotiation) { json() }
+                handler()
+                configureUsers()
+            }
+
+            assertEquals(HttpStatusCode.OK, client.get("/users").status)
+            assertEquals(HttpStatusCode.Unauthorized, client.get("/users/$targetUserId").status)
+        }
+
+    @Test
+    fun `non admin with users update cannot assign an admin role`() =
+        testApplication {
+            val auth = installNonAdminAuth()
+            grantPermission("non-admin-test-role", "users_update")
+            val adminRoleId = ExposedTestDb.seedRole("target-admin-role", isAdmin = true)
+            val targetUserId = ExposedTestDb.seedUser("target-user", ExposedTestDb.seedRole("target-role"))
+            application {
+                install(ContentNegotiation) { json() }
+                handler()
+                configureUsers()
+            }
+
+            val response =
+                client.put("/users/$targetUserId") {
+                    withAuthCookies(auth)
+                    header(HttpHeaders.ContentType, "application/json")
+                    setBody("""{"roleId":"$adminRoleId"}""")
+                }
+
+            assertEquals(HttpStatusCode.Forbidden, response.status)
+        }
+
+    @Test
+    fun `non admin with roles update cannot promote a role to admin`() =
+        testApplication {
+            val auth = installNonAdminAuth()
+            grantPermission("non-admin-test-role", "roles_update")
+            val targetRoleId = ExposedTestDb.seedRole("target-role")
+            application {
+                install(ContentNegotiation) { json() }
+                handler()
+                configureRoles()
+            }
+
+            val response =
+                client.put("/roles/$targetRoleId") {
+                    withAuthCookies(auth)
+                    header(HttpHeaders.ContentType, "application/json")
+                    setBody("""{"role":"Promoted role","isAdmin":true}""")
+                }
+
+            assertEquals(HttpStatusCode.Forbidden, response.status)
+        }
+
+    @Test
+    fun `non admin with users create cannot create a user with an admin role`() =
+        testApplication {
+            val auth = installNonAdminAuth()
+            grantPermission("non-admin-test-role", "users_create")
+            val adminRoleId = ExposedTestDb.seedRole("target-admin-role", isAdmin = true)
+            application {
+                install(ContentNegotiation) { json() }
+                handler()
+                configureUsers()
+            }
+
+            val response =
+                client.post("/users") {
+                    withAuthCookies(auth)
+                    header(HttpHeaders.ContentType, "application/json")
+                    setBody("""{"name":"new-admin","pin":"1234","role":"$adminRoleId"}""")
+                }
+
+            assertEquals(HttpStatusCode.Forbidden, response.status)
+        }
+
+    @Test
+    fun `non admin with roles create cannot create an admin role`() =
+        testApplication {
+            val auth = installNonAdminAuth()
+            grantPermission("non-admin-test-role", "roles_create")
+            application {
+                install(ContentNegotiation) { json() }
+                handler()
+                configureRoles()
+            }
+
+            val response =
+                client.post("/roles") {
+                    withAuthCookies(auth)
+                    header(HttpHeaders.ContentType, "application/json")
+                    setBody("""{"role":"new-admin-role","isAdmin":true}""")
+                }
+
+            assertEquals(HttpStatusCode.Forbidden, response.status)
+        }
+
+    private fun grantPermission(
+        roleName: String,
+        permission: String,
+    ) {
+        val roleId = ExposedTestDb.seedRole(roleName)
+        ExposedTestDb.seedPermission(permission)
+        PermissionsService().replaceRolePermissions(roleId, listOf(permission))
+    }
+}

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/UsersServiceTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/UsersServiceTest.kt
@@ -11,7 +11,9 @@ import pos.ambrosia.utils.ExposedTestDb
 import pos.ambrosia.utils.LastAdminRemovalException
 import java.io.File
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 class UsersServiceTest {
@@ -65,6 +67,20 @@ class UsersServiceTest {
             val userId = ExposedTestDb.seedUser("cashier-user", roleId = cashierRoleId)
 
             assertTrue(service.deleteUser(userId))
+        }
+    }
+
+    @Test
+    fun `getUserById masks refresh token`() {
+        runBlocking {
+            val roleId = ExposedTestDb.seedRole("Cashier", isAdmin = false)
+            val userId = ExposedTestDb.seedUser("cashier-user", roleId = roleId)
+
+            val user = service.getUserById(userId)
+
+            assertNotNull(user)
+            assertEquals("****", user.pin)
+            assertEquals("****", user.refreshToken)
         }
     }
 }


### PR DESCRIPTION
## Problem

The user-management API exposed two critical privilege and session-token risks.

First, `GET /users/{id}` was publicly accessible and returned the user's stored `refreshToken`. An unauthenticated attacker could call the intentionally public `GET /users` endpoint to discover user IDs, request an administrator by ID, obtain the administrator refresh token, and exchange it for an authenticated session.

Second, permissions such as `users_update` and `roles_update` were enough to grant administrator privileges. A non-admin user with one of those permissions could assign an existing admin role to a user or promote a regular role by setting `isAdmin: true`. The equivalent create operations had the same problem: `users_create` could create a user with an admin role, and `roles_create` could create a new admin role.

The client also showed only a generic error when the server rejected one of these operations, giving the user no explanation that administrator privileges were required.

## Fix

Protected individual user reads and prevented non-admin users from creating or assigning administrator privileges.

`GET /users/{id}` now requires the `users_read` permission, while the intentionally public `GET /users` endpoint remains unchanged for the pre-login user/PIN selector. `getUserById()` now masks both `pin` and `refreshToken`, matching the defense-in-depth behavior already used by the public user list.

Admin role creation and assignment now require the authenticated caller to already be an administrator. This applies to both user and role creation/update operations. The check uses the existing server-side admin guard, which resolves the caller from the stored refresh token and current database role instead of trusting only the access-token claim.

The client now shows localized warning toasts when user or role management receives the admin-only `403` response.

## What Changed

### Protected individual user lookup

Moved `GET /users/{id}` behind `authorizePermission("users_read")`.

The public `GET /users` route remains available because it is required before login. Its existing masking behavior was not changed.

### Refresh token masking

Updated `UsersService.getUserById()` so it returns:

- `pin: "****"`
- `refreshToken: "****"`

Raw session tokens are no longer exposed by the user response, even to an authenticated caller.

### Admin-only user role assignment

Added an admin check when:

- creating a user with an admin role through `POST /users`
- assigning an admin role through `PUT /users/{id}`

Users with `users_create` or `users_update` can continue managing ordinary users and roles, but they cannot grant administrator access unless they are already administrators.

### Admin-only role creation and promotion

Added an admin check when:

- creating a role with `isAdmin: true` through `POST /roles`
- promoting a role with `isAdmin: true` through `PUT /roles/{id}`

Users with `roles_create` or `roles_update` can continue managing standard roles without being able to escalate privileges.

### Localized client feedback

Added specific English and Spanish warning toasts for rejected administrator assignments.

The user-management flow now explains that only an administrator can assign an admin role. The role-management flow explains that only an administrator can create or grant an admin role. Existing generic, duplicate-name, and last-admin feedback remains unchanged.

### Security regression coverage

Added HTTP route tests covering:

- the public user list remaining accessible without authentication
- individual user lookup rejecting unauthenticated requests
- `users_create` not allowing a non-admin to create an admin user
- `users_update` not allowing a non-admin to assign an admin role
- `roles_create` not allowing a non-admin to create an admin role
- `roles_update` not allowing a non-admin to promote a role

Added service coverage confirming that `getUserById()` masks both the PIN and refresh token.

Added client coverage for the administrator-required toasts in user creation/update and role creation/promotion flows.

## New Files

- `server/app/src/test/kotlin/pos/ambrosia/utest/UserPrivilegeEscalationRouteTest.kt` — HTTP regression coverage for authentication and privilege-escalation attempts.

## Modified Files

- `server/app/src/main/kotlin/pos/ambrosia/api/Users.kt` — protects user-by-ID reads and requires admin status when creating or assigning admin users.
- `server/app/src/main/kotlin/pos/ambrosia/api/Roles.kt` — requires admin status when creating or promoting admin roles.
- `server/app/src/main/kotlin/pos/ambrosia/services/UsersService.kt` — masks refresh tokens and exposes the role-admin lookup used by the route guard.
- `server/app/src/test/kotlin/pos/ambrosia/utest/UsersServiceTest.kt` — verifies sensitive user fields are masked.
- `client/src/components/pages/Store/hooks/useUsers.jsx` — shows administrator-required feedback for rejected user mutations.
- `client/src/components/pages/Store/hooks/__tests__/useUsers.test.jsx` — verifies the user-management warning toast.
- `client/src/components/pages/Store/Users/Roles/Roles.jsx` — shows administrator-required feedback for rejected role mutations.
- `client/src/components/pages/Store/Users/Roles/__tests__/Roles.test.jsx` — verifies role creation and promotion warning toasts.
- User and role locale files — add English and Spanish administrator-required messages.

## Screenshots
<img width="1034" height="689" alt="image" src="https://github.com/user-attachments/assets/e0e5c255-11be-4bdf-a49c-59126d99e585" />


## How to Test

1. Create a standard role with only `users_read`, `users_create`, `users_update`, `roles_read`, `roles_create`, and `roles_update` permissions.

2. Assign that role to a non-admin user and log in as that user.

3. Confirm the public login user selector still loads before authentication.

4. While logged in, confirm users with `users_read` can access individual user information and that no raw PIN or refresh token is returned.

5. Try to create a user with an existing admin role.

6. Confirm the request is rejected with `403 Forbidden` and the client shows the administrator-required warning.

7. Try to assign an existing admin role to a regular user.

8. Confirm the request is rejected with `403 Forbidden` and the client shows the administrator-required warning.

9. Try to create a role with **With admin privileges** enabled.

10. Confirm the request is rejected with `403 Forbidden` and the client shows the administrator-required warning.

11. Try to edit a standard role and enable **With admin privileges**.

12. Confirm the request is rejected with `403 Forbidden` and the client shows the administrator-required warning.

13. Log in as an administrator and confirm all four administrator creation/assignment operations still succeed.

14. Confirm non-admin user and role operations continue to work when the caller has the corresponding permission.

## Verification Run

```bash
cd server
./gradlew test ktlintCheck

cd ../client
npm test
npm run lint

cd ..
git diff --check
```

Verification results:

- server test suite passed
- server `ktlintCheck` passed
- 264 client test suites passed
- 2,515 client tests passed
- client ESLint passed
- `git diff --check` passed

## Notes

- `GET /users` remains public by design because the PIN login screen uses it before authentication. It continues masking `pin` and `refreshToken`.
- This change is separate from hashing refresh tokens at rest. Masking the HTTP response prevents direct token disclosure, while hashing stored refresh tokens remains a separate defense for database compromise.
- Existing last-admin protections remain in place and continue preventing deletion or demotion of the final active administrator.
- This PR does not add step-up authentication. It enforces that the caller is already an administrator before administrator privileges can be granted.
