### PR TITLE
fix(security): secure admin role permission management

### DIFF
--- a/client/src/components/pages/Store/Users/Roles/EditRoleModal.jsx
+++ b/client/src/components/pages/Store/Users/Roles/EditRoleModal.jsx
@@ -59,7 +59,11 @@ export function EditRoleModal({
 
           <Checkbox
             isSelected={form.isAdmin}
-            onValueChange={(isSelected) => setForm((previousForm) => ({ ...previousForm, isAdmin: isSelected }))}
+            onValueChange={(isSelected) => setForm((previousForm) => ({
+              ...previousForm,
+              isAdmin: isSelected,
+              permissions: isSelected ? previousForm.permissions : [],
+            }))}
           >
             {roleTranslations("roles.edit.isAdmin")}
           </Checkbox>

--- a/client/src/components/pages/Store/Users/Roles/PermissionSelector.jsx
+++ b/client/src/components/pages/Store/Users/Roles/PermissionSelector.jsx
@@ -62,12 +62,6 @@ export function PermissionSelector({
                     defaultValue: permission.key,
                   })}
                 </p>
-                {permission.related && permission.related.length > 0 && (
-                  <p className="text-[11px] text-default-400">
-                    {roleTranslations("roles.permissions.affects")}{" "}
-                    {permission.related.map((relatedSection) => roleTranslations(`roles.permissions.related.${relatedSection}`, { defaultValue: relatedSection })).join(", ")}
-                  </p>
-                )}
               </div>
             ))}
           </div>

--- a/client/src/components/pages/Store/Users/Roles/Roles.jsx
+++ b/client/src/components/pages/Store/Users/Roles/Roles.jsx
@@ -3,24 +3,26 @@
 import { useMemo, useRef, useState } from "react";
 
 import { addToast, Button, Card, CardBody } from "@heroui/react";
+import { ShieldCheck } from "lucide-react";
 import { useTranslations } from "next-intl";
 
 import { usePermissions } from "@/components/pages/Store/hooks/usePermissions";
 import { PageHeader } from "@/components/shared/PageHeader";
+import { useNavigation } from "@/hooks/useNavigation";
 import { RequirePermission } from "@/hooks/usePermission";
-import { buildPermissionSet } from "@/lib/features";
 import { useConfigurations } from "@/providers/configurations/configurationsProvider";
 
 import { CreateRoleModal } from "./CreateRoleModal";
 import { DeleteRoleModal } from "./DeleteRoleModal";
 import { EditRoleModal } from "./EditRoleModal";
 import { RolesList } from "./RolesList";
-import { permissionCatalog } from "./utils/permissionCatalog";
+import { getVisiblePermissionCatalog } from "./utils/permissionCatalog";
 
 export function Roles({ roles, createRole, deleteRole, loading: loadingRoles, updateRoleWithPermissions, getRolePermissions }) {
-  const { permissions, loading: loadingPerms } = usePermissions();
   const roleTranslations = useTranslations();
   const { businessType } = useConfigurations();
+  const { isAdmin } = useNavigation();
+  const { permissions, loading: loadingPerms } = usePermissions({ enabled: isAdmin });
   const [showModal, setShowModal] = useState(false);
   const [showEditModal, setShowEditModal] = useState(false);
   const [editingRole, setEditingRole] = useState(null);
@@ -37,12 +39,11 @@ export function Roles({ roles, createRole, deleteRole, loading: loadingRoles, up
     permissions: [],
   });
 
-  const permSet = useMemo(() => buildPermissionSet(permissions), [permissions]);
-  const filteredCatalog = useMemo(() => permissionCatalog.filter((permission) => {
-    if (!permSet.has(permission.key)) return false;
-    if (!businessType) return true;
-    return permission.business === "both" || permission.business === businessType;
-  }), [permSet, businessType]);
+  const filteredCatalog = useMemo(() => getVisiblePermissionCatalog({
+    availablePermissions: permissions,
+    businessType,
+    isAdmin: form.isAdmin,
+  }), [permissions, businessType, form.isAdmin]);
 
   const togglePermission = (name) => {
     setForm((previousForm) => {
@@ -161,24 +162,37 @@ export function Roles({ roles, createRole, deleteRole, loading: loadingRoles, up
         title={roleTranslations("roles.header.title")}
         subtitle={roleTranslations("roles.header.subtitle")}
         actions={(
-          <RequirePermission allOf={["roles_create"]}>
-            <Button
-              color="primary"
-              className="bg-green-800"
-              onPress={() => setShowModal(true)}
-              isDisabled={loadingPerms}
-            >
-              {roleTranslations("roles.actions.new")}
-            </Button>
-          </RequirePermission>
+          isAdmin ? (
+            <RequirePermission allOf={["roles_create"]}>
+              <Button
+                color="primary"
+                className="bg-green-800"
+                onPress={() => setShowModal(true)}
+                isDisabled={loadingPerms}
+              >
+                {roleTranslations("roles.actions.new")}
+              </Button>
+            </RequirePermission>
+          ) : null
         )}
       />
+
+      {!isAdmin && (
+        <div className="mb-4 flex items-start gap-3 rounded-lg border border-green-200 bg-green-50 p-3 sm:p-4">
+          <ShieldCheck aria-hidden="true" className="mt-0.5 h-5 w-5 shrink-0 text-green-700" />
+          <div>
+            <p className="text-sm font-semibold text-green-900">{roleTranslations("roles.state.readOnlyTitle")}</p>
+            <p className="mt-0.5 text-sm text-green-700">{roleTranslations("roles.state.readOnlyDescription")}</p>
+          </div>
+        </div>
+      )}
 
       <Card className="bg-white rounded-lg shadow-lg overflow-x-auto">
         <CardBody className="p-4 lg:p-8">
           <RolesList
             roles={roles}
             loading={loadingRoles}
+            canManageRoles={isAdmin}
             onEdit={openEditModal}
             onDelete={setRoleToDelete}
           />

--- a/client/src/components/pages/Store/Users/Roles/RolesList/RolesList.jsx
+++ b/client/src/components/pages/Store/Users/Roles/RolesList/RolesList.jsx
@@ -2,14 +2,11 @@
 
 import { useTranslations } from "next-intl";
 
-import { usePermission } from "@/hooks/usePermission";
-
 import { RolesCard } from "./RolesCard";
 import { RolesTable } from "./RolesTable";
 
-export function RolesList({ roles, loading, onEdit, onDelete }) {
+export function RolesList({ roles, loading, canManageRoles = false, onEdit, onDelete }) {
   const t = useTranslations();
-  const canManageRoles = usePermission({ anyOf: ["roles_update", "roles_delete"] });
 
   if (loading) {
     return <p className="text-default-500">{t("roles.state.loading")}</p>;

--- a/client/src/components/pages/Store/Users/Roles/RolesList/__tests__/RolesList.test.jsx
+++ b/client/src/components/pages/Store/Users/Roles/RolesList/__tests__/RolesList.test.jsx
@@ -6,29 +6,25 @@ jest.mock("next-intl", () => ({
   useTranslations: () => (key) => key,
 }));
 
-jest.mock("@/hooks/usePermission", () => ({
-  usePermission: () => true,
-}));
-
 jest.mock("../RolesCard", () => ({
-  RolesCard: ({ role, onEdit, onDelete }) => (
+  RolesCard: ({ role, canManageRoles, onEdit, onDelete }) => (
     <div>
       <span>{role.role}</span>
-      <button aria-label="Edit Role" onClick={() => onEdit(role)}>edit</button>
-      <button aria-label="Delete Role" onClick={() => onDelete(role)}>delete</button>
+      {canManageRoles && <button aria-label="Edit Role" onClick={() => onEdit(role)}>edit</button>}
+      {canManageRoles && <button aria-label="Delete Role" onClick={() => onDelete(role)}>delete</button>}
     </div>
   ),
 }));
 
 jest.mock("../RolesTable", () => ({
-  RolesTable: ({ roles, onEdit, onDelete }) => (
+  RolesTable: ({ roles, canManageRoles, onEdit, onDelete }) => (
     <table>
       <tbody>
         {roles.map((role) => (
           <tr key={role.id}>
             <td>{role.role}</td>
-            <td><button aria-label="Edit Role" onClick={() => onEdit(role)}>edit</button></td>
-            <td><button aria-label="Delete Role" onClick={() => onDelete(role)}>delete</button></td>
+            <td>{canManageRoles && <button aria-label="Edit Role" onClick={() => onEdit(role)}>edit</button>}</td>
+            <td>{canManageRoles && <button aria-label="Delete Role" onClick={() => onDelete(role)}>delete</button>}</td>
           </tr>
         ))}
       </tbody>
@@ -70,14 +66,14 @@ describe("RolesList", () => {
 
   it("calls onEdit when edit is pressed", () => {
     const onEdit = jest.fn();
-    render(<RolesList roles={roles} loading={false} onEdit={onEdit} onDelete={jest.fn()} />);
+    render(<RolesList roles={roles} loading={false} canManageRoles onEdit={onEdit} onDelete={jest.fn()} />);
     fireEvent.click(screen.getAllByLabelText("Edit Role")[0]);
     expect(onEdit).toHaveBeenCalledWith(roles[0]);
   });
 
   it("calls onDelete when delete is pressed", () => {
     const onDelete = jest.fn();
-    render(<RolesList roles={roles} loading={false} onEdit={jest.fn()} onDelete={onDelete} />);
+    render(<RolesList roles={roles} loading={false} canManageRoles onEdit={jest.fn()} onDelete={onDelete} />);
     fireEvent.click(screen.getAllByLabelText("Delete Role")[0]);
     expect(onDelete).toHaveBeenCalledWith(roles[0]);
   });

--- a/client/src/components/pages/Store/Users/Roles/__tests__/EditRoleModal.test.jsx
+++ b/client/src/components/pages/Store/Users/Roles/__tests__/EditRoleModal.test.jsx
@@ -66,6 +66,21 @@ describe("EditRoleModal", () => {
     expect(result.name).toBe("supervisor");
   });
 
+  it("clears inherited permissions when admin privileges are removed", () => {
+    const adminForm = { ...baseForm, isAdmin: true };
+    const setForm = jest.fn((updater) => updater(adminForm));
+    renderModal({ form: adminForm, setForm });
+
+    fireEvent.click(screen.getByText("roles.edit.isAdmin"));
+
+    expect(setForm).toHaveBeenCalled();
+    expect(setForm.mock.results[0].value).toEqual({
+      ...adminForm,
+      isAdmin: false,
+      permissions: [],
+    });
+  });
+
   it("save button is disabled when name is empty", () => {
     renderModal({ form: { ...baseForm, name: "" } });
     const saveBtn = screen.getByText("roles.actions.save").closest("button");

--- a/client/src/components/pages/Store/Users/Roles/__tests__/Roles.test.jsx
+++ b/client/src/components/pages/Store/Users/Roles/__tests__/Roles.test.jsx
@@ -2,6 +2,8 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 
 import { Roles } from "../Roles";
 
+let mockIsAdmin = true;
+
 jest.mock("@heroui/react", () => {
   const actual = jest.requireActual("@heroui/react");
   return { ...actual, addToast: jest.fn() };
@@ -16,6 +18,10 @@ jest.mock("@/hooks/usePermission", () => ({
   RequirePermission: ({ children }) => children,
 }));
 
+jest.mock("@/hooks/useNavigation", () => ({
+  useNavigation: () => ({ isAdmin: mockIsAdmin }),
+}));
+
 jest.mock("@/providers/configurations/configurationsProvider", () => ({
   useConfigurations: () => ({ businessType: "store" }),
 }));
@@ -25,18 +31,22 @@ jest.mock("@/components/pages/Store/hooks/usePermissions", () => ({
 }));
 
 jest.mock("../RolesList", () => ({
-  RolesList: ({ roles, onEdit, onDelete }) => (
+  RolesList: ({ roles, canManageRoles, onEdit, onDelete }) => (
     <div>
       roles list
       {roles.map((role) => (
         <div key={role.id}>
           <span>{role.role}</span>
-          <button type="button" onClick={() => onEdit(role)}>
-            edit role
-          </button>
-          <button type="button" onClick={() => onDelete(role)}>
-            delete role
-          </button>
+          {canManageRoles && (
+            <>
+              <button type="button" onClick={() => onEdit(role)}>
+                edit role
+              </button>
+              <button type="button" onClick={() => onDelete(role)}>
+                delete role
+              </button>
+            </>
+          )}
         </div>
       ))}
     </div>
@@ -116,6 +126,19 @@ const renderRoles = (props = {}) => render(
 describe("Roles", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockIsAdmin = true;
+  });
+
+  it("shows a read-only notice and hides management controls for non-admin users", () => {
+    mockIsAdmin = false;
+
+    renderRoles({ roles: [{ id: "role-id", role: "cashier", isAdmin: false }] });
+
+    expect(screen.getByText("roles.state.readOnlyTitle")).toBeInTheDocument();
+    expect(screen.getByText("roles.state.readOnlyDescription")).toBeInTheDocument();
+    expect(screen.queryByText("roles.actions.new")).not.toBeInTheDocument();
+    expect(screen.queryByText("edit role")).not.toBeInTheDocument();
+    expect(screen.queryByText("delete role")).not.toBeInTheDocument();
   });
 
   it("shows a success toast after creating a role", async () => {

--- a/client/src/components/pages/Store/Users/Roles/__tests__/permissionCatalog.test.js
+++ b/client/src/components/pages/Store/Users/Roles/__tests__/permissionCatalog.test.js
@@ -1,0 +1,35 @@
+import { getVisiblePermissionCatalog } from "../utils/permissionCatalog";
+
+describe("permissionCatalog", () => {
+  it("hides admin-only permissions from limited roles", () => {
+    const visibleKeys = getVisiblePermissionCatalog({
+      availablePermissions: [
+        { name: "roles_read", adminOnly: false },
+        { name: "roles_create", adminOnly: true },
+        { name: "roles_update", adminOnly: true },
+        { name: "roles_delete", adminOnly: true },
+        { name: "permissions_read", adminOnly: true },
+      ],
+      businessType: "store",
+      isAdmin: false,
+    }).map((permission) => permission.key);
+
+    expect(visibleKeys).toEqual(["roles_read"]);
+  });
+
+  it("shows admin-only permissions when admin is enabled", () => {
+    const visibleKeys = getVisiblePermissionCatalog({
+      availablePermissions: [
+        { name: "roles_read", adminOnly: false },
+        { name: "roles_create", adminOnly: true },
+        { name: "roles_update", adminOnly: true },
+        { name: "roles_delete", adminOnly: true },
+        { name: "permissions_read", adminOnly: true },
+      ],
+      businessType: "store",
+      isAdmin: true,
+    }).map((permission) => permission.key);
+
+    expect(visibleKeys).toEqual(["roles_read", "roles_create", "roles_update", "roles_delete", "permissions_read"]);
+  });
+});

--- a/client/src/components/pages/Store/Users/Roles/locales/en.js
+++ b/client/src/components/pages/Store/Users/Roles/locales/en.js
@@ -73,18 +73,6 @@ const rolesEn = {
       subtitle: "Catalog filtered by business type",
       legend: "Select the permissions for this role. Only those that apply to the current business type are shown.",
       adminNotice: "Admin roles automatically get every permission.",
-      affects: "Affects:",
-      related: {
-        Users: "Users",
-        Products: "Products",
-        Orders: "Orders",
-        Sale: "Sale",
-        Wallet: "Wallet",
-        Settings: "Settings",
-        Dishes: "Dishes",
-        Tables: "Tables",
-        Spaces: "Spaces",
-      },
       scope: {
         store: "Store",
         restaurant: "Restaurant",
@@ -179,6 +167,8 @@ const rolesEn = {
       loading: "Loading roles...",
       empty: "No roles created.",
       loadingPerms: "Loading permissions...",
+      readOnlyTitle: "Read-only view",
+      readOnlyDescription: "Only administrators can create, edit, delete roles, or change their permissions.",
     },
   },
 };

--- a/client/src/components/pages/Store/Users/Roles/locales/es.js
+++ b/client/src/components/pages/Store/Users/Roles/locales/es.js
@@ -73,18 +73,6 @@ const rolesEs = {
       subtitle: "Catálogo filtrado según el tipo de negocio",
       legend: "Selecciona los permisos que tendrá este rol. Solo se muestran los que aplican al tipo de negocio actual.",
       adminNotice: "Los roles admin reciben automáticamente todos los permisos.",
-      affects: "Afecta a:",
-      related: {
-        Users: "Usuarios",
-        Products: "Productos",
-        Orders: "Órdenes",
-        Sale: "Venta",
-        Wallet: "Wallet",
-        Settings: "Configuración",
-        Dishes: "Platillos",
-        Tables: "Mesas",
-        Spaces: "Espacios",
-      },
       scope: {
         store: "Tienda",
         restaurant: "Restaurante",
@@ -179,6 +167,8 @@ const rolesEs = {
       loading: "Cargando roles...",
       empty: "No hay roles creados.",
       loadingPerms: "Cargando permisos...",
+      readOnlyTitle: "Vista de solo lectura",
+      readOnlyDescription: "Solo los administradores pueden crear, editar, eliminar roles o cambiar sus permisos.",
     },
   },
 };

--- a/client/src/components/pages/Store/Users/Roles/utils/permissionCatalog.js
+++ b/client/src/components/pages/Store/Users/Roles/utils/permissionCatalog.js
@@ -1,10 +1,5 @@
 export const permissionCatalog = [
-  {
-    key: "users_read",
-    group: "people",
-    business: "both",
-    related: ["Users"],
-  },
+  { key: "users_read", group: "people", business: "both" },
   { key: "users_create", group: "people", business: "both" },
   { key: "users_update", group: "people", business: "both" },
   { key: "users_delete", group: "people", business: "both" },
@@ -14,7 +9,7 @@ export const permissionCatalog = [
   { key: "roles_delete", group: "people", business: "both" },
   { key: "permissions_read", group: "people", business: "both" },
 
-  { key: "products_read", group: "catalog", business: "store", related: ["Products"] },
+  { key: "products_read", group: "catalog", business: "store" },
   { key: "products_create", group: "catalog", business: "store" },
   { key: "products_update", group: "catalog", business: "store" },
   { key: "products_delete", group: "catalog", business: "store" },
@@ -23,7 +18,7 @@ export const permissionCatalog = [
   { key: "categories_update", group: "catalog", business: "store" },
   { key: "categories_delete", group: "catalog", business: "store" },
 
-  { key: "orders_read", group: "sales", business: "store", related: ["Orders", "Sale"] },
+  { key: "orders_read", group: "sales", business: "store" },
   { key: "orders_create", group: "sales", business: "store" },
   { key: "orders_update", group: "sales", business: "store" },
   { key: "orders_delete", group: "sales", business: "store" },
@@ -31,15 +26,15 @@ export const permissionCatalog = [
   { key: "orders_refund", group: "sales", business: "store" },
   { key: "orders_discount", group: "sales", business: "store" },
 
-  { key: "payments_read", group: "payments", business: "both", related: ["Wallet"] },
+  { key: "payments_read", group: "payments", business: "both" },
   { key: "payments_create", group: "payments", business: "both" },
   { key: "payments_update", group: "payments", business: "both" },
   { key: "wallet_read", group: "payments", business: "store" },
 
-  { key: "settings_update", group: "settings", business: "both", related: ["Settings"] },
+  { key: "settings_update", group: "settings", business: "both" },
   { key: "printer_update", group: "settings", business: "store" },
 
-  { key: "dish_read", group: "menu", business: "restaurant", related: ["Dishes"] },
+  { key: "dish_read", group: "menu", business: "restaurant" },
   { key: "dish_create", group: "menu", business: "restaurant" },
   { key: "dish_update", group: "menu", business: "restaurant" },
   { key: "dish_delete", group: "menu", business: "restaurant" },
@@ -54,12 +49,12 @@ export const permissionCatalog = [
   { key: "suppliers_update", group: "inventory", business: "restaurant" },
   { key: "suppliers_delete", group: "inventory", business: "restaurant" },
 
-  { key: "tables_read", group: "floor", business: "restaurant", related: ["Tables"] },
+  { key: "tables_read", group: "floor", business: "restaurant" },
   { key: "tables_create", group: "floor", business: "restaurant" },
   { key: "tables_update", group: "floor", business: "restaurant" },
   { key: "tables_delete", group: "floor", business: "restaurant" },
 
-  { key: "spaces_read", group: "floor", business: "restaurant", related: ["Spaces"] },
+  { key: "spaces_read", group: "floor", business: "restaurant" },
   { key: "spaces_create", group: "floor", business: "restaurant" },
   { key: "spaces_update", group: "floor", business: "restaurant" },
   { key: "spaces_delete", group: "floor", business: "restaurant" },
@@ -75,3 +70,15 @@ export const permissionCatalog = [
   { key: "reports_read", group: "reports", business: "store" },
   { key: "reports_export", group: "reports", business: "store" },
 ];
+
+export function getVisiblePermissionCatalog({ availablePermissions, businessType, isAdmin }) {
+  const permissionsByKey = new Map(availablePermissions.map((permission) => [permission.name, permission]));
+
+  return permissionCatalog.filter((permission) => {
+    const serverPermission = permissionsByKey.get(permission.key);
+    if (!serverPermission) return false;
+    if (serverPermission.adminOnly && !isAdmin) return false;
+    if (!businessType) return true;
+    return permission.business === "both" || permission.business === businessType;
+  });
+}

--- a/client/src/components/pages/Store/hooks/__tests__/usePermissions.test.jsx
+++ b/client/src/components/pages/Store/hooks/__tests__/usePermissions.test.jsx
@@ -9,8 +9,8 @@ jest.mock("@/lib/http", () => ({
   parseJsonResponse: jest.fn(),
 }));
 
-function TestComponent() {
-  const { permissions, loading, error } = usePermissions();
+function TestComponent({ enabled = true }) {
+  const { permissions, loading, error } = usePermissions({ enabled });
 
   return (
     <div>
@@ -71,5 +71,13 @@ describe("usePermissions", () => {
 
     await waitFor(() => expect(screen.getByTestId("loading")).toHaveTextContent("no"));
     expect(httpClient).toHaveBeenCalledWith("/permissions");
+  });
+
+  it("does not request permissions when disabled", async () => {
+    render(<TestComponent enabled={false} />);
+
+    await waitFor(() => expect(screen.getByTestId("loading")).toHaveTextContent("no"));
+    expect(httpClient).not.toHaveBeenCalled();
+    expect(screen.getByTestId("count")).toHaveTextContent("0");
   });
 });

--- a/client/src/components/pages/Store/hooks/__tests__/useRoles.test.jsx
+++ b/client/src/components/pages/Store/hooks/__tests__/useRoles.test.jsx
@@ -27,15 +27,14 @@ jest.mock("@/hooks/usePermission", () => ({
 const handlers = {};
 
 function TestComponent() {
-  const { roles, loading, error, createRole, updateRoleWithPermissions, deleteRole, getRolePermissions, assignPermissions } = useRoles();
+  const { roles, loading, error, createRole, updateRoleWithPermissions, deleteRole, getRolePermissions } = useRoles();
 
   useEffect(() => {
     handlers.createRole = createRole;
     handlers.updateRoleWithPermissions = updateRoleWithPermissions;
     handlers.deleteRole = deleteRole;
     handlers.getRolePermissions = getRolePermissions;
-    handlers.assignPermissions = assignPermissions;
-  }, [createRole, updateRoleWithPermissions, deleteRole, getRolePermissions, assignPermissions]);
+  }, [createRole, updateRoleWithPermissions, deleteRole, getRolePermissions]);
 
   return (
     <div>
@@ -89,7 +88,7 @@ describe("useRoles", () => {
     expect(httpClient).toHaveBeenCalledWith("/roles", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ role: "seller", isAdmin: false }),
+      body: JSON.stringify({ role: "seller", isAdmin: false, permissions: [] }),
     });
     await waitFor(() => expect(screen.getByTestId("first-role")).toHaveTextContent("seller"));
   });
@@ -110,12 +109,11 @@ describe("useRoles", () => {
     expect(httpClient).toHaveBeenCalledWith("/roles", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ role: "manager", isAdmin: false }),
-    });
-    expect(httpClient).toHaveBeenCalledWith("/roles/xyz/permissions", {
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ permissions: ["orders_read"] }),
+      body: JSON.stringify({
+        role: "manager",
+        isAdmin: false,
+        permissions: ["orders_read"],
+      }),
     });
   });
 
@@ -138,12 +136,11 @@ describe("useRoles", () => {
     expect(httpClient).toHaveBeenCalledWith("/roles/1", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ role: "updated", isAdmin: false }),
-    });
-    expect(httpClient).toHaveBeenCalledWith("/roles/1/permissions", {
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ permissions: ["products_read"] }),
+      body: JSON.stringify({
+        role: "updated",
+        isAdmin: false,
+        permissions: ["products_read"],
+      }),
     });
   });
 
@@ -213,19 +210,5 @@ describe("useRoles", () => {
     });
 
     expect(rolePermissions).toEqual([]);
-  });
-
-  it("does nothing when assignPermissions called with no roleId", async () => {
-    httpClient.mockResolvedValue({ ok: true });
-    parseJsonResponse.mockResolvedValueOnce([]);
-
-    render(<TestComponent />);
-    await waitFor(() => expect(screen.getByTestId("loading")).toHaveTextContent("no"));
-
-    await act(async () => {
-      await handlers.assignPermissions(null, ["orders_read"]);
-    });
-
-    expect(httpClient).toHaveBeenCalledTimes(1);
   });
 });

--- a/client/src/components/pages/Store/hooks/usePermissions.jsx
+++ b/client/src/components/pages/Store/hooks/usePermissions.jsx
@@ -4,12 +4,18 @@ import { useCallback, useEffect, useState } from "react";
 import { toArray } from "@/components/utils/array";
 import { httpClient, parseJsonResponse } from "@/lib/http";
 
-export function usePermissions() {
+export function usePermissions({ enabled = true } = {}) {
   const [permissions, setPermissions] = useState([]);
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(enabled);
   const [error, setError] = useState(null);
 
   const fetchPermissions = useCallback(async () => {
+    if (!enabled) {
+      setPermissions([]);
+      setError(null);
+      setLoading(false);
+      return;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -23,7 +29,7 @@ export function usePermissions() {
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [enabled]);
 
   useEffect(() => {
     fetchPermissions();

--- a/client/src/components/pages/Store/hooks/useRoles.jsx
+++ b/client/src/components/pages/Store/hooks/useRoles.jsx
@@ -50,26 +50,10 @@ export function useRoles() {
     }
   }, []);
 
-  const assignPermissions = useCallback(async (roleId, permissions = []) => {
-    if (!roleId) return;
-    try {
-      await httpClient(`/roles/${roleId}/permissions`, {
-        method: "PUT",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ permissions }),
-      });
-    } catch (assignPermissionsError) {
-      console.error("Error assigning permissions:", assignPermissionsError);
-      throw assignPermissionsError;
-    }
-  }, []);
-
   const createRole = useCallback(
     async ({ name, isAdmin = false, permissions = [] }) => {
       try {
-        const roleRequestBody = { role: name, isAdmin };
+        const roleRequestBody = { role: name, isAdmin, permissions };
         const createRoleRequest = await httpClient("/roles", {
           method: "POST",
           headers: {
@@ -82,9 +66,6 @@ export function useRoles() {
         }
         const createdRoleData = await parseJsonResponse(createRoleRequest, []);
         const createdRoleId = createdRoleData?.id || createdRoleData?.roleId;
-        if (permissions.length > 0) {
-          await assignPermissions(createdRoleId, permissions);
-        }
         await fetchRoles();
         return createdRoleId;
       } catch (createRoleError) {
@@ -92,7 +73,7 @@ export function useRoles() {
         throw createRoleError;
       }
     },
-    [assignPermissions, fetchRoles],
+    [fetchRoles],
   );
 
   const updateRoleWithPermissions = useCallback(
@@ -101,11 +82,11 @@ export function useRoles() {
       await updateRole(roleId, {
         role: name,
         isAdmin,
+        permissions,
       });
-      await assignPermissions(roleId, permissions);
       await fetchRoles();
     },
-    [assignPermissions, fetchRoles, updateRole],
+    [fetchRoles, updateRole],
   );
 
   const deleteRole = useCallback(async (roleId) => {
@@ -138,7 +119,6 @@ export function useRoles() {
     roles,
     createRole,
     deleteRole,
-    assignPermissions,
     updateRoleWithPermissions,
     getRolePermissions,
     loading,

--- a/server/app/src/main/kotlin/pos/ambrosia/api/Permissions.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/api/Permissions.kt
@@ -7,13 +7,13 @@ import io.ktor.server.routing.get
 import io.ktor.server.routing.route
 import io.ktor.server.routing.routing
 import pos.ambrosia.services.PermissionsService
-import pos.ambrosia.utils.authorizePermission
+import pos.ambrosia.utils.authorizeAdminPermission
 
 fun Application.configurePermissions() {
     val permissionsService = PermissionsService()
     routing {
         route("/permissions") {
-            authorizePermission("permissions_read") {
+            authorizeAdminPermission("permissions_read") {
                 get("") {
                     val list = permissionsService.getAll()
                     if (list.isEmpty()) {

--- a/server/app/src/main/kotlin/pos/ambrosia/api/Roles.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/api/Roles.kt
@@ -15,10 +15,11 @@ import pos.ambrosia.logger
 import pos.ambrosia.models.Role
 import pos.ambrosia.models.RolePermissionsUpdateRequest
 import pos.ambrosia.models.RolePermissionsUpdateResult
+import pos.ambrosia.models.UpsertRoleRequest
 import pos.ambrosia.services.PermissionsService
 import pos.ambrosia.services.RolesService
+import pos.ambrosia.utils.authorizeAdminPermission
 import pos.ambrosia.utils.authorizePermission
-import pos.ambrosia.utils.requireAdmin
 
 fun Application.configureRoles() {
     val roleService = RolesService(environment)
@@ -72,13 +73,11 @@ fun Route.roles(
             call.respond(HttpStatusCode.OK, perms)
         }
     }
-    authorizePermission("roles_create") {
+    authorizeAdminPermission("roles_create") {
         post("") {
-            val user = call.receive<Role>()
-            if (user.isAdmin == true) {
-                call.requireAdmin()
-            }
-            val id = roleService.addRole(user)
+            val payload = call.receive<UpsertRoleRequest>()
+            val role = Role(role = payload.role, password = payload.password, isAdmin = payload.isAdmin)
+            val id = roleService.addRole(role, payload.permissions.orEmpty().distinct())
             if (id == null) {
                 call.respond(HttpStatusCode.BadRequest, "Invalid role data")
                 return@post
@@ -89,7 +88,7 @@ fun Route.roles(
             )
         }
     }
-    authorizePermission("roles_update") {
+    authorizeAdminPermission("roles_update") {
         put("/{id}") {
             val id = call.parameters["id"]
             if (id == null) {
@@ -97,15 +96,13 @@ fun Route.roles(
                 return@put
             }
 
-            val updatedRole = call.receive<Role>()
-            if (updatedRole.role.isBlank()) {
+            val payload = call.receive<UpsertRoleRequest>()
+            if (payload.role.isBlank()) {
                 call.respond(HttpStatusCode.BadRequest, "Invalid role data")
                 return@put
             }
-            if (updatedRole.isAdmin == true) {
-                call.requireAdmin()
-            }
-            val isUpdated = roleService.updateRole(id, updatedRole)
+            val updatedRole = Role(role = payload.role, password = payload.password, isAdmin = payload.isAdmin)
+            val isUpdated = roleService.updateRole(id, updatedRole, payload.permissions?.distinct())
 
             if (!isUpdated) {
                 call.respond(HttpStatusCode.NotFound, "Role with ID: $id not found")
@@ -131,7 +128,7 @@ fun Route.roles(
             call.respond(HttpStatusCode.OK, RolePermissionsUpdateResult(roleId = id, assigned = count))
         }
     }
-    authorizePermission("roles_delete") {
+    authorizeAdminPermission("roles_delete") {
         delete("/{id}") {
             val id = call.parameters["id"]
             if (id == null) {

--- a/server/app/src/main/kotlin/pos/ambrosia/api/Roles.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/api/Roles.kt
@@ -75,9 +75,14 @@ fun Route.roles(
     }
     authorizeAdminPermission("roles_create") {
         post("") {
-            val payload = call.receive<UpsertRoleRequest>()
-            val role = Role(role = payload.role, password = payload.password, isAdmin = payload.isAdmin)
-            val id = roleService.addRole(role, payload.permissions.orEmpty().distinct())
+            val roleCreateRequest = call.receive<UpsertRoleRequest>()
+            val role =
+                Role(
+                    role = roleCreateRequest.role,
+                    password = roleCreateRequest.password,
+                    isAdmin = roleCreateRequest.isAdmin,
+                )
+            val id = roleService.addRole(role, roleCreateRequest.permissions.orEmpty().distinct())
             if (id == null) {
                 call.respond(HttpStatusCode.BadRequest, "Invalid role data")
                 return@post
@@ -96,13 +101,18 @@ fun Route.roles(
                 return@put
             }
 
-            val payload = call.receive<UpsertRoleRequest>()
-            if (payload.role.isBlank()) {
+            val roleUpdateRequest = call.receive<UpsertRoleRequest>()
+            if (roleUpdateRequest.role.isBlank()) {
                 call.respond(HttpStatusCode.BadRequest, "Invalid role data")
                 return@put
             }
-            val updatedRole = Role(role = payload.role, password = payload.password, isAdmin = payload.isAdmin)
-            val isUpdated = roleService.updateRole(id, updatedRole, payload.permissions?.distinct())
+            val updatedRole =
+                Role(
+                    role = roleUpdateRequest.role,
+                    password = roleUpdateRequest.password,
+                    isAdmin = roleUpdateRequest.isAdmin,
+                )
+            val isUpdated = roleService.updateRole(id, updatedRole, roleUpdateRequest.permissions?.distinct())
 
             if (!isUpdated) {
                 call.respond(HttpStatusCode.NotFound, "Role with ID: $id not found")
@@ -123,8 +133,8 @@ fun Route.roles(
                 return@put
             }
 
-            val payload = call.receive<RolePermissionsUpdateRequest>()
-            val count = permissionsService.replaceRolePermissions(id, payload.permissions.distinct())
+            val permissionsUpdateRequest = call.receive<RolePermissionsUpdateRequest>()
+            val count = permissionsService.replaceRolePermissions(id, permissionsUpdateRequest.permissions.distinct())
             call.respond(HttpStatusCode.OK, RolePermissionsUpdateResult(roleId = id, assigned = count))
         }
     }

--- a/server/app/src/main/kotlin/pos/ambrosia/models/AppModels.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/models/AppModels.kt
@@ -107,6 +107,14 @@ data class Role(
     val isAdmin: Boolean? = false,
 )
 
+@Serializable
+data class UpsertRoleRequest(
+    val role: String,
+    val password: String? = null,
+    val isAdmin: Boolean? = false,
+    val permissions: List<String>? = null,
+)
+
 @Serializable data class Space(
     val id: String? = null,
     val name: String,
@@ -314,6 +322,7 @@ data class Permission(
     val name: String,
     val description: String? = null,
     val enabled: Boolean = true,
+    val adminOnly: Boolean = false,
 )
 
 @Serializable

--- a/server/app/src/main/kotlin/pos/ambrosia/services/PermissionsService.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/services/PermissionsService.kt
@@ -16,6 +16,7 @@ import pos.ambrosia.db.tables.RolePermissionsTable
 import pos.ambrosia.db.tables.RolesTable
 import pos.ambrosia.logger
 import pos.ambrosia.models.Permission
+import pos.ambrosia.utils.AdminOnlyPermissions
 import java.util.UUID
 
 class PermissionsService {
@@ -25,6 +26,7 @@ class PermissionsService {
             name = entity.name,
             description = entity.description,
             enabled = entity.enabled,
+            adminOnly = AdminOnlyPermissions.contains(entity.name),
         )
 
     private fun enabledPermissionIds() = PermissionEntity.find { PermissionsTable.enabled eq true }.map { it.id }
@@ -58,6 +60,7 @@ class PermissionsService {
                         name = it[PermissionsTable.name],
                         description = it[PermissionsTable.description],
                         enabled = it[PermissionsTable.enabled],
+                        adminOnly = AdminOnlyPermissions.contains(it[PermissionsTable.name]),
                     )
                 }
         }
@@ -70,38 +73,46 @@ class PermissionsService {
     fun replaceRolePermissions(
         roleId: String,
         permissionKeys: List<String>,
-    ): Int =
-        transaction {
-            val roleUUID =
-                try {
-                    UUID.fromString(roleId)
-                } catch (_: IllegalArgumentException) {
-                    return@transaction 0
-                }
-            val roleEntityId = EntityID(roleUUID, RolesTable)
-            val role = RoleEntity.findById(roleUUID)?.takeIf { !it.isDeleted } ?: return@transaction 0
+    ): Int = transaction { replaceRolePermissionsInCurrentTransaction(roleId, permissionKeys) }
 
-            RolePermissionsTable.deleteWhere { RolePermissionsTable.roleId eq roleEntityId }
-
-            if (!role.isAdmin && permissionKeys.isEmpty()) return@transaction 0
-
-            val permissionIds =
-                if (role.isAdmin) {
-                    enabledPermissionIds()
-                } else {
-                    PermissionEntity
-                        .find { (PermissionsTable.name inList permissionKeys) and (PermissionsTable.enabled eq true) }
-                        .map { it.id }
-                }
-
-            permissionIds.sumOf { permissionId ->
-                RolePermissionsTable
-                    .insertIgnore {
-                        it[RolePermissionsTable.roleId] = roleEntityId
-                        it[RolePermissionsTable.permissionId] = permissionId
-                    }.insertedCount
+    internal fun replaceRolePermissionsInCurrentTransaction(
+        roleId: String,
+        permissionKeys: List<String>,
+    ): Int {
+        val roleUUID =
+            try {
+                UUID.fromString(roleId)
+            } catch (_: IllegalArgumentException) {
+                return 0
             }
+        val roleEntityId = EntityID(roleUUID, RolesTable)
+        val role = RoleEntity.findById(roleUUID)?.takeIf { !it.isDeleted } ?: return 0
+
+        RolePermissionsTable.deleteWhere { RolePermissionsTable.roleId eq roleEntityId }
+
+        if (!role.isAdmin && permissionKeys.isEmpty()) return 0
+
+        val allowedPermissionKeys =
+            if (role.isAdmin) permissionKeys else permissionKeys.filterNot(AdminOnlyPermissions::contains)
+        if (!role.isAdmin && allowedPermissionKeys.isEmpty()) return 0
+
+        val permissionIds =
+            if (role.isAdmin) {
+                enabledPermissionIds()
+            } else {
+                PermissionEntity
+                    .find { (PermissionsTable.name inList allowedPermissionKeys) and (PermissionsTable.enabled eq true) }
+                    .map { it.id }
+            }
+
+        return permissionIds.sumOf { permissionId ->
+            RolePermissionsTable
+                .insertIgnore {
+                    it[RolePermissionsTable.roleId] = roleEntityId
+                    it[RolePermissionsTable.permissionId] = permissionId
+                }.insertedCount
         }
+    }
 
     fun assignAllEnabledToRole(roleId: String): Int =
         transaction {

--- a/server/app/src/main/kotlin/pos/ambrosia/services/RolesService.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/services/RolesService.kt
@@ -18,13 +18,17 @@ import pos.ambrosia.utils.LastAdminRemovalException
 import pos.ambrosia.utils.SecurePinProcessor
 import java.util.UUID
 
-class RolesService(
+class RolesService internal constructor(
     private val env: ApplicationEnvironment,
+    private val writeRolePermissions: (String, List<String>) -> Int =
+        PermissionsService()::replaceRolePermissionsInCurrentTransaction,
 ) {
     private val adminGuard = AdminGuardService()
-    private val permissionsService = PermissionsService()
 
-    fun addRole(role: Role): String? =
+    fun addRole(
+        role: Role,
+        permissionKeys: List<String> = emptyList(),
+    ): String? =
         transaction {
             if (role.role.isBlank()) return@transaction null
             if (roleNameExists(role.role)) {
@@ -50,7 +54,7 @@ class RolesService(
                     }.id.value
                     .toString()
 
-            grantAllPermissionsIfAdmin(generatedId, isAdmin)
+            writeRolePermissions(generatedId, permissionKeys.distinct())
 
             logger.info("Role created successfully with ID: $generatedId")
             generatedId
@@ -109,6 +113,7 @@ class RolesService(
     fun updateRole(
         id: String?,
         role: Role,
+        permissionKeys: List<String>? = null,
     ): Boolean =
         transaction {
             if (id == null) return@transaction false
@@ -127,7 +132,11 @@ class RolesService(
             } else {
                 entity.role = role.role
                 entity.isAdmin = isAdmin
-                grantAllPermissionsIfAdmin(id, isAdmin)
+                if (permissionKeys == null) {
+                    if (isAdmin) writeRolePermissions(id, emptyList())
+                } else {
+                    writeRolePermissions(id, permissionKeys.distinct())
+                }
                 logger.info("Role updated successfully: ${role.id}")
                 true
             }
@@ -164,13 +173,6 @@ class RolesService(
                 newPassword.fill('\u0000')
             }
         }
-
-    private fun grantAllPermissionsIfAdmin(
-        roleId: String,
-        isAdmin: Boolean,
-    ) {
-        if (isAdmin) permissionsService.assignAllEnabledToRole(roleId)
-    }
 
     fun deleteRole(id: String): Boolean =
         transaction {

--- a/server/app/src/main/kotlin/pos/ambrosia/utils/AdminOnlyPermissions.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/utils/AdminOnlyPermissions.kt
@@ -1,0 +1,7 @@
+package pos.ambrosia.utils
+
+object AdminOnlyPermissions {
+    private val keys = setOf("roles_create", "roles_update", "roles_delete", "permissions_read")
+
+    fun contains(permissionKey: String): Boolean = permissionKey in keys
+}

--- a/server/app/src/main/kotlin/pos/ambrosia/utils/AuthUtils.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/utils/AuthUtils.kt
@@ -114,6 +114,17 @@ fun Route.authorizePermission(
         build()
     }
 
+fun Route.authorizeAdminPermission(
+    key: String,
+    name: String = "auth-jwt",
+    build: Route.() -> Unit,
+): Route =
+    authenticate(name) {
+        install(RequirePermission) { this.key = key }
+        install(AdminAccess)
+        build()
+    }
+
 class PermissionPluginConfig {
     lateinit var key: String
 }

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/PermissionsServiceTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/PermissionsServiceTest.kt
@@ -29,13 +29,17 @@ class PermissionsServiceTest {
     fun `getAll returns list ordered by name when found`() {
         ExposedTestDb.seedPermission("perm.write", "Write")
         ExposedTestDb.seedPermission("perm.read", "Read")
+        ExposedTestDb.seedPermission("roles_update", "Update roles")
 
         val list = service.getAll()
 
-        assertEquals(2, list.size)
+        assertEquals(3, list.size)
         assertEquals("perm.read", list[0].name)
         assertEquals("perm.write", list[1].name)
+        assertEquals("roles_update", list[2].name)
         assertTrue(list.all { it.enabled })
+        assertTrue(!list[0].adminOnly)
+        assertTrue(list[2].adminOnly)
     }
 
     @Test
@@ -122,6 +126,25 @@ class PermissionsServiceTest {
         assertEquals(1, count)
         val names = service.getByRole(roleId)!!.map { it.name }
         assertEquals(listOf("perm.write"), names)
+    }
+
+    @Test
+    fun `replaceRolePermissions excludes admin-only permissions from limited roles`() {
+        val roleId = ExposedTestDb.seedRole("Manager", isAdmin = false)
+        ExposedTestDb.seedPermission("roles_read", "Read roles")
+        ExposedTestDb.seedPermission("roles_create", "Create roles")
+        ExposedTestDb.seedPermission("roles_update", "Update roles")
+        ExposedTestDb.seedPermission("roles_delete", "Delete roles")
+        ExposedTestDb.seedPermission("permissions_read", "Read permissions")
+
+        val count =
+            service.replaceRolePermissions(
+                roleId,
+                listOf("roles_read", "roles_create", "roles_update", "roles_delete", "permissions_read"),
+            )
+
+        assertEquals(1, count)
+        assertEquals(listOf("roles_read"), service.getByRole(roleId)!!.map { it.name })
     }
 
     @Test

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/RoleServiceTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/RoleServiceTest.kt
@@ -92,6 +92,22 @@ class RoleServiceTest {
     }
 
     @Test
+    fun `addRole assigns requested permissions atomically when role is not admin`() {
+        runBlocking {
+            ExposedTestDb.seedPermission("perm.read", "Read")
+
+            val roleId =
+                service.addRole(
+                    Role(role = "Cashier", password = "1234", isAdmin = false),
+                    listOf("perm.read"),
+                )
+
+            assertNotNull(roleId)
+            assertEquals(listOf("perm.read"), permissionsService.getByRole(roleId!!)!!.map { it.name })
+        }
+    }
+
+    @Test
     fun `updateRole returns false if role name is blank`() {
         runBlocking {
             val result = service.updateRole("some-id", Role(role = "  "))
@@ -194,6 +210,86 @@ class RoleServiceTest {
             assertTrue(result)
             val names = permissionsService.getByRole(roleId)!!.map { it.name }
             assertEquals(listOf("perm.read", "perm.write"), names)
+        }
+    }
+
+    @Test
+    fun `updateRole updates fields and permissions together`() {
+        runBlocking {
+            val roleId = ExposedTestDb.seedRole("Cashier", isAdmin = false)
+            ExposedTestDb.seedPermission("perm.read", "Read")
+            ExposedTestDb.seedPermission("perm.write", "Write")
+            permissionsService.replaceRolePermissions(roleId, listOf("perm.read"))
+
+            val result =
+                service.updateRole(
+                    roleId,
+                    Role(role = "Manager", isAdmin = false),
+                    listOf("perm.write"),
+                )
+
+            assertTrue(result)
+            assertEquals("Manager", service.getRoleById(roleId)?.role)
+            assertEquals(listOf("perm.write"), permissionsService.getByRole(roleId)!!.map { it.name })
+        }
+    }
+
+    @Test
+    fun `updateRole rolls back role fields when permission persistence fails`() {
+        runBlocking {
+            val roleId = ExposedTestDb.seedRole("Cashier", isAdmin = false)
+            ExposedTestDb.seedPermission("perm.read", "Read")
+            permissionsService.replaceRolePermissions(roleId, listOf("perm.read"))
+            val failingService =
+                RolesService(env) { _, _ ->
+                    throw IllegalStateException("Permission persistence failed")
+                }
+
+            assertFailsWith<IllegalStateException> {
+                failingService.updateRole(
+                    roleId,
+                    Role(role = "Manager", isAdmin = true),
+                    listOf("perm.read"),
+                )
+            }
+
+            val unchangedRole = service.getRoleById(roleId)
+            assertEquals("Cashier", unchangedRole?.role)
+            assertFalse(unchangedRole?.isAdmin ?: true)
+            assertEquals(listOf("perm.read"), permissionsService.getByRole(roleId)!!.map { it.name })
+        }
+    }
+
+    @Test
+    fun `updateRole preserves permissions when permission payload is omitted`() {
+        runBlocking {
+            val roleId = ExposedTestDb.seedRole("Cashier", isAdmin = false)
+            ExposedTestDb.seedPermission("perm.read", "Read")
+            permissionsService.replaceRolePermissions(roleId, listOf("perm.read"))
+
+            val result = service.updateRole(roleId, Role(role = "Seller", isAdmin = false))
+
+            assertTrue(result)
+            assertEquals(listOf("perm.read"), permissionsService.getByRole(roleId)!!.map { it.name })
+        }
+    }
+
+    @Test
+    fun `updateRole keeps all enabled permissions when admin payload is partial`() {
+        runBlocking {
+            val roleId = ExposedTestDb.seedRole("Admin", isAdmin = true)
+            ExposedTestDb.seedPermission("perm.read", "Read")
+            ExposedTestDb.seedPermission("perm.write", "Write")
+
+            val result =
+                service.updateRole(
+                    roleId,
+                    Role(role = "Administrator", isAdmin = true),
+                    listOf("perm.read"),
+                )
+
+            assertTrue(result)
+            assertEquals(listOf("perm.read", "perm.write"), permissionsService.getByRole(roleId)!!.map { it.name })
         }
     }
 

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/UserPrivilegeEscalationRouteTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/UserPrivilegeEscalationRouteTest.kt
@@ -1,5 +1,6 @@
 package pos.ambrosia.utest
 
+import io.ktor.client.request.delete
 import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.request.post
@@ -13,6 +14,7 @@ import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.server.testing.testApplication
 import org.junit.After
 import org.junit.Before
+import pos.ambrosia.api.configurePermissions
 import pos.ambrosia.api.configureRoles
 import pos.ambrosia.api.configureUsers
 import pos.ambrosia.api.handler
@@ -100,6 +102,28 @@ class UserPrivilegeEscalationRouteTest {
         }
 
     @Test
+    fun `non admin with roles update cannot edit a standard role`() =
+        testApplication {
+            val auth = installNonAdminAuth()
+            grantPermission("non-admin-test-role", "roles_update")
+            val targetRoleId = ExposedTestDb.seedRole("target-role")
+            application {
+                install(ContentNegotiation) { json() }
+                handler()
+                configureRoles()
+            }
+
+            val response =
+                client.put("/roles/$targetRoleId") {
+                    withAuthCookies(auth)
+                    header(HttpHeaders.ContentType, "application/json")
+                    setBody("""{"role":"Renamed role","isAdmin":false}""")
+                }
+
+            assertEquals(HttpStatusCode.Forbidden, response.status)
+        }
+
+    @Test
     fun `non admin with users create cannot create a user with an admin role`() =
         testApplication {
             val auth = installNonAdminAuth()
@@ -138,6 +162,140 @@ class UserPrivilegeEscalationRouteTest {
                     header(HttpHeaders.ContentType, "application/json")
                     setBody("""{"role":"new-admin-role","isAdmin":true}""")
                 }
+
+            assertEquals(HttpStatusCode.Forbidden, response.status)
+        }
+
+    @Test
+    fun `non admin with roles create cannot create a standard role`() =
+        testApplication {
+            val auth = installNonAdminAuth()
+            grantPermission("non-admin-test-role", "roles_create")
+            application {
+                install(ContentNegotiation) { json() }
+                handler()
+                configureRoles()
+            }
+
+            val response =
+                client.post("/roles") {
+                    withAuthCookies(auth)
+                    header(HttpHeaders.ContentType, "application/json")
+                    setBody("""{"role":"new-standard-role","isAdmin":false}""")
+                }
+
+            assertEquals(HttpStatusCode.Forbidden, response.status)
+        }
+
+    @Test
+    fun `admin without roles create permission cannot create a role`() =
+        testApplication {
+            val auth = installAdminAuth()
+            application {
+                install(ContentNegotiation) { json() }
+                handler()
+                configureRoles()
+            }
+
+            val response =
+                client.post("/roles") {
+                    withAuthCookies(auth)
+                    header(HttpHeaders.ContentType, "application/json")
+                    setBody("""{"role":"new-standard-role","isAdmin":false,"permissions":[]}""")
+                }
+
+            assertEquals(HttpStatusCode.Forbidden, response.status)
+        }
+
+    @Test
+    fun `admin with roles create permission can create a role atomically`() =
+        testApplication {
+            val auth = installAdminAuth()
+            grantPermission("admin-test-role", "roles_create")
+            ExposedTestDb.seedPermission("users_read")
+            application {
+                install(ContentNegotiation) { json() }
+                handler()
+                configureRoles()
+            }
+
+            val response =
+                client.post("/roles") {
+                    withAuthCookies(auth)
+                    header(HttpHeaders.ContentType, "application/json")
+                    setBody("""{"role":"new-standard-role","isAdmin":false,"permissions":["users_read"]}""")
+                }
+
+            assertEquals(HttpStatusCode.Created, response.status)
+        }
+
+    @Test
+    fun `non admin with permissions read cannot access permission catalog`() =
+        testApplication {
+            val auth = installNonAdminAuth()
+            grantPermission("non-admin-test-role", "permissions_read")
+            application {
+                install(ContentNegotiation) { json() }
+                handler()
+                configurePermissions()
+            }
+
+            val response = client.get("/permissions") { withAuthCookies(auth) }
+
+            assertEquals(HttpStatusCode.Forbidden, response.status)
+        }
+
+    @Test
+    fun `admin with permissions read can access permission catalog`() =
+        testApplication {
+            val auth = installAdminAuth()
+            grantPermission("admin-test-role", "permissions_read")
+            application {
+                install(ContentNegotiation) { json() }
+                handler()
+                configurePermissions()
+            }
+
+            val response = client.get("/permissions") { withAuthCookies(auth) }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+        }
+
+    @Test
+    fun `non admin with roles update cannot replace role permissions`() =
+        testApplication {
+            val auth = installNonAdminAuth()
+            grantPermission("non-admin-test-role", "roles_update")
+            val targetRoleId = ExposedTestDb.seedRole("target-role")
+            application {
+                install(ContentNegotiation) { json() }
+                handler()
+                configureRoles()
+            }
+
+            val response =
+                client.put("/roles/$targetRoleId/permissions") {
+                    withAuthCookies(auth)
+                    header(HttpHeaders.ContentType, "application/json")
+                    setBody("""{"permissions":["roles_create"]}""")
+                }
+
+            assertEquals(HttpStatusCode.Forbidden, response.status)
+        }
+
+    @Test
+    fun `non admin with roles delete cannot delete a role`() =
+        testApplication {
+            val auth = installNonAdminAuth()
+            grantPermission("non-admin-test-role", "roles_delete")
+            val targetRoleId = ExposedTestDb.seedRole("target-role")
+            application {
+                install(ContentNegotiation) { json() }
+                handler()
+                configureRoles()
+            }
+
+            val response = client.delete("/roles/$targetRoleId") { withAuthCookies(auth) }
 
             assertEquals(HttpStatusCode.Forbidden, response.status)
         }

--- a/server/e2e_tests_py/tests/test_inventory_permissions_e2e.py
+++ b/server/e2e_tests_py/tests/test_inventory_permissions_e2e.py
@@ -9,6 +9,7 @@ from ambrosia.api_utils import assert_status_code
 logger = logging.getLogger(__name__)
 
 DUMMY_ID = "00000000-0000-0000-0000-000000000000"
+BASELINE_PERMISSIONS = ["wallet_read"]
 
 
 async def assert_permission_gate(client_factory, method, path, permission, body=None):
@@ -18,7 +19,7 @@ async def assert_permission_gate(client_factory, method, path, permission, body=
         if body is not None and method in ("post", "put", "patch")
         else {}
     )
-    no_perm = await client_factory(permissions=["permissions_read"])
+    no_perm = await client_factory(permissions=BASELINE_PERMISSIONS)
     assert_status_code(await getattr(no_perm, method)(path, **kwargs), 403)
 
     with_perm = await client_factory(permissions=[permission])
@@ -31,7 +32,7 @@ class TestCategoriesPermissions:
     @pytest.mark.asyncio
     async def test_categories_read_required_for_get(self, client_factory):
         """GET /categories returns 403 without categories_read permission."""
-        no_perm = await client_factory(permissions=["permissions_read"])
+        no_perm = await client_factory(permissions=BASELINE_PERMISSIONS)
         assert_status_code(await no_perm.get("/categories"), 403)
 
         with_perm = await client_factory(permissions=["categories_read"])
@@ -41,7 +42,7 @@ class TestCategoriesPermissions:
     @pytest.mark.asyncio
     async def test_categories_create_required_for_post(self, client_factory):
         """POST /categories returns 403 without categories_create permission."""
-        no_perm = await client_factory(permissions=["permissions_read"])
+        no_perm = await client_factory(permissions=BASELINE_PERMISSIONS)
         assert_status_code(
             await no_perm.post("/categories", json={"name": "x", "type": "dish"}), 403
         )
@@ -55,7 +56,7 @@ class TestCategoriesPermissions:
     @pytest.mark.asyncio
     async def test_categories_update_required_for_put(self, client_factory):
         """PUT /categories/{id} returns 403 without categories_update permission."""
-        no_perm = await client_factory(permissions=["permissions_read"])
+        no_perm = await client_factory(permissions=BASELINE_PERMISSIONS)
         assert_status_code(
             await no_perm.put(
                 f"/categories/{DUMMY_ID}", json={"name": "x", "type": "dish"}
@@ -74,7 +75,7 @@ class TestCategoriesPermissions:
     @pytest.mark.asyncio
     async def test_categories_delete_required_for_delete(self, client_factory):
         """DELETE /categories/{id} returns 403 without categories_delete permission."""
-        no_perm = await client_factory(permissions=["permissions_read"])
+        no_perm = await client_factory(permissions=BASELINE_PERMISSIONS)
         assert_status_code(await no_perm.delete(f"/categories/{DUMMY_ID}"), 403)
 
         with_perm = await client_factory(permissions=["categories_delete"])
@@ -88,7 +89,7 @@ class TestIngredientsPermissions:
     @pytest.mark.asyncio
     async def test_ingredients_read_required_for_get(self, client_factory):
         """GET /ingredients returns 403 without ingredients_read permission."""
-        no_perm = await client_factory(permissions=["permissions_read"])
+        no_perm = await client_factory(permissions=BASELINE_PERMISSIONS)
         assert_status_code(await no_perm.get("/ingredients"), 403)
 
         with_perm = await client_factory(permissions=["ingredients_read"])
@@ -98,7 +99,7 @@ class TestIngredientsPermissions:
     @pytest.mark.asyncio
     async def test_ingredients_create_required_for_post(self, client_factory):
         """POST /ingredients returns 403 without ingredients_create permission."""
-        no_perm = await client_factory(permissions=["permissions_read"])
+        no_perm = await client_factory(permissions=BASELINE_PERMISSIONS)
         assert_status_code(await no_perm.post("/ingredients", json={}), 403)
 
         with_perm = await client_factory(permissions=["ingredients_create"])
@@ -108,7 +109,7 @@ class TestIngredientsPermissions:
     @pytest.mark.asyncio
     async def test_ingredients_update_required_for_put(self, client_factory):
         """PUT /ingredients/{id} returns 403 without ingredients_update permission."""
-        no_perm = await client_factory(permissions=["permissions_read"])
+        no_perm = await client_factory(permissions=BASELINE_PERMISSIONS)
         assert_status_code(await no_perm.put(f"/ingredients/{DUMMY_ID}", json={}), 403)
 
         with_perm = await client_factory(permissions=["ingredients_update"])
@@ -120,7 +121,7 @@ class TestIngredientsPermissions:
     @pytest.mark.asyncio
     async def test_ingredients_delete_required_for_delete(self, client_factory):
         """DELETE /ingredients/{id} returns 403 without ingredients_delete permission."""
-        no_perm = await client_factory(permissions=["permissions_read"])
+        no_perm = await client_factory(permissions=BASELINE_PERMISSIONS)
         assert_status_code(await no_perm.delete(f"/ingredients/{DUMMY_ID}"), 403)
 
         with_perm = await client_factory(permissions=["ingredients_delete"])
@@ -134,7 +135,7 @@ class TestProductsPermissions:
     @pytest.mark.asyncio
     async def test_products_read_required_for_get(self, client_factory):
         """GET /products returns 403 without products_read permission."""
-        no_perm = await client_factory(permissions=["permissions_read"])
+        no_perm = await client_factory(permissions=BASELINE_PERMISSIONS)
         assert_status_code(await no_perm.get("/products"), 403)
 
         with_perm = await client_factory(permissions=["products_read"])
@@ -238,7 +239,7 @@ class TestProductsPermissions:
     @pytest.mark.asyncio
     async def test_products_create_required_for_post(self, client_factory):
         """POST /products returns 403 without products_create permission."""
-        no_perm = await client_factory(permissions=["permissions_read"])
+        no_perm = await client_factory(permissions=BASELINE_PERMISSIONS)
         assert_status_code(await no_perm.post("/products", json={}), 403)
 
         with_perm = await client_factory(permissions=["products_create"])
@@ -248,7 +249,7 @@ class TestProductsPermissions:
     @pytest.mark.asyncio
     async def test_products_update_required_for_put(self, client_factory):
         """PUT /products/{id} returns 403 without products_update permission."""
-        no_perm = await client_factory(permissions=["permissions_read"])
+        no_perm = await client_factory(permissions=BASELINE_PERMISSIONS)
         assert_status_code(await no_perm.put(f"/products/{DUMMY_ID}", json={}), 403)
 
         with_perm = await client_factory(permissions=["products_update"])
@@ -260,7 +261,7 @@ class TestProductsPermissions:
     @pytest.mark.asyncio
     async def test_products_delete_required_for_delete(self, client_factory):
         """DELETE /products/{id} returns 403 without products_delete permission."""
-        no_perm = await client_factory(permissions=["permissions_read"])
+        no_perm = await client_factory(permissions=BASELINE_PERMISSIONS)
         assert_status_code(await no_perm.delete(f"/products/{DUMMY_ID}"), 403)
 
         with_perm = await client_factory(permissions=["products_delete"])

--- a/server/e2e_tests_py/tests/test_operations_permissions_e2e.py
+++ b/server/e2e_tests_py/tests/test_operations_permissions_e2e.py
@@ -9,6 +9,7 @@ from ambrosia.api_utils import assert_status_code
 logger = logging.getLogger(__name__)
 
 DUMMY_ID = "00000000-0000-0000-0000-000000000000"
+BASELINE_PERMISSIONS = ["wallet_read"]
 
 
 class TestPaymentsPermissions:
@@ -17,7 +18,7 @@ class TestPaymentsPermissions:
     @pytest.mark.asyncio
     async def test_payments_read_required_for_get(self, client_factory):
         """GET /payments returns 403 without payments_read permission."""
-        no_perm = await client_factory(permissions=["permissions_read"])
+        no_perm = await client_factory(permissions=BASELINE_PERMISSIONS)
         assert_status_code(await no_perm.get("/payments"), 403)
 
         with_perm = await client_factory(permissions=["payments_read"])
@@ -27,7 +28,7 @@ class TestPaymentsPermissions:
     @pytest.mark.asyncio
     async def test_payments_create_required_for_post(self, client_factory):
         """POST /payments returns 403 without payments_create permission."""
-        no_perm = await client_factory(permissions=["permissions_read"])
+        no_perm = await client_factory(permissions=BASELINE_PERMISSIONS)
         assert_status_code(await no_perm.post("/payments", json={}), 403)
 
         with_perm = await client_factory(permissions=["payments_create"])
@@ -37,7 +38,7 @@ class TestPaymentsPermissions:
     @pytest.mark.asyncio
     async def test_payments_update_required_for_put(self, client_factory):
         """PUT /payments/{id} returns 403 without payments_update permission."""
-        no_perm = await client_factory(permissions=["permissions_read"])
+        no_perm = await client_factory(permissions=BASELINE_PERMISSIONS)
         assert_status_code(await no_perm.put(f"/payments/{DUMMY_ID}", json={}), 403)
 
         with_perm = await client_factory(permissions=["payments_update"])
@@ -49,7 +50,7 @@ class TestPaymentsPermissions:
     @pytest.mark.asyncio
     async def test_payments_delete_required_for_delete(self, client_factory):
         """DELETE /payments/{id} returns 403 without payments_delete permission."""
-        no_perm = await client_factory(permissions=["permissions_read"])
+        no_perm = await client_factory(permissions=BASELINE_PERMISSIONS)
         assert_status_code(await no_perm.delete(f"/payments/{DUMMY_ID}"), 403)
 
         with_perm = await client_factory(permissions=["payments_delete"])
@@ -63,7 +64,7 @@ class TestSuppliersPermissions:
     @pytest.mark.asyncio
     async def test_suppliers_read_required_for_get(self, client_factory):
         """GET /suppliers returns 403 without suppliers_read permission."""
-        no_perm = await client_factory(permissions=["permissions_read"])
+        no_perm = await client_factory(permissions=BASELINE_PERMISSIONS)
         assert_status_code(await no_perm.get("/suppliers"), 403)
 
         with_perm = await client_factory(permissions=["suppliers_read"])
@@ -73,7 +74,7 @@ class TestSuppliersPermissions:
     @pytest.mark.asyncio
     async def test_suppliers_create_required_for_post(self, client_factory):
         """POST /suppliers returns 403 without suppliers_create permission."""
-        no_perm = await client_factory(permissions=["permissions_read"])
+        no_perm = await client_factory(permissions=BASELINE_PERMISSIONS)
         assert_status_code(await no_perm.post("/suppliers", json={}), 403)
 
         with_perm = await client_factory(permissions=["suppliers_create"])
@@ -83,7 +84,7 @@ class TestSuppliersPermissions:
     @pytest.mark.asyncio
     async def test_suppliers_update_required_for_put(self, client_factory):
         """PUT /suppliers/{id} returns 403 without suppliers_update permission."""
-        no_perm = await client_factory(permissions=["permissions_read"])
+        no_perm = await client_factory(permissions=BASELINE_PERMISSIONS)
         assert_status_code(await no_perm.put(f"/suppliers/{DUMMY_ID}", json={}), 403)
 
         with_perm = await client_factory(permissions=["suppliers_update"])
@@ -95,7 +96,7 @@ class TestSuppliersPermissions:
     @pytest.mark.asyncio
     async def test_suppliers_delete_required_for_delete(self, client_factory):
         """DELETE /suppliers/{id} returns 403 without suppliers_delete permission."""
-        no_perm = await client_factory(permissions=["permissions_read"])
+        no_perm = await client_factory(permissions=BASELINE_PERMISSIONS)
         assert_status_code(await no_perm.delete(f"/suppliers/{DUMMY_ID}"), 403)
 
         with_perm = await client_factory(permissions=["suppliers_delete"])
@@ -109,7 +110,7 @@ class TestSpacesPermissions:
     @pytest.mark.asyncio
     async def test_spaces_read_required_for_get(self, client_factory):
         """GET /spaces returns 403 without spaces_read permission."""
-        no_perm = await client_factory(permissions=["permissions_read"])
+        no_perm = await client_factory(permissions=BASELINE_PERMISSIONS)
         assert_status_code(await no_perm.get("/spaces"), 403)
 
         with_perm = await client_factory(permissions=["spaces_read"])
@@ -119,7 +120,7 @@ class TestSpacesPermissions:
     @pytest.mark.asyncio
     async def test_spaces_create_required_for_post(self, client_factory):
         """POST /spaces returns 403 without spaces_create permission."""
-        no_perm = await client_factory(permissions=["permissions_read"])
+        no_perm = await client_factory(permissions=BASELINE_PERMISSIONS)
         assert_status_code(await no_perm.post("/spaces", json={}), 403)
 
         with_perm = await client_factory(permissions=["spaces_create"])
@@ -129,7 +130,7 @@ class TestSpacesPermissions:
     @pytest.mark.asyncio
     async def test_spaces_update_required_for_put(self, client_factory):
         """PUT /spaces/{id} returns 403 without spaces_update permission."""
-        no_perm = await client_factory(permissions=["permissions_read"])
+        no_perm = await client_factory(permissions=BASELINE_PERMISSIONS)
         assert_status_code(await no_perm.put(f"/spaces/{DUMMY_ID}", json={}), 403)
 
         with_perm = await client_factory(permissions=["spaces_update"])
@@ -139,7 +140,7 @@ class TestSpacesPermissions:
     @pytest.mark.asyncio
     async def test_spaces_delete_required_for_delete(self, client_factory):
         """DELETE /spaces/{id} returns 403 without spaces_delete permission."""
-        no_perm = await client_factory(permissions=["permissions_read"])
+        no_perm = await client_factory(permissions=BASELINE_PERMISSIONS)
         assert_status_code(await no_perm.delete(f"/spaces/{DUMMY_ID}"), 403)
 
         with_perm = await client_factory(permissions=["spaces_delete"])
@@ -153,7 +154,7 @@ class TestTablesPermissions:
     @pytest.mark.asyncio
     async def test_tables_read_required_for_get(self, client_factory):
         """GET /tables returns 403 without tables_read permission."""
-        no_perm = await client_factory(permissions=["permissions_read"])
+        no_perm = await client_factory(permissions=BASELINE_PERMISSIONS)
         assert_status_code(await no_perm.get("/tables"), 403)
 
         with_perm = await client_factory(permissions=["tables_read"])
@@ -163,7 +164,7 @@ class TestTablesPermissions:
     @pytest.mark.asyncio
     async def test_tables_create_required_for_post(self, client_factory):
         """POST /tables returns 403 without tables_create permission."""
-        no_perm = await client_factory(permissions=["permissions_read"])
+        no_perm = await client_factory(permissions=BASELINE_PERMISSIONS)
         assert_status_code(await no_perm.post("/tables", json={}), 403)
 
         with_perm = await client_factory(permissions=["tables_create"])
@@ -173,7 +174,7 @@ class TestTablesPermissions:
     @pytest.mark.asyncio
     async def test_tables_update_required_for_put(self, client_factory):
         """PUT /tables/{id} returns 403 without tables_update permission."""
-        no_perm = await client_factory(permissions=["permissions_read"])
+        no_perm = await client_factory(permissions=BASELINE_PERMISSIONS)
         assert_status_code(await no_perm.put(f"/tables/{DUMMY_ID}", json={}), 403)
 
         with_perm = await client_factory(permissions=["tables_update"])
@@ -183,7 +184,7 @@ class TestTablesPermissions:
     @pytest.mark.asyncio
     async def test_tables_delete_required_for_delete(self, client_factory):
         """DELETE /tables/{id} returns 403 without tables_delete permission."""
-        no_perm = await client_factory(permissions=["permissions_read"])
+        no_perm = await client_factory(permissions=BASELINE_PERMISSIONS)
         assert_status_code(await no_perm.delete(f"/tables/{DUMMY_ID}"), 403)
 
         with_perm = await client_factory(permissions=["tables_delete"])
@@ -197,7 +198,7 @@ class TestShiftsPermissions:
     @pytest.mark.asyncio
     async def test_shifts_read_required_for_get(self, client_factory):
         """GET /shifts returns 403 without shifts_read permission."""
-        no_perm = await client_factory(permissions=["permissions_read"])
+        no_perm = await client_factory(permissions=BASELINE_PERMISSIONS)
         assert_status_code(await no_perm.get("/shifts"), 403)
 
         with_perm = await client_factory(permissions=["shifts_read"])
@@ -207,7 +208,7 @@ class TestShiftsPermissions:
     @pytest.mark.asyncio
     async def test_shifts_create_required_for_post(self, client_factory):
         """POST /shifts returns 403 without shifts_create permission."""
-        no_perm = await client_factory(permissions=["permissions_read"])
+        no_perm = await client_factory(permissions=BASELINE_PERMISSIONS)
         assert_status_code(await no_perm.post("/shifts", json={}), 403)
 
         with_perm = await client_factory(permissions=["shifts_create"])
@@ -217,7 +218,7 @@ class TestShiftsPermissions:
     @pytest.mark.asyncio
     async def test_shifts_update_required_for_put(self, client_factory):
         """PUT /shifts/{id} returns 403 without shifts_update permission."""
-        no_perm = await client_factory(permissions=["permissions_read"])
+        no_perm = await client_factory(permissions=BASELINE_PERMISSIONS)
         assert_status_code(await no_perm.put(f"/shifts/{DUMMY_ID}", json={}), 403)
 
         with_perm = await client_factory(permissions=["shifts_update"])
@@ -227,7 +228,7 @@ class TestShiftsPermissions:
     @pytest.mark.asyncio
     async def test_shifts_delete_required_for_delete(self, client_factory):
         """DELETE /shifts/{id} returns 403 without shifts_delete permission."""
-        no_perm = await client_factory(permissions=["permissions_read"])
+        no_perm = await client_factory(permissions=BASELINE_PERMISSIONS)
         assert_status_code(await no_perm.delete(f"/shifts/{DUMMY_ID}"), 403)
 
         with_perm = await client_factory(permissions=["shifts_delete"])

--- a/server/e2e_tests_py/tests/test_roles_users_permissions_e2e.py
+++ b/server/e2e_tests_py/tests/test_roles_users_permissions_e2e.py
@@ -9,6 +9,7 @@ from ambrosia.api_utils import assert_status_code
 logger = logging.getLogger(__name__)
 
 DUMMY_ID = "00000000-0000-0000-0000-000000000000"
+BASELINE_PERMISSIONS = ["wallet_read"]
 
 
 class TestRolesPermissions:
@@ -17,7 +18,7 @@ class TestRolesPermissions:
     @pytest.mark.asyncio
     async def test_roles_read_required_for_get(self, client_factory):
         """GET /roles returns 403 without roles_read permission."""
-        no_perm = await client_factory(permissions=["permissions_read"])
+        no_perm = await client_factory(permissions=BASELINE_PERMISSIONS)
         response = await no_perm.get("/roles")
         assert_status_code(response, 403, "GET /roles should require roles_read")
 
@@ -27,44 +28,55 @@ class TestRolesPermissions:
         logger.info("✓ roles_read correctly gates GET /roles")
 
     @pytest.mark.asyncio
-    async def test_roles_create_required_for_post(self, client_factory):
-        """POST /roles returns 403 without roles_create permission."""
-        no_perm = await client_factory(permissions=["permissions_read"])
+    async def test_roles_create_requires_admin(self, client_factory, admin_client):
+        """POST /roles requires admin even when roles_create is requested."""
+        no_perm = await client_factory(permissions=BASELINE_PERMISSIONS)
         response = await no_perm.post("/roles", json={"role": "test_role"})
         assert_status_code(response, 403, "POST /roles should require roles_create")
 
-        with_perm = await client_factory(permissions=["roles_create"])
-        response = await with_perm.post("/roles", json={"role": "test_role"})
-        assert response.status_code != 403, "roles_create should allow POST /roles"
-        logger.info("✓ roles_create correctly gates POST /roles")
+        non_admin = await client_factory(permissions=["roles_create", "wallet_read"])
+        response = await non_admin.post("/roles", json={"role": "test_role"})
+        assert_status_code(response, 403, "roles_create must remain admin-only")
+
+        response = await admin_client.post("/roles", json={"role": "test_role"})
+        assert response.status_code != 403, "admin should be allowed to POST /roles"
+        logger.info("✓ POST /roles correctly requires admin access")
 
     @pytest.mark.asyncio
-    async def test_roles_update_required_for_put(self, client_factory):
-        """PUT /roles/{id} returns 403 without roles_update permission."""
-        no_perm = await client_factory(permissions=["permissions_read"])
+    async def test_roles_update_requires_admin(self, client_factory, admin_client):
+        """PUT /roles/{id} requires admin even when roles_update is requested."""
+        no_perm = await client_factory(permissions=BASELINE_PERMISSIONS)
         response = await no_perm.put(f"/roles/{DUMMY_ID}", json={"role": "updated"})
         assert_status_code(response, 403, "PUT /roles/{id} should require roles_update")
 
-        with_perm = await client_factory(permissions=["roles_update"])
-        response = await with_perm.put(f"/roles/{DUMMY_ID}", json={"role": "updated"})
-        assert response.status_code != 403, "roles_update should allow PUT /roles/{id}"
-        logger.info("✓ roles_update correctly gates PUT /roles/{id}")
+        non_admin = await client_factory(permissions=["roles_update", "wallet_read"])
+        response = await non_admin.put(f"/roles/{DUMMY_ID}", json={"role": "updated"})
+        assert_status_code(response, 403, "roles_update must remain admin-only")
+
+        response = await admin_client.put(
+            f"/roles/{DUMMY_ID}", json={"role": "updated"}
+        )
+        assert response.status_code != 403, "admin should be allowed to PUT /roles/{id}"
+        logger.info("✓ PUT /roles/{id} correctly requires admin access")
 
     @pytest.mark.asyncio
-    async def test_roles_delete_required_for_delete(self, client_factory):
-        """DELETE /roles/{id} returns 403 without roles_delete permission."""
-        no_perm = await client_factory(permissions=["permissions_read"])
+    async def test_roles_delete_requires_admin(self, client_factory, admin_client):
+        """DELETE /roles/{id} requires admin even when roles_delete is requested."""
+        no_perm = await client_factory(permissions=BASELINE_PERMISSIONS)
         response = await no_perm.delete(f"/roles/{DUMMY_ID}")
         assert_status_code(
             response, 403, "DELETE /roles/{id} should require roles_delete"
         )
 
-        with_perm = await client_factory(permissions=["roles_delete"])
-        response = await with_perm.delete(f"/roles/{DUMMY_ID}")
+        non_admin = await client_factory(permissions=["roles_delete", "wallet_read"])
+        response = await non_admin.delete(f"/roles/{DUMMY_ID}")
+        assert_status_code(response, 403, "roles_delete must remain admin-only")
+
+        response = await admin_client.delete(f"/roles/{DUMMY_ID}")
         assert response.status_code != 403, (
-            "roles_delete should allow DELETE /roles/{id}"
+            "admin should be allowed to DELETE /roles/{id}"
         )
-        logger.info("✓ roles_delete correctly gates DELETE /roles/{id}")
+        logger.info("✓ DELETE /roles/{id} correctly requires admin access")
 
 
 class TestUsersPermissions:
@@ -73,7 +85,7 @@ class TestUsersPermissions:
     @pytest.mark.asyncio
     async def test_users_create_required_for_post(self, client_factory):
         """POST /users returns 403 without users_create permission."""
-        no_perm = await client_factory(permissions=["permissions_read"])
+        no_perm = await client_factory(permissions=BASELINE_PERMISSIONS)
         response = await no_perm.post(
             "/users", json={"name": "x", "pin": "0000", "role": DUMMY_ID}
         )
@@ -89,7 +101,7 @@ class TestUsersPermissions:
     @pytest.mark.asyncio
     async def test_users_update_required_for_put(self, client_factory):
         """PUT /users/{id} returns 403 without users_update permission."""
-        no_perm = await client_factory(permissions=["permissions_read"])
+        no_perm = await client_factory(permissions=BASELINE_PERMISSIONS)
         response = await no_perm.put(
             f"/users/{DUMMY_ID}", json={"name": "x", "pin": "0000"}
         )
@@ -105,7 +117,7 @@ class TestUsersPermissions:
     @pytest.mark.asyncio
     async def test_users_delete_required_for_delete(self, client_factory):
         """DELETE /users/{id} returns 403 without users_delete permission."""
-        no_perm = await client_factory(permissions=["permissions_read"])
+        no_perm = await client_factory(permissions=BASELINE_PERMISSIONS)
         response = await no_perm.delete(f"/users/{DUMMY_ID}")
         assert_status_code(
             response, 403, "DELETE /users/{id} should require users_delete"


### PR DESCRIPTION
## Summary

This PR strengthens role and permission management by enforcing administrator-only operations across the backend and frontend.

- Requires both administrator access and the corresponding permission to create, update, or delete roles.
- Restricts access to the permission catalog to authorized administrators.
- Prevents non-admin roles from receiving administrator-only permissions.
- Automatically assigns every enabled permission to administrator roles.
- Creates and updates roles together with their permissions in a single transaction.
- Rolls back role changes if permission persistence fails.
- Keeps existing permissions when legacy update requests omit the permission list.
- Provides non-admin users with a read-only role view.
- Hides role creation, editing, and deletion controls from non-admin users.
- Avoids requesting the administrator permission catalog for non-admin users.
- Hides administrator-only permissions until the admin checkbox is enabled.
- Clears inherited permissions when administrator privileges are removed.
- Uses backend-provided `adminOnly` metadata as the source of truth.
- Removes redundant `Affects` permission labels from the role editor.

## Screenshots

### Read-only role view

<img width="1374" height="995" alt="image" src="https://github.com/user-attachments/assets/414a3bec-e963-4a43-bd0b-5283a3cc94f6" />

**Mobile**
<img width="390" height="847" alt="image" src="https://github.com/user-attachments/assets/dbc85d04-69f9-453b-a8ce-d6cb338737ee" />

### Administrator role editor

<img width="769" height="656" alt="image" src="https://github.com/user-attachments/assets/d12c9b29-22b7-40a6-8151-7c7875481df6" />

### Limited role editor

<img width="775" height="530" alt="image" src="https://github.com/user-attachments/assets/ec0cb27f-48cb-470e-a89c-db0d3e68a2b6" />

## Testing

### Client

- Role management, permission selector, and permission catalog Jest tests.
- `useRoles` and `usePermissions` hook tests.
- ESLint checks for all modified role management files.

### Server

- `PermissionsServiceTest`
- `RoleServiceTest`
- `UserPrivilegeEscalationRouteTest`
- `./gradlew ktlintCheck`

All executed checks pass successfully. Role creation, role updates, administrator restrictions, permission filtering, and transactional rollback behavior are covered by automated tests.