### PR TITLE
Fix/store permission crash

### DIFF
--- a/client/src/components/pages/Auth/PinLogin/PinLogin.jsx
+++ b/client/src/components/pages/Auth/PinLogin/PinLogin.jsx
@@ -9,7 +9,7 @@ import { useTranslations } from "next-intl";
 
 import { useAuth } from "@/hooks/auth/useAuth";
 import { useConfigurations } from "@/providers/configurations/configurationsProvider";
-import { getUsers } from "@/services/authService";
+import { getPublicUsers } from "@/services/authService";
 
 import { BusinessHeader } from "./BusinessHeader";
 import { EmployeeSelect } from "./EmployeeSelect";
@@ -45,9 +45,9 @@ export default function PinLogin() {
   useEffect(() => {
     async function fetchEmployees() {
       try {
-        const users = await getUsers({ silentAuth: true });
+        const publicUsers = await getPublicUsers();
         setEmployees(
-          users.map((user) => ({
+          publicUsers.map((user) => ({
             ...user,
             avatar: user.name.slice(0, 2),
           })),

--- a/client/src/components/pages/Auth/PinLogin/__tests__/PinLogin.test.jsx
+++ b/client/src/components/pages/Auth/PinLogin/__tests__/PinLogin.test.jsx
@@ -6,7 +6,7 @@ import { act, render, screen, fireEvent } from "@testing-library/react";
 import { useAuth } from "@/hooks/auth/useAuth";
 import { I18nProvider } from "@/i18n/I18nProvider";
 import { useConfigurations } from "@/providers/configurations/configurationsProvider";
-import { getUsers } from "@/services/authService";
+import { getPublicUsers } from "@/services/authService";
 
 import PinLogin from "../PinLogin";
 
@@ -29,7 +29,7 @@ jest.mock("@heroui/react", () => ({
   addToast: jest.fn(),
 }));
 
-jest.mock("@/services/authService", () => ({ getUsers: jest.fn() }));
+jest.mock("@/services/authService", () => ({ getPublicUsers: jest.fn() }));
 jest.mock("@/hooks/auth/useAuth", () => ({ useAuth: jest.fn() }));
 jest.mock("@/providers/configurations/configurationsProvider", () => ({ useConfigurations: jest.fn() }));
 jest.mock("next/navigation", () => ({ useRouter: jest.fn() }));
@@ -58,7 +58,7 @@ beforeEach(() => {
   useRouter.mockReturnValue({ push: jest.fn(), replace: mockReplace });
   useAuth.mockReturnValue({ login: mockLogin, isAuth: false, isLoading: false });
   useConfigurations.mockReturnValue({ config: { businessName: "Test Store", businessLogoUrl: null } });
-  getUsers.mockResolvedValue(employees);
+  getPublicUsers.mockResolvedValue(employees);
 });
 
 describe("PinLogin", () => {
@@ -71,19 +71,19 @@ describe("PinLogin", () => {
 
   it("loads and displays employees from the API", async () => {
     await renderPinLogin();
-    expect(getUsers).toHaveBeenCalledWith({ silentAuth: true });
+    expect(getPublicUsers).toHaveBeenCalledWith();
     expect(screen.getByText("Alice")).toBeInTheDocument();
     expect(screen.getByText("Bob")).toBeInTheDocument();
   });
 
   it("shows no-employees message when API returns empty array", async () => {
-    getUsers.mockResolvedValue([]);
+    getPublicUsers.mockResolvedValue([]);
     await renderPinLogin();
     expect(screen.getByText("noEmployees")).toBeInTheDocument();
   });
 
   it("shows an error toast when employees cannot be loaded", async () => {
-    getUsers.mockRejectedValueOnce(new Error("Users unavailable"));
+    getPublicUsers.mockRejectedValueOnce(new Error("Users unavailable"));
 
     await renderPinLogin();
 

--- a/client/src/components/pages/Store/Cart/Cart.jsx
+++ b/client/src/components/pages/Store/Cart/Cart.jsx
@@ -14,6 +14,7 @@ import { CashPaymentModal } from "./CashPaymentModal";
 import { useCartOperations } from "./hooks/useCartOperations";
 import { useCartPayment } from "./hooks/useCartPayment";
 import { usePersistentCart } from "./hooks/usePersistentCart";
+import { PermissionBlockedState } from "./PermissionBlockedState";
 import { SearchProducts } from "./SearchProducts";
 import { MobileSummaryBar, Summary, SummaryModal } from "./Summary";
 import { usePendingRemoval } from "./Summary/hooks/usePendingRemoval";
@@ -58,8 +59,8 @@ export function Cart() {
     },
     [setDiscount, setDiscountType],
   );
-  const { products, refetch: refetchProducts } = useProducts();
-  const { categories } = useCategories();
+  const { products, forbidden: productsForbidden, refetch: refetchProducts } = useProducts({ skipForbiddenRedirect: true });
+  const { categories, forbidden: categoriesForbidden } = useCategories();
 
   useEffect(() => {
     if (!isCartRestored || products.length === 0) return;
@@ -106,6 +107,7 @@ export function Cart() {
     isPaying,
     paymentError,
     clearPaymentError,
+    paymentsForbidden,
     btcPayment: {
       config: btcPaymentConfig,
       onClose: clearBtcPaymentConfig,
@@ -139,6 +141,21 @@ export function Cart() {
     () => calculateCartTotals(visibleCart, discount).total,
     [visibleCart, discount],
   );
+
+  const missingPermissions = [
+    ...(productsForbidden ? ["products_read"] : []),
+    ...(categoriesForbidden ? ["categories_read"] : []),
+    ...(paymentsForbidden ? ["payments_read"] : []),
+  ];
+
+  if (missingPermissions.length > 0) {
+    return (
+      <div>
+        <PageHeader title={cartTranslations("title")} subtitle={cartTranslations("subtitle")} />
+        <PermissionBlockedState missingPermissions={missingPermissions} />
+      </div>
+    );
+  }
 
   return (
     <div className={`transition-[padding] duration-200 md:pt-0 ${visibleCart.length ? "pt-14" : "pt-0"}`}>

--- a/client/src/components/pages/Store/Cart/PermissionBlockedState.jsx
+++ b/client/src/components/pages/Store/Cart/PermissionBlockedState.jsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { ShieldAlert } from "lucide-react";
+import { useTranslations } from "next-intl";
+
+const PERMISSION_LABEL_KEYS = {
+  products_read: "permissionBlocked.products",
+  categories_read: "permissionBlocked.categories",
+  payments_read: "permissionBlocked.payments",
+};
+
+export function PermissionBlockedState({ missingPermissions = [] }) {
+  const cartTranslations = useTranslations("cart");
+
+  return (
+    <div className="text-center py-12">
+      <ShieldAlert aria-hidden="true" className="w-16 h-16 text-gray-300 mx-auto mb-4" />
+      <h3 className="text-xl font-semibold text-deep mb-2">{cartTranslations("permissionBlocked.title")}</h3>
+      <p className="text-gray-500 mb-4">{cartTranslations("permissionBlocked.subtitle")}</p>
+      <ul className="text-gray-500 list-disc list-inside space-y-1">
+        {missingPermissions.map((permissionKey) => (
+          <li key={permissionKey}>{cartTranslations(PERMISSION_LABEL_KEYS[permissionKey])}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/client/src/components/pages/Store/Cart/__tests__/Cart.test.jsx
+++ b/client/src/components/pages/Store/Cart/__tests__/Cart.test.jsx
@@ -86,12 +86,17 @@ jest.mock("../hooks/usePersistentCart", () => ({
   }),
 }));
 
+let mockProductsForbidden = false;
+let mockCategoriesForbidden = false;
+let mockPaymentsForbidden = false;
+
 jest.mock("../../hooks/useProducts", () => ({
   useProducts: () => ({
     products: [
       { id: 1, quantity: 5, priceCents: 100 },
       { id: 2, quantity: 5, priceCents: 200 },
     ],
+    forbidden: mockProductsForbidden,
     refetch: jest.fn(),
   }),
 }));
@@ -99,6 +104,7 @@ jest.mock("../../hooks/useProducts", () => ({
 jest.mock("../../hooks/useCategories", () => ({
   useCategories: () => ({
     categories: [],
+    forbidden: mockCategoriesForbidden,
   }),
 }));
 
@@ -108,6 +114,7 @@ jest.mock("../hooks/useCartPayment", () => ({
     isPaying: false,
     paymentError: "",
     clearPaymentError: jest.fn(),
+    paymentsForbidden: mockPaymentsForbidden,
     btcPayment: {
       config: null,
       onInvoiceReady: jest.fn(),
@@ -164,6 +171,10 @@ beforeEach(() => {
   };
 
   jest.clearAllMocks();
+
+  mockProductsForbidden = false;
+  mockCategoriesForbidden = false;
+  mockPaymentsForbidden = false;
 
   jest.spyOn(useNavigationHook, "useNavigation").mockReturnValue({
     availableFeatures: {},
@@ -281,5 +292,52 @@ describe("Cart page", () => {
 
     fireEvent.click(screen.getByText("clear"));
     expect(mockClearCart).toHaveBeenCalled();
+  });
+
+  it("shows the permission-blocked message instead of the cart when products are forbidden", async () => {
+    mockProductsForbidden = true;
+
+    await act(async () => {
+      renderCart();
+    });
+
+    expect(screen.getByText("permissionBlocked.title")).toBeInTheDocument();
+    expect(screen.getByText("permissionBlocked.products")).toBeInTheDocument();
+    expect(screen.queryByText("add-existing")).not.toBeInTheDocument();
+  });
+
+  it("shows the permission-blocked message when categories are forbidden", async () => {
+    mockCategoriesForbidden = true;
+
+    await act(async () => {
+      renderCart();
+    });
+
+    expect(screen.getByText("permissionBlocked.title")).toBeInTheDocument();
+    expect(screen.getByText("permissionBlocked.categories")).toBeInTheDocument();
+  });
+
+  it("shows the permission-blocked message when payments are forbidden", async () => {
+    mockPaymentsForbidden = true;
+
+    await act(async () => {
+      renderCart();
+    });
+
+    expect(screen.getByText("permissionBlocked.title")).toBeInTheDocument();
+    expect(screen.getByText("permissionBlocked.payments")).toBeInTheDocument();
+  });
+
+  it("lists every missing permission when more than one is forbidden", async () => {
+    mockProductsForbidden = true;
+    mockPaymentsForbidden = true;
+
+    await act(async () => {
+      renderCart();
+    });
+
+    expect(screen.getByText("permissionBlocked.products")).toBeInTheDocument();
+    expect(screen.getByText("permissionBlocked.payments")).toBeInTheDocument();
+    expect(screen.queryByText("permissionBlocked.categories")).not.toBeInTheDocument();
   });
 });

--- a/client/src/components/pages/Store/Cart/__tests__/Cart.test.jsx
+++ b/client/src/components/pages/Store/Cart/__tests__/Cart.test.jsx
@@ -294,7 +294,7 @@ describe("Cart page", () => {
     expect(mockClearCart).toHaveBeenCalled();
   });
 
-  it("shows the permission-blocked message instead of the cart when products are forbidden", async () => {
+  it("shows the permission-blocked message when products are forbidden", async () => {
     mockProductsForbidden = true;
 
     await act(async () => {

--- a/client/src/components/pages/Store/Cart/__tests__/PermissionBlockedState.test.jsx
+++ b/client/src/components/pages/Store/Cart/__tests__/PermissionBlockedState.test.jsx
@@ -1,0 +1,28 @@
+import { render, screen } from "@testing-library/react";
+
+import { PermissionBlockedState } from "../PermissionBlockedState";
+
+describe("PermissionBlockedState", () => {
+  it("always shows the title and subtitle", () => {
+    render(<PermissionBlockedState missingPermissions={["products_read"]} />);
+
+    expect(screen.getByText("permissionBlocked.title")).toBeInTheDocument();
+    expect(screen.getByText("permissionBlocked.subtitle")).toBeInTheDocument();
+  });
+
+  it("lists a label for each missing permission", () => {
+    render(<PermissionBlockedState missingPermissions={["products_read", "categories_read", "payments_read"]} />);
+
+    expect(screen.getByText("permissionBlocked.products")).toBeInTheDocument();
+    expect(screen.getByText("permissionBlocked.categories")).toBeInTheDocument();
+    expect(screen.getByText("permissionBlocked.payments")).toBeInTheDocument();
+  });
+
+  it("renders no list items when nothing is missing", () => {
+    render(<PermissionBlockedState missingPermissions={[]} />);
+
+    expect(screen.queryByText("permissionBlocked.products")).not.toBeInTheDocument();
+    expect(screen.queryByText("permissionBlocked.categories")).not.toBeInTheDocument();
+    expect(screen.queryByText("permissionBlocked.payments")).not.toBeInTheDocument();
+  });
+});

--- a/client/src/components/pages/Store/Cart/hooks/__tests__/useCartPayment.test.jsx
+++ b/client/src/components/pages/Store/Cart/hooks/__tests__/useCartPayment.test.jsx
@@ -40,7 +40,7 @@ jest.mock("@/hooks/auth/useAuth", () => ({
 jest.mock("@/components/hooks/useCurrency", () => ({
   useCurrency: () => ({
     currency: { id: "cur-1", acronym: "MXN" },
-    formatAmount: (value) => `fmt-${value}`,
+    formatAmount: (amount) => `fmt-${amount}`,
   }),
 }));
 

--- a/client/src/components/pages/Store/Cart/hooks/__tests__/useCartPayment.test.jsx
+++ b/client/src/components/pages/Store/Cart/hooks/__tests__/useCartPayment.test.jsx
@@ -14,6 +14,8 @@ import { httpClient, parseJsonResponse } from "@/lib/http";
 import { useCartPayment } from "../useCartPayment";
 
 let mockPaymentMethods;
+let mockPaymentMethodsForbidden;
+let mockPaymentCurrencyForbidden;
 
 jest.mock("@heroui/react", () => ({
   addToast: jest.fn(),
@@ -45,12 +47,14 @@ jest.mock("@/components/hooks/useCurrency", () => ({
 jest.mock("../usePaymentMethod", () => ({
   usePaymentMethods: () => ({
     paymentMethods: mockPaymentMethods,
+    forbidden: mockPaymentMethodsForbidden,
   }),
 }));
 
-jest.mock("../../../hooks/usePayments", () => ({
-  usePayments: () => ({
+jest.mock("../../../hooks/usePaymentCurrency", () => ({
+  usePaymentCurrency: () => ({
     getPaymentCurrencyById: jest.fn(() => Promise.resolve({ acronym: "USD" })),
+    forbidden: mockPaymentCurrencyForbidden,
   }),
 }));
 
@@ -68,6 +72,8 @@ describe("useCartPayment", () => {
       { id: "btc", name: "BTC" },
       { id: "cash", name: "Cash" },
     ];
+    mockPaymentMethodsForbidden = false;
+    mockPaymentCurrencyForbidden = false;
 
     addToast.mockClear();
     getCompletedCheckouts.mockReset().mockResolvedValue([]);
@@ -179,6 +185,26 @@ describe("useCartPayment", () => {
     const { result } = renderHook(() => useCartPayment());
 
     expect(typeof result.current.handlePay).toBe("function");
+  });
+
+  it("reports paymentsForbidden when payment methods are forbidden", () => {
+    mockPaymentMethodsForbidden = true;
+    const { result } = renderHook(() => useCartPayment());
+
+    expect(result.current.paymentsForbidden).toBe(true);
+  });
+
+  it("reports paymentsForbidden when payment currency is forbidden", () => {
+    mockPaymentCurrencyForbidden = true;
+    const { result } = renderHook(() => useCartPayment());
+
+    expect(result.current.paymentsForbidden).toBe(true);
+  });
+
+  it("reports paymentsForbidden as false when neither is forbidden", () => {
+    const { result } = renderHook(() => useCartPayment());
+
+    expect(result.current.paymentsForbidden).toBe(false);
   });
 
   describe("BTC checkout recovery", () => {

--- a/client/src/components/pages/Store/Cart/hooks/__tests__/usePaymentMethod.test.jsx
+++ b/client/src/components/pages/Store/Cart/hooks/__tests__/usePaymentMethod.test.jsx
@@ -9,17 +9,23 @@ jest.mock("@/lib/http", () => ({
   parseJsonResponse: jest.fn(),
 }));
 
+let mockCanReadPaymentMethods = true;
+jest.mock("@/hooks/usePermission", () => ({
+  usePermission: () => mockCanReadPaymentMethods,
+}));
+
 jest.mock("@heroui/react", () => ({
   addToast: jest.fn(),
 }));
 
 function TestComponent() {
-  const { paymentMethods, loading, error } = usePaymentMethods();
+  const { paymentMethods, loading, error, forbidden } = usePaymentMethods();
   return (
     <div>
       <span data-testid="loading">{loading ? "yes" : "no"}</span>
       <span data-testid="count">{paymentMethods.length}</span>
       <span data-testid="error">{error ? "yes" : "no"}</span>
+      <span data-testid="forbidden">{forbidden ? "yes" : "no"}</span>
     </div>
   );
 }
@@ -27,6 +33,7 @@ function TestComponent() {
 describe("usePaymentMethods", () => {
   beforeEach(() => {
     jest.resetAllMocks();
+    mockCanReadPaymentMethods = true;
   });
 
   it("loads payment methods when response returns array", async () => {
@@ -56,5 +63,16 @@ describe("usePaymentMethods", () => {
     await waitFor(() => expect(screen.getByTestId("loading")).toHaveTextContent("no"));
     expect(screen.getByTestId("error")).toHaveTextContent("yes");
     console.error.mockRestore();
+  });
+
+  it("does not fetch payment methods when the user lacks payments_read", async () => {
+    mockCanReadPaymentMethods = false;
+
+    render(<TestComponent />);
+
+    await waitFor(() => expect(screen.getByTestId("loading")).toHaveTextContent("no"));
+    expect(screen.getByTestId("count")).toHaveTextContent("0");
+    expect(screen.getByTestId("forbidden")).toHaveTextContent("yes");
+    expect(httpClient).not.toHaveBeenCalled();
   });
 });

--- a/client/src/components/pages/Store/Cart/hooks/useCartPayment.jsx
+++ b/client/src/components/pages/Store/Cart/hooks/useCartPayment.jsx
@@ -7,7 +7,7 @@ import { useCurrency } from "@/components/hooks/useCurrency";
 import { useAuth } from "@/hooks/auth/useAuth";
 import { useTurn } from "@/hooks/turn/useTurn";
 
-import { usePayments } from "../../hooks/usePayments";
+import { usePaymentCurrency } from "../../hooks/usePaymentCurrency";
 import { usePaymentMethods } from "../hooks/usePaymentMethod";
 import {
   ensureCartReady,
@@ -30,8 +30,9 @@ export function useCartPayment({ onPay, onResetCart } = {}) {
   const { currency, formatAmount } = useCurrency();
   const { refreshShiftTickets } = useTurn();
   const { printCustomerReceipt } = useCustomerReceipt();
-  const { paymentMethods } = usePaymentMethods();
-  const { getPaymentCurrencyById } = usePayments();
+  const { paymentMethods, forbidden: paymentMethodsForbidden } = usePaymentMethods();
+  const { getPaymentCurrencyById, forbidden: paymentCurrencyForbidden } = usePaymentCurrency();
+  const paymentsForbidden = paymentMethodsForbidden || paymentCurrencyForbidden;
 
   const { isPaying, paymentError, dispatch, notifyError, notifySuccess, clearPaymentError } = usePaymentState(paymentTranslations);
 
@@ -117,6 +118,7 @@ export function useCartPayment({ onPay, onResetCart } = {}) {
     isPaying,
     paymentError,
     clearPaymentError,
+    paymentsForbidden,
     btcPayment,
     cashPayment,
     cardPayment,

--- a/client/src/components/pages/Store/Cart/hooks/usePaymentMethod.jsx
+++ b/client/src/components/pages/Store/Cart/hooks/usePaymentMethod.jsx
@@ -1,15 +1,18 @@
 "use client";
 import { useState, useEffect, useCallback } from "react";
 
+import { usePermission } from "@/hooks/usePermission";
 import { useFetchList } from "@/lib/http/useFetchList";
 
 export function usePaymentMethods() {
   const { fetchList } = useFetchList();
+  const canRead = usePermission({ allOf: ["payments_read"] });
   const [paymentMethods, setPaymentMethods] = useState([]);
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(canRead);
   const [error, setError] = useState(null);
 
   const fetchPaymentMethods = useCallback(async () => {
+    if (!canRead) return;
     setLoading(true);
     setError(null);
 
@@ -26,13 +29,13 @@ export function usePaymentMethods() {
       } else {
         setPaymentMethods([]);
       }
-    } catch (error) {
-      console.error("Error fetching payment methods:", error);
-      setError(error);
+    } catch (paymentMethodsLoadError) {
+      console.error("Error fetching payment methods:", paymentMethodsLoadError);
+      setError(paymentMethodsLoadError);
     } finally {
       setLoading(false);
     }
-  }, [fetchList]);
+  }, [canRead, fetchList]);
 
   useEffect(() => {
     fetchPaymentMethods();
@@ -42,6 +45,7 @@ export function usePaymentMethods() {
     paymentMethods,
     loading,
     error,
+    forbidden: !canRead,
     refetch: fetchPaymentMethods,
   };
 }

--- a/client/src/components/pages/Store/Cart/locales/en.js
+++ b/client/src/components/pages/Store/Cart/locales/en.js
@@ -81,6 +81,13 @@ const cartEn = {
     errors: {
       outOfStock: "Not enough stock available for this product.",
     },
+    permissionBlocked: {
+      title: "You can't complete the sale",
+      subtitle: "Ask an administrator to grant you the missing permissions:",
+      products: "View products",
+      categories: "View categories",
+      payments: "View payment methods",
+    },
     paymentModal: {
       bitcoin: {
         title: "Pay with Bitcoin (Lightning)",

--- a/client/src/components/pages/Store/Cart/locales/es.js
+++ b/client/src/components/pages/Store/Cart/locales/es.js
@@ -81,6 +81,13 @@ const cartEs = {
     errors: {
       outOfStock: "No hay stock suficiente para este producto.",
     },
+    permissionBlocked: {
+      title: "No puedes completar la venta",
+      subtitle: "Pídele a un administrador que te otorgue los permisos que faltan:",
+      products: "Ver productos",
+      categories: "Ver categorías",
+      payments: "Ver métodos de pago",
+    },
     paymentModal: {
       bitcoin: {
         title: "Pago con Bitcoin (Lightning)",

--- a/client/src/components/pages/Store/Settings/Printers/PrinterConfigRow.jsx
+++ b/client/src/components/pages/Store/Settings/Printers/PrinterConfigRow.jsx
@@ -3,6 +3,7 @@
 import { Card, CardBody, Select, SelectItem, Switch } from "@heroui/react";
 import { useTranslations } from "next-intl";
 
+import { RequirePermission } from "@/hooks/usePermission";
 import { DeleteButton } from "@components/shared/DeleteButton";
 
 export function PrinterConfigRow({
@@ -15,7 +16,7 @@ export function PrinterConfigRow({
   onToggleEnabled,
   onRemove,
 }) {
-  const t = useTranslations("settings");
+  const settingsTranslations = useTranslations("settings");
   return (
     <Card shadow="none" className="border border-gray-200 rounded-lg">
       <CardBody className="flex flex-col gap-3 p-4">
@@ -25,71 +26,73 @@ export function PrinterConfigRow({
           </span>
           <div className="mt-1 flex flex-wrap gap-2 text-xs text-gray-600">
             <span className="rounded-full border border-gray-200 px-2 py-0.5">
-              {t(`cardPrinters.types.${config.printerType}`)}
+              {settingsTranslations(`cardPrinters.types.${config.printerType}`)}
             </span>
             {config.isDefault && (
               <span className="rounded-full border border-green-200 bg-green-50 px-2 py-0.5 text-green-700">
-                {t("cardPrinters.defaultBadge")}
+                {settingsTranslations("cardPrinters.defaultBadge")}
               </span>
             )}
             {!config.enabled && (
               <span className="rounded-full border border-red-200 bg-red-50 px-2 py-0.5 text-red-700">
-                {t("cardPrinters.disabledBadge")}
+                {settingsTranslations("cardPrinters.disabledBadge")}
               </span>
             )}
           </div>
         </div>
 
-        <Select
-          className="w-full"
-          label={t("cardPrinters.templateLabel")}
-          selectedKeys={config.templateName ? [config.templateName] : []}
-          onChange={(e) => onTemplateChange(e.target.value || null)}
-          isLoading={loadingTemplates}
-        >
-          <SelectItem key="none" value="">
-            {t("cardPrinters.templateNone")}
-          </SelectItem>
-          {Array.isArray(templates) &&
-            templates.map((template) => (
-              <SelectItem key={template.name} value={template.name}>
-                {template.name}
-              </SelectItem>
-            ))}
-        </Select>
+        <RequirePermission allOf={["printer_update"]}>
+          <Select
+            className="w-full"
+            label={settingsTranslations("cardPrinters.templateLabel")}
+            selectedKeys={config.templateName ? [config.templateName] : []}
+            onChange={(event) => onTemplateChange(event.target.value || null)}
+            isLoading={loadingTemplates}
+          >
+            <SelectItem key="none" value="">
+              {settingsTranslations("cardPrinters.templateNone")}
+            </SelectItem>
+            {Array.isArray(templates) &&
+              templates.map((template) => (
+                <SelectItem key={template.name} value={template.name}>
+                  {template.name}
+                </SelectItem>
+              ))}
+          </Select>
 
-        <div className="flex items-center justify-between gap-3">
-          <div className="flex items-center gap-3 flex-wrap">
-            <Switch
-              size="sm"
-              isSelected={config.isDefault}
-              onValueChange={(value) => {
-                if (value) {
-                  onSetDefault();
-                } else {
-                  onToggleDefault(false);
-                }
-              }}
-            >
-              <span className="text-xs sm:text-sm">{t("cardPrinters.defaultLabel")}</span>
-            </Switch>
-            <Switch
-              size="sm"
-              isSelected={config.enabled}
-              onValueChange={onToggleEnabled}
-            >
-              <span className="text-xs sm:text-sm">{t("cardPrinters.enabledLabel")}</span>
-            </Switch>
+          <div className="flex items-center justify-between gap-3">
+            <div className="flex items-center gap-3 flex-wrap">
+              <Switch
+                size="sm"
+                isSelected={config.isDefault}
+                onValueChange={(isDefaultSelected) => {
+                  if (isDefaultSelected) {
+                    onSetDefault();
+                  } else {
+                    onToggleDefault(false);
+                  }
+                }}
+              >
+                <span className="text-xs sm:text-sm">{settingsTranslations("cardPrinters.defaultLabel")}</span>
+              </Switch>
+              <Switch
+                size="sm"
+                isSelected={config.enabled}
+                onValueChange={onToggleEnabled}
+              >
+                <span className="text-xs sm:text-sm">{settingsTranslations("cardPrinters.enabledLabel")}</span>
+              </Switch>
+            </div>
+            <div className="shrink-0">
+              <span className="sm:hidden">
+                <DeleteButton onPress={onRemove} />
+              </span>
+              <span className="hidden sm:inline">
+                <DeleteButton onPress={onRemove}>{settingsTranslations("cardPrinters.remove")}</DeleteButton>
+              </span>
+            </div>
           </div>
-          <div className="shrink-0">
-            <span className="sm:hidden">
-              <DeleteButton onPress={onRemove} />
-            </span>
-            <span className="hidden sm:inline">
-              <DeleteButton onPress={onRemove}>{t("cardPrinters.remove")}</DeleteButton>
-            </span>
-          </div>
-        </div>
+        </RequirePermission>
       </CardBody>
     </Card>
   );

--- a/client/src/components/pages/Store/Settings/Printers/PrintersCard.jsx
+++ b/client/src/components/pages/Store/Settings/Printers/PrintersCard.jsx
@@ -3,11 +3,13 @@
 import { Card, CardBody, CardHeader } from "@heroui/react";
 import { useTranslations } from "next-intl";
 
+import { RequirePermission } from "@/hooks/usePermission";
+
 import { PrinterAddForm } from "./PrinterAddForm";
 import { PrinterConfigRow } from "./PrinterConfigRow";
 
 export function PrintersCard({ formState, data, loading, state }) {
-  const t = useTranslations("settings");
+  const settingsTranslations = useTranslations("settings");
   const { configRows } = data;
   const { configs: loadingConfigs } = loading;
   const { error, saving, onAdd, onUpdateConfig, onDeleteConfig, onSetDefaultConfig } = state;
@@ -18,45 +20,47 @@ export function PrintersCard({ formState, data, loading, state }) {
     <Card shadow="none" className="rounded-lg p-6 shadow-lg">
       <CardHeader className="flex flex-col items-start pb-0">
         <h2 className="text-lg sm:text-xl xl:text-2xl font-semibold text-green-900">
-          {t("cardPrinters.title")}
+          {settingsTranslations("cardPrinters.title")}
         </h2>
         <p className="text-xs sm:text-sm text-gray-600 mt-1">
-          {t("cardPrinters.subtitle")}
+          {settingsTranslations("cardPrinters.subtitle")}
         </p>
       </CardHeader>
 
       <CardBody>
         <div className="flex flex-col gap-6">
-          <PrinterAddForm
-            formState={addFormState}
-            data={data}
-            loading={loading}
-            saving={saving}
-          />
+          <RequirePermission allOf={["printer_update"]}>
+            <PrinterAddForm
+              formState={addFormState}
+              data={data}
+              loading={loading}
+              saving={saving}
+            />
+          </RequirePermission>
 
           {error && (
             <p className="text-sm text-red-600">
-              {t("cardPrinters.error")}
+              {settingsTranslations("cardPrinters.error")}
             </p>
           )}
 
           <div className="flex flex-col gap-3">
             <div className="flex flex-col gap-1 lg:flex-row lg:items-center lg:justify-between">
               <h3 className="text-sm sm:text-base font-semibold text-green-900">
-                {t("cardPrinters.listTitle")}
+                {settingsTranslations("cardPrinters.listTitle")}
               </h3>
               <span className="text-xs text-gray-500">
-                {t("cardPrinters.listHint")}
+                {settingsTranslations("cardPrinters.listHint")}
               </span>
             </div>
             {loadingConfigs && (
               <p className="text-sm text-gray-600">
-                {t("cardPrinters.loading")}
+                {settingsTranslations("cardPrinters.loading")}
               </p>
             )}
             {!loadingConfigs && configRows.length === 0 && (
               <p className="text-sm text-gray-600">
-                {t("cardPrinters.empty")}
+                {settingsTranslations("cardPrinters.empty")}
               </p>
             )}
             {configRows.map((config) => (
@@ -65,10 +69,10 @@ export function PrintersCard({ formState, data, loading, state }) {
                 config={config}
                 templates={data.templates}
                 loadingTemplates={loading.templates}
-                onTemplateChange={(value) => onUpdateConfig(config.id, { templateName: value })}
+                onTemplateChange={(templateName) => onUpdateConfig(config.id, { templateName })}
                 onSetDefault={() => onSetDefaultConfig(config.id)}
-                onToggleDefault={(value) => onUpdateConfig(config.id, { isDefault: value })}
-                onToggleEnabled={(value) => onUpdateConfig(config.id, { enabled: value })}
+                onToggleDefault={(isDefault) => onUpdateConfig(config.id, { isDefault })}
+                onToggleEnabled={(enabled) => onUpdateConfig(config.id, { enabled })}
                 onRemove={() => onDeleteConfig(config.id)}
               />
             ))}

--- a/client/src/components/pages/Store/Settings/Printers/__tests__/PrinterConfigRow.test.jsx
+++ b/client/src/components/pages/Store/Settings/Printers/__tests__/PrinterConfigRow.test.jsx
@@ -6,6 +6,10 @@ jest.mock("next-intl", () => ({
   useTranslations: () => (key) => key,
 }));
 
+jest.mock("@/hooks/usePermission", () => ({
+  RequirePermission: ({ children }) => children,
+}));
+
 jest.mock("@components/shared/DeleteButton", () => ({
   DeleteButton: ({ onPress }) => (
     <button type="button" onClick={onPress} aria-label="delete">delete</button>
@@ -40,7 +44,7 @@ jest.mock("@heroui/react", () => ({
       <input
         type="checkbox"
         checked={!!isSelected}
-        onChange={(e) => onValueChange(e.target.checked)}
+        onChange={(event) => onValueChange(event.target.checked)}
       />
       {children}
     </label>

--- a/client/src/components/pages/Store/Settings/Printers/__tests__/PrintersCard.test.jsx
+++ b/client/src/components/pages/Store/Settings/Printers/__tests__/PrintersCard.test.jsx
@@ -6,6 +6,10 @@ jest.mock("next-intl", () => ({
   useTranslations: () => (key) => key,
 }));
 
+jest.mock("@/hooks/usePermission", () => ({
+  RequirePermission: ({ children }) => children,
+}));
+
 jest.mock("@heroui/react", () => ({
   Button: ({ onPress, children, ...props }) => (
     <button type="button" onClick={onPress} {...props}>

--- a/client/src/components/pages/Store/Settings/TicketTemplates/Editor.jsx
+++ b/client/src/components/pages/Store/Settings/TicketTemplates/Editor.jsx
@@ -13,12 +13,12 @@ export function TicketTemplatesEditor({
   onElementReorder,
   onElementRemove,
   config,
-  t,
+  settingsTranslations,
 }) {
   return (
     <div className="flex min-w-0 flex-2 flex-col gap-4">
       <Input
-        label={t("templates.nameLabel")}
+        label={settingsTranslations("templates.nameLabel")}
         value={name}
         onChange={onNameChange}
       />
@@ -30,7 +30,7 @@ export function TicketTemplatesEditor({
         onReorder={onElementReorder}
         onRemove={onElementRemove}
         config={config}
-        t={t}
+        settingsTranslations={settingsTranslations}
       />
     </div>
   );

--- a/client/src/components/pages/Store/Settings/TicketTemplates/ElementRow.jsx
+++ b/client/src/components/pages/Store/Settings/TicketTemplates/ElementRow.jsx
@@ -27,7 +27,7 @@ const ELEMENT_TYPES = [
 const JUSTIFICATIONS = ["LEFT", "CENTER", "RIGHT"];
 const FONT_SIZES = ["NORMAL", "LARGE", "EXTRA_LARGE"];
 
-export function TemplateElementRow({ element, isOpen, onToggle, onChange, onRemove, config, t }) {
+export function TemplateElementRow({ element, isOpen, onToggle, onChange, onRemove, config, settingsTranslations }) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: element.localId,
   });
@@ -50,7 +50,7 @@ export function TemplateElementRow({ element, isOpen, onToggle, onChange, onRemo
 
   const selectVariable = (variable) => handleChange({ value: variable });
 
-  const typeLabel = t(`templates.elementTypes.${type}`);
+  const typeLabel = settingsTranslations(`templates.elementTypes.${type}`);
   const resolvedSummary = resolveValue(element.value ?? "", config);
   const valueSummary = resolvedSummary ? `— "${resolvedSummary}"` : "";
 
@@ -62,7 +62,7 @@ export function TemplateElementRow({ element, isOpen, onToggle, onChange, onRemo
       >
         <span
           className="cursor-grab text-gray-400 hover:text-gray-600 shrink-0"
-          onClick={(e) => e.stopPropagation()}
+          onClick={(event) => event.stopPropagation()}
           {...attributes}
           {...listeners}
         >
@@ -74,18 +74,18 @@ export function TemplateElementRow({ element, isOpen, onToggle, onChange, onRemo
           <span className="text-xs text-gray-400 truncate">{valueSummary}</span>
         )}
 
-        <div className="ml-auto flex items-center gap-1" onClick={(e) => e.stopPropagation()}>
+        <div className="ml-auto flex items-center gap-1" onClick={(event) => event.stopPropagation()}>
           <Button
             isIconOnly
             size="sm"
             variant="light"
             onPress={onToggle}
-            aria-label={isOpen ? t("templates.collapse") : t("templates.expand")}
+            aria-label={isOpen ? settingsTranslations("templates.collapse") : settingsTranslations("templates.expand")}
           >
             {isOpen ? <ChevronUp className="w-4 h-4" /> : <ChevronDown className="w-4 h-4" />}
           </Button>
           <DeleteButton onPress={() => onRemove(element.localId)}>
-            <span className="hidden sm:inline">{t("templates.removeElement")}</span>
+            <span className="hidden sm:inline">{settingsTranslations("templates.removeElement")}</span>
           </DeleteButton>
         </div>
       </div>
@@ -94,13 +94,13 @@ export function TemplateElementRow({ element, isOpen, onToggle, onChange, onRemo
         <div className="border-t border-gray-100 px-3 pb-3 pt-3">
           <div className="mb-3">
             <Select
-              label={t("templates.elementTypeLabel")}
+              label={settingsTranslations("templates.elementTypeLabel")}
               selectedKeys={element.type ? [element.type] : []}
-              onChange={(e) => { if (e.target.value) handleChange({ type: e.target.value }); }}
+              onChange={(event) => { if (event.target.value) handleChange({ type: event.target.value }); }}
             >
               {ELEMENT_TYPES.map((typeOption) => (
                 <SelectItem key={typeOption} value={typeOption}>
-                  {t(`templates.elementTypes.${typeOption}`)}
+                  {settingsTranslations(`templates.elementTypes.${typeOption}`)}
                 </SelectItem>
               ))}
             </Select>
@@ -110,19 +110,19 @@ export function TemplateElementRow({ element, isOpen, onToggle, onChange, onRemo
             <div className="grid gap-3 lg:grid-cols-[1.2fr_160px_160px_auto] lg:items-end">
               {showValue && (
                 <Input
-                  label={t("templates.elementValueLabel")}
+                  label={settingsTranslations("templates.elementValueLabel")}
                   value={element.value ?? ""}
-                  onChange={(e) => handleChange({ value: e.target.value })}
+                  onChange={(event) => handleChange({ value: event.target.value })}
                   endContent={showVariablePicker ? (
                     <Tooltip
                       showArrow
                       placement="right"
                       size="sm"
-                      content={t("templates.variables.tooltip")}
+                      content={settingsTranslations("templates.variables.tooltip")}
                       classNames={{ base: "before:rounded-none before:shadow-none shadow-none", content: "rounded-md border-none shadow-none" }}
                     >
                       <div>
-                        <TemplateVariablePicker onSelect={selectVariable} t={t} />
+                        <TemplateVariablePicker onSelect={selectVariable} settingsTranslations={settingsTranslations} />
                       </div>
                     </Tooltip>
                   ) : null}
@@ -131,15 +131,15 @@ export function TemplateElementRow({ element, isOpen, onToggle, onChange, onRemo
 
               {showJustification && (
                 <Select
-                  label={t("templates.justificationLabel")}
+                  label={settingsTranslations("templates.justificationLabel")}
                   selectedKeys={element.style?.justification ? [element.style.justification] : []}
-                  onChange={(e) => handleChange({
-                    style: { ...element.style, justification: e.target.value },
+                  onChange={(event) => handleChange({
+                    style: { ...element.style, justification: event.target.value },
                   })}
                 >
                   {JUSTIFICATIONS.map((justification) => (
                     <SelectItem key={justification} value={justification}>
-                      {t(`templates.justifications.${justification}`)}
+                      {settingsTranslations(`templates.justifications.${justification}`)}
                     </SelectItem>
                   ))}
                 </Select>
@@ -147,15 +147,15 @@ export function TemplateElementRow({ element, isOpen, onToggle, onChange, onRemo
 
               {showFontSize && (
                 <Select
-                  label={t("templates.fontSizeLabel")}
+                  label={settingsTranslations("templates.fontSizeLabel")}
                   selectedKeys={element.style?.fontSize ? [element.style.fontSize] : []}
-                  onChange={(e) => handleChange({
-                    style: { ...element.style, fontSize: e.target.value },
+                  onChange={(event) => handleChange({
+                    style: { ...element.style, fontSize: event.target.value },
                   })}
                 >
                   {FONT_SIZES.map((fontSize) => (
                     <SelectItem key={fontSize} value={fontSize}>
-                      {t(`templates.fontSizes.${fontSize}`)}
+                      {settingsTranslations(`templates.fontSizes.${fontSize}`)}
                     </SelectItem>
                   ))}
                 </Select>
@@ -170,7 +170,7 @@ export function TemplateElementRow({ element, isOpen, onToggle, onChange, onRemo
                   onPress={() => handleChange({
                     style: { ...element.style, bold: !element.style?.bold },
                   })}
-                  aria-label={t("templates.boldToggle")}
+                  aria-label={settingsTranslations("templates.boldToggle")}
                 >
                   <Bold className="w-4 h-4" />
                 </Button>

--- a/client/src/components/pages/Store/Settings/TicketTemplates/ElementsEditor.jsx
+++ b/client/src/components/pages/Store/Settings/TicketTemplates/ElementsEditor.jsx
@@ -8,7 +8,7 @@ import { Button } from "@heroui/react";
 
 import { TemplateElementRow } from "./ElementRow";
 
-export function TemplateElementsEditor({ elements, onChange, onAdd, onReorder, onRemove, config, t }) {
+export function TemplateElementsEditor({ elements, onChange, onAdd, onReorder, onRemove, config, settingsTranslations }) {
   const [openIds, setOpenIds] = useState(() => new Set());
 
   const sensors = useSensors(
@@ -25,8 +25,8 @@ export function TemplateElementsEditor({ elements, onChange, onAdd, onReorder, o
   const handleDragEnd = useCallback((event) => {
     const { active, over } = event;
     if (!over || active.id === over.id) return;
-    const oldIndex = elements.findIndex((el) => el.localId === active.id);
-    const newIndex = elements.findIndex((el) => el.localId === over.id);
+    const oldIndex = elements.findIndex((element) => element.localId === active.id);
+    const newIndex = elements.findIndex((element) => element.localId === over.id);
     onReorder(arrayMove(elements, oldIndex, newIndex));
   }, [elements, onReorder]);
 
@@ -53,15 +53,15 @@ export function TemplateElementsEditor({ elements, onChange, onAdd, onReorder, o
     <div className="flex min-w-0 flex-1 flex-col gap-4">
       <div className="flex items-center justify-between">
         <h3 className="text-base sm:text-lg font-semibold text-green-900">
-          {t("templates.elementsTitle")}
+          {settingsTranslations("templates.elementsTitle")}
         </h3>
         <Button color="primary" className="bg-green-800" onPress={handleAdd}>
-          {t("templates.addElement")}
+          {settingsTranslations("templates.addElement")}
         </Button>
       </div>
 
       <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
-        <SortableContext items={elements.map((el) => el.localId)} strategy={verticalListSortingStrategy}>
+        <SortableContext items={elements.map((element) => element.localId)} strategy={verticalListSortingStrategy}>
           <div className="flex max-h-[50vh] flex-col gap-2 overflow-y-auto pr-2">
             {elements.map((element) => (
               <TemplateElementRow
@@ -72,7 +72,7 @@ export function TemplateElementsEditor({ elements, onChange, onAdd, onReorder, o
                 onChange={onChange}
                 onRemove={onRemove}
                 config={config}
-                t={t}
+                settingsTranslations={settingsTranslations}
               />
             ))}
           </div>

--- a/client/src/components/pages/Store/Settings/TicketTemplates/Footer.jsx
+++ b/client/src/components/pages/Store/Settings/TicketTemplates/Footer.jsx
@@ -4,6 +4,8 @@ import { useState } from "react";
 
 import { Button, ModalFooter } from "@heroui/react";
 
+import { RequirePermission } from "@/hooks/usePermission";
+
 export function TicketTemplatesFooter({
   selectedId,
   deleting,
@@ -12,7 +14,7 @@ export function TicketTemplatesFooter({
   onSave,
   saving,
   name,
-  t,
+  settingsTranslations,
 }) {
   const [confirmDelete, setConfirmDelete] = useState(false);
 
@@ -20,20 +22,22 @@ export function TicketTemplatesFooter({
     <ModalFooter className="flex justify-between">
       <div className="flex items-center gap-2">
         {selectedId && (
-          confirmDelete ? (
-            <>
-              <Button size="sm" color="danger" onPress={onDelete} isDisabled={deleting}>
-                {t("templates.confirmDelete")}
+          <RequirePermission allOf={["printer_update"]}>
+            {confirmDelete ? (
+              <>
+                <Button size="sm" color="danger" onPress={onDelete} isDisabled={deleting}>
+                  {settingsTranslations("templates.confirmDelete")}
+                </Button>
+                <Button size="sm" variant="light" onPress={() => setConfirmDelete(false)}>
+                  {settingsTranslations("templates.cancelDelete")}
+                </Button>
+              </>
+            ) : (
+              <Button color="danger" variant="bordered" onPress={() => setConfirmDelete(true)}>
+                {settingsTranslations("templates.deleteTemplate")}
               </Button>
-              <Button size="sm" variant="light" onPress={() => setConfirmDelete(false)}>
-                {t("templates.cancelDelete")}
-              </Button>
-            </>
-          ) : (
-            <Button color="danger" variant="bordered" onPress={() => setConfirmDelete(true)}>
-              {t("templates.deleteTemplate")}
-            </Button>
-          )
+            )}
+          </RequirePermission>
         )}
       </div>
       <div className="flex items-center gap-2">
@@ -42,16 +46,18 @@ export function TicketTemplatesFooter({
           className="border border-border text-foreground hover:bg-muted transition-colors"
           onPress={onClose}
         >
-          {t("templates.close")}
+          {settingsTranslations("templates.close")}
         </Button>
-        <Button
-          color="primary"
-          className="bg-green-800"
-          onPress={onSave}
-          isDisabled={saving || !name.trim()}
-        >
-          {selectedId ? t("templates.saveChanges") : t("templates.saveNew")}
-        </Button>
+        <RequirePermission allOf={["printer_update"]}>
+          <Button
+            color="primary"
+            className="bg-green-800"
+            onPress={onSave}
+            isDisabled={saving || !name.trim()}
+          >
+            {selectedId ? settingsTranslations("templates.saveChanges") : settingsTranslations("templates.saveNew")}
+          </Button>
+        </RequirePermission>
       </div>
     </ModalFooter>
   );

--- a/client/src/components/pages/Store/Settings/TicketTemplates/List.jsx
+++ b/client/src/components/pages/Store/Settings/TicketTemplates/List.jsx
@@ -2,6 +2,8 @@
 
 import { Button, Select, SelectItem } from "@heroui/react";
 
+import { RequirePermission } from "@/hooks/usePermission";
+
 export function TemplateList({
   templates,
   selectedId,
@@ -9,10 +11,10 @@ export function TemplateList({
   error,
   onSelect,
   onNew,
-  t,
+  settingsTranslations,
 }) {
-  const handleSelectionChange = (e) => {
-    const templateId = e.target.value;
+  const handleSelectionChange = (event) => {
+    const templateId = event.target.value;
     if (!templateId) return;
     const template = templates.find((tpl) => tpl.id === templateId);
     if (template) {
@@ -23,12 +25,12 @@ export function TemplateList({
   return (
     <div className="flex w-full flex-col gap-3">
       {error && (
-        <p className="text-sm text-red-600">{t("templates.error")}</p>
+        <p className="text-sm text-red-600">{settingsTranslations("templates.error")}</p>
       )}
       <div className="flex flex-col gap-3">
         <Select
-          label={t("templates.listTitle")}
-          placeholder={t("templates.selectPlaceholder")}
+          label={settingsTranslations("templates.listTitle")}
+          placeholder={settingsTranslations("templates.selectPlaceholder")}
           selectedKeys={selectedId ? [selectedId] : []}
           onChange={handleSelectionChange}
           isLoading={loading}
@@ -39,15 +41,17 @@ export function TemplateList({
             </SelectItem>
           ))}
         </Select>
-        <div className="flex justify-end">
-          <Button
-            color="primary"
-            className="h-8 min-w-16 px-3 rounded-small sm:h-10 sm:min-w-20 sm:px-4 sm:rounded-medium bg-green-800"
-            onPress={onNew}
-          >
-            {t("templates.addTemplate")}
-          </Button>
-        </div>
+        <RequirePermission allOf={["printer_update"]}>
+          <div className="flex justify-end">
+            <Button
+              color="primary"
+              className="h-8 min-w-16 px-3 rounded-small sm:h-10 sm:min-w-20 sm:px-4 sm:rounded-medium bg-green-800"
+              onPress={onNew}
+            >
+              {settingsTranslations("templates.addTemplate")}
+            </Button>
+          </div>
+        </RequirePermission>
       </div>
     </div>
   );

--- a/client/src/components/pages/Store/Settings/TicketTemplates/Modal.jsx
+++ b/client/src/components/pages/Store/Settings/TicketTemplates/Modal.jsx
@@ -63,7 +63,7 @@ export function TicketTemplatesModal({ isOpen, onClose, initialTemplate = null }
   const handleSave = async () => {
     if (!name.trim()) return;
     setSaving(true);
-    const payload = {
+    const templatePayload = {
       name: name.trim(),
       elements: elements.map((element) => ({
         type: element.type,
@@ -73,16 +73,16 @@ export function TicketTemplatesModal({ isOpen, onClose, initialTemplate = null }
     };
     try {
       if (selectedId) {
-        await updateTemplate(selectedId, payload);
+        await updateTemplate(selectedId, templatePayload);
       } else {
-        const created = await createTemplate(payload);
-        if (created?.id) {
-          setSelectedId(created.id);
+        const createdTemplate = await createTemplate(templatePayload);
+        if (createdTemplate?.id) {
+          setSelectedId(createdTemplate.id);
         }
       }
       addToast({ color: "success", description: settingsTranslations("templates.saveSuccess") });
-    } catch (error) {
-      console.error("Failed to save template:", error);
+    } catch (saveError) {
+      console.error("Failed to save template:", saveError);
       addToast({ color: "danger", description: settingsTranslations("templates.saveError") });
     } finally {
       setSaving(false);
@@ -105,8 +105,8 @@ export function TicketTemplatesModal({ isOpen, onClose, initialTemplate = null }
         description: settingsTranslations("templates.printSuccessDescription"),
         color: "success",
       });
-    } catch (error) {
-      console.error("Error printing test ticket:", error);
+    } catch (printTestError) {
+      console.error("Error printing test ticket:", printTestError);
       addToast({
         title: settingsTranslations("templates.printErrorTitle"),
         description: settingsTranslations("templates.printErrorDescription"),
@@ -129,8 +129,8 @@ export function TicketTemplatesModal({ isOpen, onClose, initialTemplate = null }
       await deleteTemplate(selectedId);
       resetForm();
       addToast({ color: "success", description: settingsTranslations("templates.deleteSuccess") });
-    } catch (error) {
-      console.error("Failed to delete template:", error);
+    } catch (deleteError) {
+      console.error("Failed to delete template:", deleteError);
       addToast({ color: "danger", description: settingsTranslations("templates.deleteError") });
     } finally {
       setDeleting(false);
@@ -157,30 +157,30 @@ export function TicketTemplatesModal({ isOpen, onClose, initialTemplate = null }
           <div className="flex w-full flex-col gap-4 lg:flex-row lg:items-start">
             <TicketTemplatesEditor
               name={name}
-              onNameChange={(e) => setName(e.target.value)}
+              onNameChange={(event) => setName(event.target.value)}
               elements={elements}
-              onElementChange={(updated) => setElements((prev) => prev.map((el) => (el.localId === updated.localId ? updated : el)))}
+              onElementChange={(updatedElement) => setElements((prev) => prev.map((element) => (element.localId === updatedElement.localId ? updatedElement : element)))}
               onElementAdd={() => {
-                const newEl = createElement();
-                setElements((prev) => [...prev, newEl]);
-                return newEl;
+                const newElement = createElement();
+                setElements((prev) => [...prev, newElement]);
+                return newElement;
               }}
-              onElementReorder={(newArray) => setElements(newArray)}
-              onElementRemove={(id) => setElements((prev) => prev.filter((el) => el.localId !== id))}
+              onElementReorder={(reorderedElements) => setElements(reorderedElements)}
+              onElementRemove={(localId) => setElements((prev) => prev.filter((element) => element.localId !== localId))}
               config={config}
-              t={settingsTranslations}
+              settingsTranslations={settingsTranslations}
             />
 
             <TemplatePreview
               elements={elements}
               config={config}
               printerType={printerType}
-              onPrinterTypeChange={(e) => setPrinterType(e.target.value)}
+              onPrinterTypeChange={(event) => setPrinterType(event.target.value)}
               printerTypes={PRINTER_TYPES}
               onPrintTest={handlePrintTest}
               printing={printing}
               templateExists={templateExists}
-              t={settingsTranslations}
+              settingsTranslations={settingsTranslations}
             />
           </div>
         </ModalBody>
@@ -193,7 +193,7 @@ export function TicketTemplatesModal({ isOpen, onClose, initialTemplate = null }
           onSave={handleSave}
           saving={saving}
           name={name}
-          t={settingsTranslations}
+          settingsTranslations={settingsTranslations}
         />
       </ModalContent>
     </Modal>

--- a/client/src/components/pages/Store/Settings/TicketTemplates/Preview.jsx
+++ b/client/src/components/pages/Store/Settings/TicketTemplates/Preview.jsx
@@ -13,24 +13,24 @@ export function TemplatePreview({
   onPrintTest,
   printing,
   templateExists,
-  t,
+  settingsTranslations,
 }) {
   return (
     <div className="w-full lg:flex-1 lg:sticky lg:top-0">
       <div className="flex flex-col">
         <h3 className="text-base sm:text-lg font-semibold text-green-900">
-          {t("templates.previewTitle")}
+          {settingsTranslations("templates.previewTitle")}
         </h3>
         <div className="mt-4 flex items-end gap-2">
           <Select
             className="flex-1"
-            label={t("templates.printTypeLabel")}
+            label={settingsTranslations("templates.printTypeLabel")}
             selectedKeys={printerType ? [printerType] : []}
             onChange={onPrinterTypeChange}
           >
             {printerTypes.map((type) => (
               <SelectItem key={type} value={type}>
-                {t(`cardPrinters.types.${type}`)}
+                {settingsTranslations(`cardPrinters.types.${type}`)}
               </SelectItem>
             ))}
           </Select>
@@ -39,7 +39,7 @@ export function TemplatePreview({
             onPress={onPrintTest}
             isDisabled={!templateExists || printing}
           >
-            {printing ? t("templates.printing") : t("templates.printTest")}
+            {printing ? settingsTranslations("templates.printing") : settingsTranslations("templates.printTest")}
           </Button>
         </div>
       </div>
@@ -50,7 +50,7 @@ export function TemplatePreview({
         </div>
         {!hasVisibleContent(elements) && (
           <p className="text-sm text-gray-400 italic text-center py-4">
-            {t("templates.previewEmpty")}
+            {settingsTranslations("templates.previewEmpty")}
           </p>
         )}
       </div>

--- a/client/src/components/pages/Store/Settings/TicketTemplates/TicketTemplates.jsx
+++ b/client/src/components/pages/Store/Settings/TicketTemplates/TicketTemplates.jsx
@@ -10,7 +10,7 @@ import { TicketTemplatesModal } from "./Modal";
 import { TicketTemplatesCard } from "./TicketTemplatesCard";
 
 export function TicketTemplates() {
-  const t = useTranslations("settings");
+  const settingsTranslations = useTranslations("settings");
   const { templates, loading, error, refetch } = useTemplates();
   const [modalOpen, setModalOpen] = useState(false);
   const [selectedTemplate, setSelectedTemplate] = useState(null);
@@ -35,7 +35,7 @@ export function TicketTemplates() {
         selectedId={selectedTemplate?.id || ""}
         onSelect={handleOpen}
         onNew={() => handleOpen(null)}
-        t={t}
+        settingsTranslations={settingsTranslations}
       />
       <TicketTemplatesModal
         isOpen={modalOpen}

--- a/client/src/components/pages/Store/Settings/TicketTemplates/TicketTemplatesCard.jsx
+++ b/client/src/components/pages/Store/Settings/TicketTemplates/TicketTemplatesCard.jsx
@@ -11,16 +11,16 @@ export function TicketTemplatesCard({
   selectedId,
   onSelect,
   onNew,
-  t,
+  settingsTranslations,
 }) {
   return (
     <Card shadow="none" className="rounded-lg p-6 shadow-lg">
       <CardHeader className="flex flex-col items-start pb-0">
         <h2 className="text-lg sm:text-xl xl:text-2xl font-semibold text-green-900">
-          {t("templates.title")}
+          {settingsTranslations("templates.title")}
         </h2>
         <p className="text-xs sm:text-sm text-gray-600 mt-1">
-          {t("templates.subtitle")}
+          {settingsTranslations("templates.subtitle")}
         </p>
       </CardHeader>
       <CardBody>
@@ -32,7 +32,7 @@ export function TicketTemplatesCard({
             error={error}
             onSelect={onSelect}
             onNew={onNew}
-            t={t}
+            settingsTranslations={settingsTranslations}
           />
         </div>
       </CardBody>

--- a/client/src/components/pages/Store/Settings/TicketTemplates/VariablePicker.jsx
+++ b/client/src/components/pages/Store/Settings/TicketTemplates/VariablePicker.jsx
@@ -6,7 +6,7 @@ import { Braces } from "lucide-react";
 const VARIABLE_GROUPS = [
   {
     group: "config",
-    vars: [
+    variables: [
       { key: "{{config.businessName}}", label: "businessName" },
       { key: "{{config.businessAddress}}", label: "businessAddress" },
       { key: "{{config.businessPhone}}", label: "businessPhone" },
@@ -15,7 +15,7 @@ const VARIABLE_GROUPS = [
   },
 ];
 
-export function TemplateVariablePicker({ onSelect, t }) {
+export function TemplateVariablePicker({ onSelect, settingsTranslations }) {
   return (
     <Popover placement="bottom-end">
       <PopoverTrigger>
@@ -24,19 +24,19 @@ export function TemplateVariablePicker({ onSelect, t }) {
           size="sm"
           variant="light"
           className="text-gray-400 hover:text-primary-500"
-          aria-label={t("templates.variables.title")}
+          aria-label={settingsTranslations("templates.variables.title")}
         >
           <Braces className="w-4 h-4" />
         </Button>
       </PopoverTrigger>
       <PopoverContent className="p-3 w-60">
         <p className="mb-2 text-xs font-semibold text-gray-500 uppercase tracking-wide">
-          {t("templates.variables.title")}
+          {settingsTranslations("templates.variables.title")}
         </p>
-        {VARIABLE_GROUPS.map(({ group, vars }) => (
+        {VARIABLE_GROUPS.map(({ group, variables }) => (
           <div key={group} className="mb-3 last:mb-0">
             <div className="flex flex-wrap gap-1">
-              {vars.map(({ key, label }) => (
+              {variables.map(({ key, label }) => (
                 <Chip
                   key={key}
                   size="sm"
@@ -45,7 +45,7 @@ export function TemplateVariablePicker({ onSelect, t }) {
                   className="cursor-pointer bg-green-200 text-xs text-green-800 border border-green-300"
                   onClick={() => onSelect(key)}
                 >
-                  {t(`templates.variables.${label}`)}
+                  {settingsTranslations(`templates.variables.${label}`)}
                 </Chip>
               ))}
             </div>

--- a/client/src/components/pages/Store/Settings/TicketTemplates/__tests__/ElementRow.test.jsx
+++ b/client/src/components/pages/Store/Settings/TicketTemplates/__tests__/ElementRow.test.jsx
@@ -68,7 +68,7 @@ jest.mock("@dnd-kit/utilities", () => ({
   CSS: { Transform: { toString: jest.fn(() => "") } },
 }));
 
-const t = (key) => key;
+const settingsTranslations = (key) => key;
 
 const element = {
   localId: "el-1",
@@ -90,7 +90,7 @@ describe("TemplateElementRow", () => {
         onChange={onChange}
         onRemove={onRemove}
         config={null}
-        t={t}
+        settingsTranslations={settingsTranslations}
       />,
     );
 
@@ -141,7 +141,7 @@ describe("TemplateElementRow", () => {
         onChange={jest.fn()}
         onRemove={jest.fn()}
         config={null}
-        t={t}
+        settingsTranslations={settingsTranslations}
       />,
     );
 
@@ -160,7 +160,7 @@ describe("TemplateElementRow", () => {
         onChange={jest.fn()}
         onRemove={jest.fn()}
         config={null}
-        t={t}
+        settingsTranslations={settingsTranslations}
       />,
     );
 
@@ -180,7 +180,7 @@ describe("TemplateElementRow", () => {
           onChange={jest.fn()}
           onRemove={jest.fn()}
           config={null}
-          t={t}
+          settingsTranslations={settingsTranslations}
         />,
       );
       expect(screen.getByTestId("variable-picker")).toBeInTheDocument();
@@ -198,7 +198,7 @@ describe("TemplateElementRow", () => {
           onChange={jest.fn()}
           onRemove={jest.fn()}
           config={null}
-          t={t}
+          settingsTranslations={settingsTranslations}
         />,
       );
       expect(screen.queryByTestId("variable-picker")).not.toBeInTheDocument();
@@ -215,7 +215,7 @@ describe("TemplateElementRow", () => {
         onChange={onChange}
         onRemove={jest.fn()}
         config={null}
-        t={t}
+        settingsTranslations={settingsTranslations}
       />,
     );
     fireEvent.click(screen.getByTestId("variable-picker"));

--- a/client/src/components/pages/Store/Settings/TicketTemplates/__tests__/ElementsEditor.test.jsx
+++ b/client/src/components/pages/Store/Settings/TicketTemplates/__tests__/ElementsEditor.test.jsx
@@ -16,7 +16,7 @@ jest.mock("../ElementRow", () => ({
   ),
 }));
 
-const t = (key) => key;
+const settingsTranslations = (key) => key;
 
 describe("TemplateElementsEditor", () => {
   it("renders rows and triggers add", () => {
@@ -28,7 +28,7 @@ describe("TemplateElementsEditor", () => {
         onAdd={onAdd}
         onMove={jest.fn()}
         onRemove={jest.fn()}
-        t={t}
+        settingsTranslations={settingsTranslations}
       />,
     );
 

--- a/client/src/components/pages/Store/Settings/TicketTemplates/__tests__/List.test.jsx
+++ b/client/src/components/pages/Store/Settings/TicketTemplates/__tests__/List.test.jsx
@@ -2,6 +2,10 @@ import { fireEvent, render, screen } from "@testing-library/react";
 
 import { TemplateList } from "../List";
 
+jest.mock("@/hooks/usePermission", () => ({
+  RequirePermission: ({ children }) => children,
+}));
+
 jest.mock("@heroui/react", () => ({
   Button: ({ onPress, children, ...props }) => (
     <button type="button" onClick={onPress} {...props}>
@@ -21,7 +25,7 @@ jest.mock("@heroui/react", () => ({
   SelectItem: ({ children, value }) => <option value={value}>{children}</option>,
 }));
 
-const t = (key) => key;
+const settingsTranslations = (key) => key;
 
 describe("TemplateList", () => {
   it("shows loading state and error message", () => {
@@ -33,7 +37,7 @@ describe("TemplateList", () => {
         error={null}
         onSelect={jest.fn()}
         onNew={jest.fn()}
-        t={t}
+        settingsTranslations={settingsTranslations}
       />,
     );
 
@@ -47,7 +51,7 @@ describe("TemplateList", () => {
         error
         onSelect={jest.fn()}
         onNew={jest.fn()}
-        t={t}
+        settingsTranslations={settingsTranslations}
       />,
     );
 
@@ -69,7 +73,7 @@ describe("TemplateList", () => {
         error={null}
         onSelect={onSelect}
         onNew={onNew}
-        t={t}
+        settingsTranslations={settingsTranslations}
       />,
     );
 
@@ -90,7 +94,7 @@ describe("TemplateList", () => {
         error={null}
         onSelect={jest.fn()}
         onNew={jest.fn()}
-        t={t}
+        settingsTranslations={settingsTranslations}
       />,
     );
 

--- a/client/src/components/pages/Store/Settings/TicketTemplates/__tests__/Preview.test.jsx
+++ b/client/src/components/pages/Store/Settings/TicketTemplates/__tests__/Preview.test.jsx
@@ -23,10 +23,10 @@ jest.mock("../TicketElements", () => ({
   TicketElementsPreview: ({ elements }) => (
     <div data-testid="elements-preview" data-count={elements.length} />
   ),
-  hasVisibleContent: (elements) => Array.isArray(elements) && elements.some((el) => ["SEPARATOR", "LINE_BREAK", "TABLE_ROW"].includes(el.type) || el.value?.trim()),
+  hasVisibleContent: (elements) => Array.isArray(elements) && elements.some((element) => ["SEPARATOR", "LINE_BREAK", "TABLE_ROW"].includes(element.type) || element.value?.trim()),
 }));
 
-const t = (key) => key;
+const settingsTranslations = (key) => key;
 
 const defaultProps = {
   elements: [],
@@ -37,7 +37,7 @@ const defaultProps = {
   onPrintTest: jest.fn(),
   printing: false,
   templateExists: false,
-  t,
+  settingsTranslations,
 };
 
 describe("TemplatePreview", () => {

--- a/client/src/components/pages/Store/Settings/TicketTemplates/__tests__/TicketTemplatesCard.test.jsx
+++ b/client/src/components/pages/Store/Settings/TicketTemplates/__tests__/TicketTemplatesCard.test.jsx
@@ -14,7 +14,7 @@ jest.mock("../List", () => ({
   ),
 }));
 
-const t = (key) => key;
+const settingsTranslations = (key) => key;
 
 describe("TicketTemplatesCard", () => {
   it("renders title and template list", () => {
@@ -26,7 +26,7 @@ describe("TicketTemplatesCard", () => {
         selectedId=""
         onSelect={jest.fn()}
         onNew={jest.fn()}
-        t={t}
+        settingsTranslations={settingsTranslations}
       />,
     );
     expect(screen.getByText("templates.title")).toBeInTheDocument();
@@ -42,7 +42,7 @@ describe("TicketTemplatesCard", () => {
         selectedId=""
         onSelect={jest.fn()}
         onNew={jest.fn()}
-        t={t}
+        settingsTranslations={settingsTranslations}
       />,
     );
     expect(screen.getByTestId("template-list")).toHaveAttribute("data-loading", "true");

--- a/client/src/components/pages/Store/Settings/TicketTemplates/__tests__/TicketTemplatesModal.test.jsx
+++ b/client/src/components/pages/Store/Settings/TicketTemplates/__tests__/TicketTemplatesModal.test.jsx
@@ -6,6 +6,10 @@ import { useTemplates } from "@components/pages/Store/hooks/useTemplates";
 
 import { TicketTemplatesModal } from "../Modal";
 
+jest.mock("@/hooks/usePermission", () => ({
+  RequirePermission: ({ children }) => children,
+}));
+
 jest.mock("@heroui/react", () => ({
   addToast: jest.fn(),
   Button: ({ onPress, isDisabled, children, isIconOnly, ...props }) => (

--- a/client/src/components/pages/Store/Settings/TicketTemplates/__tests__/VariablePicker.test.jsx
+++ b/client/src/components/pages/Store/Settings/TicketTemplates/__tests__/VariablePicker.test.jsx
@@ -22,16 +22,16 @@ jest.mock("lucide-react", () => ({
   Braces: () => <svg data-testid="braces-icon" />,
 }));
 
-const t = (key) => key;
+const settingsTranslations = (key) => key;
 
 describe("TemplateVariablePicker", () => {
   it("renders the trigger button", () => {
-    render(<TemplateVariablePicker onSelect={jest.fn()} t={t} />);
+    render(<TemplateVariablePicker onSelect={jest.fn()} settingsTranslations={settingsTranslations} />);
     expect(screen.getByRole("button", { name: "templates.variables.title" })).toBeInTheDocument();
   });
 
   it("renders config variable chips", () => {
-    render(<TemplateVariablePicker onSelect={jest.fn()} t={t} />);
+    render(<TemplateVariablePicker onSelect={jest.fn()} settingsTranslations={settingsTranslations} />);
     expect(screen.getByText("templates.variables.businessName")).toBeInTheDocument();
     expect(screen.getByText("templates.variables.businessAddress")).toBeInTheDocument();
     expect(screen.getByText("templates.variables.businessPhone")).toBeInTheDocument();
@@ -39,7 +39,7 @@ describe("TemplateVariablePicker", () => {
   });
 
   it("does not render ticket group chips", () => {
-    render(<TemplateVariablePicker onSelect={jest.fn()} t={t} />);
+    render(<TemplateVariablePicker onSelect={jest.fn()} settingsTranslations={settingsTranslations} />);
     expect(screen.queryByText("templates.variables.ticketId")).not.toBeInTheDocument();
     expect(screen.queryByText("templates.variables.tableName")).not.toBeInTheDocument();
     expect(screen.queryByText("templates.variables.total")).not.toBeInTheDocument();
@@ -47,14 +47,14 @@ describe("TemplateVariablePicker", () => {
 
   it("calls onSelect with the correct variable key when a chip is clicked", () => {
     const onSelect = jest.fn();
-    render(<TemplateVariablePicker onSelect={onSelect} t={t} />);
+    render(<TemplateVariablePicker onSelect={onSelect} settingsTranslations={settingsTranslations} />);
     fireEvent.click(screen.getByText("templates.variables.businessName"));
     expect(onSelect).toHaveBeenCalledWith("{{config.businessName}}");
   });
 
   it("calls onSelect with the correct key for each config variable", () => {
     const onSelect = jest.fn();
-    render(<TemplateVariablePicker onSelect={onSelect} t={t} />);
+    render(<TemplateVariablePicker onSelect={onSelect} settingsTranslations={settingsTranslations} />);
 
     fireEvent.click(screen.getByText("templates.variables.businessAddress"));
     expect(onSelect).toHaveBeenCalledWith("{{config.businessAddress}}");

--- a/client/src/components/pages/Store/Settings/__tests__/Settings.test.jsx
+++ b/client/src/components/pages/Store/Settings/__tests__/Settings.test.jsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 
 import * as usePrintersHook from "@/components/pages/Store/hooks/usePrinter";
 import * as useTemplatesHook from "@/components/pages/Store/hooks/useTemplates";
+import * as useAuthHook from "@/hooks/auth/useAuth";
 import * as useAdminWebPushHook from "@/hooks/useAdminWebPush";
 import * as useAutoLiquidityHook from "@/hooks/useAutoLiquidity";
 import * as adminNotificationsService from "@/services/adminNotificationsService";
@@ -117,6 +118,14 @@ beforeEach(() => {
     isLoading: false,
     user: { userName: "testuser" },
     logout: mockLogout,
+  });
+
+  jest.spyOn(useAuthHook, "useAuth").mockReturnValue({
+    isAuth: true,
+    isLoading: false,
+    user: { userId: "user-1", name: "Tester" },
+    permissions: [],
+    logout: jest.fn(),
   });
 
   jest.spyOn(configurationsProvider, "useConfigurations").mockReturnValue({

--- a/client/src/components/pages/Store/Store.jsx
+++ b/client/src/components/pages/Store/Store.jsx
@@ -14,7 +14,7 @@ import { useUsers } from "./hooks/useUsers";
 
 export function Store() {
   const dashboardTranslations = useTranslations("dashboard");
-  const { users } = useUsers();
+  const { users, forbidden: usersForbidden } = useUsers({ skipForbiddenRedirect: true });
   const { products, forbidden: productsForbidden } = useProducts({ skipForbiddenRedirect: true });
   const { orders, forbidden: ordersForbidden } = useOrders({ skipForbiddenRedirect: true });
   const { formatAmount } = useCurrency();
@@ -30,12 +30,12 @@ export function Store() {
     : { name: dashboardTranslations("stats.sales"), quantity: paidOrders.length };
 
   const STATS = [
-    {
+    ...(usersForbidden ? [] : [{
       id: 1,
       name: dashboardTranslations("stats.users"),
       quantity: users?.length,
       icon: Users,
-    },
+    }]),
     ...(productsForbidden ? [] : [{
       id: 2,
       name: dashboardTranslations("stats.products"),

--- a/client/src/components/pages/Store/Store.jsx
+++ b/client/src/components/pages/Store/Store.jsx
@@ -13,10 +13,10 @@ import { useProducts } from "./hooks/useProducts";
 import { useUsers } from "./hooks/useUsers";
 
 export function Store() {
-  const t = useTranslations("dashboard");
+  const dashboardTranslations = useTranslations("dashboard");
   const { users } = useUsers();
-  const { products } = useProducts();
-  const { orders } = useOrders();
+  const { products, forbidden: productsForbidden } = useProducts({ skipForbiddenRedirect: true });
+  const { orders, forbidden: ordersForbidden } = useOrders({ skipForbiddenRedirect: true });
   const { formatAmount } = useCurrency();
   const canSeeRevenue = usePermission({ allOf: ["reports_read"] });
 
@@ -26,32 +26,32 @@ export function Store() {
   const netRevenue = paidOrders.reduce((sum, order) => sum + (order.total ?? 0), 0);
 
   const salesStat = canSeeRevenue
-    ? { name: t("stats.revenue"), quantity: formatCurrency(netRevenue) }
-    : { name: t("stats.sales"), quantity: paidOrders.length };
+    ? { name: dashboardTranslations("stats.revenue"), quantity: formatCurrency(netRevenue) }
+    : { name: dashboardTranslations("stats.sales"), quantity: paidOrders.length };
 
   const STATS = [
     {
       id: 1,
-      name: t("stats.users"),
+      name: dashboardTranslations("stats.users"),
       quantity: users?.length,
       icon: Users,
     },
-    {
+    ...(productsForbidden ? [] : [{
       id: 2,
-      name: t("stats.products"),
+      name: dashboardTranslations("stats.products"),
       quantity: products?.length,
       icon: Package,
-    },
-    {
+    }]),
+    ...(ordersForbidden ? [] : [{
       id: 3,
       ...salesStat,
       icon: ShoppingCart,
-    },
+    }]),
   ];
 
   return (
     <>
-      <PageHeader title={t("title")} subtitle={t("subtitle")} />
+      <PageHeader title={dashboardTranslations("title")} subtitle={dashboardTranslations("subtitle")} />
 
       <div className="bg-white rounded-lg shadow-lg p-4 lg:p-8">
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">

--- a/client/src/components/pages/Store/Users/Roles/Roles.jsx
+++ b/client/src/components/pages/Store/Users/Roles/Roles.jsx
@@ -16,7 +16,7 @@ import { CreateRoleModal } from "./CreateRoleModal";
 import { DeleteRoleModal } from "./DeleteRoleModal";
 import { EditRoleModal } from "./EditRoleModal";
 import { RolesList } from "./RolesList";
-import { getVisiblePermissionCatalog } from "./utils/permissionCatalog";
+import { getVisiblePermissionCatalog, permissionCatalog } from "./utils/permissionCatalog";
 
 export function Roles({ roles, createRole, deleteRole, loading: loadingRoles, updateRoleWithPermissions, getRolePermissions }) {
   const roleTranslations = useTranslations();
@@ -48,11 +48,19 @@ export function Roles({ roles, createRole, deleteRole, loading: loadingRoles, up
   const togglePermission = (name) => {
     setForm((previousForm) => {
       const permissionExists = previousForm.permissions.includes(name);
+      if (permissionExists) {
+        return {
+          ...previousForm,
+          permissions: previousForm.permissions.filter((permissionName) => permissionName !== name),
+        };
+      }
+      const suggestedPermissions = permissionCatalog.find((permission) => permission.key === name)?.suggests ?? [];
+      const permissionsToAdd = [name, ...suggestedPermissions].filter(
+        (permissionName) => !previousForm.permissions.includes(permissionName),
+      );
       return {
         ...previousForm,
-        permissions: permissionExists
-          ? previousForm.permissions.filter((permissionName) => permissionName !== name)
-          : [...previousForm.permissions, name],
+        permissions: [...previousForm.permissions, ...permissionsToAdd],
       };
     });
   };

--- a/client/src/components/pages/Store/Users/Roles/__tests__/Roles.test.jsx
+++ b/client/src/components/pages/Store/Users/Roles/__tests__/Roles.test.jsx
@@ -54,7 +54,7 @@ jest.mock("../RolesList", () => ({
 }));
 
 jest.mock("../CreateRoleModal", () => ({
-  CreateRoleModal: ({ isOpen, onSubmit, form, setForm, creating }) => (
+  CreateRoleModal: ({ isOpen, onSubmit, form, setForm, creating, togglePermission }) => (
     isOpen ? (
       <div>
         <span>roles.create.title</span>
@@ -65,6 +65,12 @@ jest.mock("../CreateRoleModal", () => ({
         </button>
         <button type="button" onClick={() => setForm((currentForm) => ({ ...currentForm, isAdmin: true }))}>
           set admin role
+        </button>
+        <button type="button" onClick={() => togglePermission("orders_create")}>
+          toggle orders_create
+        </button>
+        <button type="button" onClick={() => togglePermission("products_read")}>
+          toggle products_read
         </button>
         <button type="button" onClick={onSubmit}>
           roles.actions.create
@@ -163,6 +169,43 @@ describe("Roles", () => {
       color: "success",
     });
     expect(screen.queryByText("roles.create.title")).not.toBeInTheDocument();
+  });
+
+  it("autocompletes the suggested permissions when orders_create is toggled on", async () => {
+    const createRole = jest.fn(() => Promise.resolve("role-id"));
+
+    renderRoles({ createRole });
+
+    fireEvent.click(screen.getByText("roles.actions.new"));
+    fireEvent.click(screen.getByText("set role name"));
+    fireEvent.click(screen.getByText("toggle orders_create"));
+
+    fireEvent.click(screen.getByText("roles.actions.create"));
+
+    await waitFor(() => expect(createRole).toHaveBeenCalledWith({
+      name: "cashier",
+      isAdmin: false,
+      permissions: ["orders_create", "products_read", "categories_read", "payments_read"],
+    }));
+  });
+
+  it("lets the admin untoggle one suggested permission without affecting the others", async () => {
+    const createRole = jest.fn(() => Promise.resolve("role-id"));
+
+    renderRoles({ createRole });
+
+    fireEvent.click(screen.getByText("roles.actions.new"));
+    fireEvent.click(screen.getByText("set role name"));
+    fireEvent.click(screen.getByText("toggle orders_create"));
+    fireEvent.click(screen.getByText("toggle products_read"));
+
+    fireEvent.click(screen.getByText("roles.actions.create"));
+
+    await waitFor(() => expect(createRole).toHaveBeenCalledWith({
+      name: "cashier",
+      isAdmin: false,
+      permissions: ["orders_create", "categories_read", "payments_read"],
+    }));
   });
 
   it("shows an error toast and keeps the create modal open when role creation fails", async () => {

--- a/client/src/components/pages/Store/Users/Roles/locales/en.js
+++ b/client/src/components/pages/Store/Users/Roles/locales/en.js
@@ -119,6 +119,7 @@ const rolesEn = {
         payments_create: { label: "Register payments", description: "Add payments to orders." },
         payments_update: { label: "Edit payments", description: "Adjust existing payments." },
         wallet_read: { label: "Access wallet", description: "Use wallet/cash UI." },
+        settings_read: { label: "View settings", description: "Read business data and currencies." },
         settings_update: { label: "Edit settings", description: "Update business data." },
         printer_update: { label: "Configure printer", description: "Update ticket printer settings." },
         dish_read: { label: "View dishes", description: "List menu dishes." },

--- a/client/src/components/pages/Store/Users/Roles/locales/es.js
+++ b/client/src/components/pages/Store/Users/Roles/locales/es.js
@@ -119,6 +119,7 @@ const rolesEs = {
         payments_create: { label: "Registrar pagos", description: "Agregar pagos a órdenes." },
         payments_update: { label: "Editar pagos", description: "Ajustar pagos existentes." },
         wallet_read: { label: "Acceder a billetera", description: "Usar la billetera/caja." },
+        settings_read: { label: "Ver configuración", description: "Leer datos de negocio y monedas." },
         settings_update: { label: "Editar configuración", description: "Actualizar datos de negocio." },
         printer_update: { label: "Configurar impresora", description: "Actualizar ajustes de tickets." },
         dish_read: { label: "Ver platillos", description: "Listar platillos del menú." },

--- a/client/src/components/pages/Store/Users/Roles/utils/permissionCatalog.js
+++ b/client/src/components/pages/Store/Users/Roles/utils/permissionCatalog.js
@@ -19,7 +19,7 @@ export const permissionCatalog = [
   { key: "categories_delete", group: "catalog", business: "store" },
 
   { key: "orders_read", group: "sales", business: "store" },
-  { key: "orders_create", group: "sales", business: "store" },
+  { key: "orders_create", group: "sales", business: "store", suggests: ["products_read", "categories_read", "payments_read"] },
   { key: "orders_update", group: "sales", business: "store" },
   { key: "orders_delete", group: "sales", business: "store" },
   { key: "orders_export", group: "sales", business: "store" },

--- a/client/src/components/pages/Store/Users/Roles/utils/permissionCatalog.js
+++ b/client/src/components/pages/Store/Users/Roles/utils/permissionCatalog.js
@@ -31,6 +31,7 @@ export const permissionCatalog = [
   { key: "payments_update", group: "payments", business: "both" },
   { key: "wallet_read", group: "payments", business: "store" },
 
+  { key: "settings_read", group: "settings", business: "both" },
   { key: "settings_update", group: "settings", business: "both" },
   { key: "printer_update", group: "settings", business: "store" },
 

--- a/client/src/components/pages/Store/__tests__/Store.test.jsx
+++ b/client/src/components/pages/Store/__tests__/Store.test.jsx
@@ -293,7 +293,14 @@ describe("Store Dashboard", () => {
     expect(screen.getByText("$150.00")).toBeInTheDocument();
   });
 
-  it("calls useProducts and useOrders with skipForbiddenRedirect: true", async () => {
+  it("calls useUsers, useProducts, and useOrders with skipForbiddenRedirect: true", async () => {
+    const usersSpy = jest.spyOn(useUsersHook, "useUsers").mockReturnValue({
+      users: mockUsers,
+      loading: false,
+      error: null,
+      forbidden: false,
+      refetch: jest.fn(),
+    });
     const productsSpy = jest.spyOn(useProductsHook, "useProducts").mockReturnValue({
       products: mockProducts,
       loading: false,
@@ -313,8 +320,27 @@ describe("Store Dashboard", () => {
       renderStore();
     });
 
+    expect(usersSpy).toHaveBeenCalledWith({ skipForbiddenRedirect: true });
     expect(productsSpy).toHaveBeenCalledWith({ skipForbiddenRedirect: true });
     expect(ordersSpy).toHaveBeenCalledWith({ skipForbiddenRedirect: true });
+  });
+
+  it("excludes the users card when useUsers reports forbidden", async () => {
+    jest.spyOn(useUsersHook, "useUsers").mockReturnValue({
+      users: [],
+      loading: false,
+      error: null,
+      forbidden: true,
+      refetch: jest.fn(),
+    });
+
+    await act(async () => {
+      renderStore();
+    });
+
+    expect(screen.queryByText("stats.users")).not.toBeInTheDocument();
+    expect(screen.getByText("stats.products")).toBeInTheDocument();
+    expect(screen.getByText("stats.sales")).toBeInTheDocument();
   });
 
   it("excludes the products card when useProducts reports forbidden", async () => {
@@ -354,7 +380,7 @@ describe("Store Dashboard", () => {
     expect(screen.queryByText("stats.revenue")).not.toBeInTheDocument();
   });
 
-  it("never excludes the users card, since listing users has no permission to check", async () => {
+  it("keeps the users card when only products and orders are forbidden", async () => {
     jest.spyOn(useProductsHook, "useProducts").mockReturnValue({
       products: [],
       loading: false,

--- a/client/src/components/pages/Store/__tests__/Store.test.jsx
+++ b/client/src/components/pages/Store/__tests__/Store.test.jsx
@@ -292,4 +292,88 @@ describe("Store Dashboard", () => {
     expect(screen.queryByText("stats.sales")).not.toBeInTheDocument();
     expect(screen.getByText("$150.00")).toBeInTheDocument();
   });
+
+  it("calls useProducts and useOrders with skipForbiddenRedirect: true", async () => {
+    const productsSpy = jest.spyOn(useProductsHook, "useProducts").mockReturnValue({
+      products: mockProducts,
+      loading: false,
+      error: null,
+      forbidden: false,
+      refetch: jest.fn(),
+    });
+    const ordersSpy = jest.spyOn(useOrdersHook, "useOrders").mockReturnValue({
+      orders: mockOrders,
+      loading: false,
+      error: null,
+      forbidden: false,
+      refetch: jest.fn(),
+    });
+
+    await act(async () => {
+      renderStore();
+    });
+
+    expect(productsSpy).toHaveBeenCalledWith({ skipForbiddenRedirect: true });
+    expect(ordersSpy).toHaveBeenCalledWith({ skipForbiddenRedirect: true });
+  });
+
+  it("excludes the products card when useProducts reports forbidden", async () => {
+    jest.spyOn(useProductsHook, "useProducts").mockReturnValue({
+      products: [],
+      loading: false,
+      error: null,
+      forbidden: true,
+      refetch: jest.fn(),
+    });
+
+    await act(async () => {
+      renderStore();
+    });
+
+    expect(screen.getByText("stats.users")).toBeInTheDocument();
+    expect(screen.queryByText("stats.products")).not.toBeInTheDocument();
+    expect(screen.getByText("stats.sales")).toBeInTheDocument();
+  });
+
+  it("excludes the revenue/sales card when useOrders reports forbidden", async () => {
+    jest.spyOn(useOrdersHook, "useOrders").mockReturnValue({
+      orders: [],
+      loading: false,
+      error: null,
+      forbidden: true,
+      refetch: jest.fn(),
+    });
+
+    await act(async () => {
+      renderStore();
+    });
+
+    expect(screen.getByText("stats.users")).toBeInTheDocument();
+    expect(screen.getByText("stats.products")).toBeInTheDocument();
+    expect(screen.queryByText("stats.sales")).not.toBeInTheDocument();
+    expect(screen.queryByText("stats.revenue")).not.toBeInTheDocument();
+  });
+
+  it("never excludes the users card, since listing users has no permission to check", async () => {
+    jest.spyOn(useProductsHook, "useProducts").mockReturnValue({
+      products: [],
+      loading: false,
+      error: null,
+      forbidden: true,
+      refetch: jest.fn(),
+    });
+    jest.spyOn(useOrdersHook, "useOrders").mockReturnValue({
+      orders: [],
+      loading: false,
+      error: null,
+      forbidden: true,
+      refetch: jest.fn(),
+    });
+
+    await act(async () => {
+      renderStore();
+    });
+
+    expect(screen.getByText("stats.users")).toBeInTheDocument();
+  });
 });

--- a/client/src/components/pages/Store/hooks/__tests__/useCategories.test.jsx
+++ b/client/src/components/pages/Store/hooks/__tests__/useCategories.test.jsx
@@ -11,6 +11,11 @@ jest.mock("@/lib/http", () => ({
   parseJsonResponse: jest.fn(),
 }));
 
+let mockCanReadCategories = true;
+jest.mock("@/hooks/usePermission", () => ({
+  usePermission: () => mockCanReadCategories,
+}));
+
 jest.mock("@heroui/react", () => ({
   addToast: jest.fn(),
 }));
@@ -52,6 +57,7 @@ describe("useCategories", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.spyOn(console, "error").mockImplementation(() => {});
+    mockCanReadCategories = true;
   });
 
   afterEach(() => {
@@ -229,5 +235,15 @@ describe("useCategories", () => {
     });
 
     expect(thrownError?.status).toBe(409);
+  });
+
+  it("does not fetch categories when the user lacks categories_read", async () => {
+    mockCanReadCategories = false;
+
+    render(<TestComponent />);
+
+    await waitFor(() => expect(screen.getByTestId("loading")).toHaveTextContent("no"));
+    expect(screen.getByTestId("count")).toHaveTextContent("0");
+    expect(httpClient).not.toHaveBeenCalled();
   });
 });

--- a/client/src/components/pages/Store/hooks/__tests__/useCategories.test.jsx
+++ b/client/src/components/pages/Store/hooks/__tests__/useCategories.test.jsx
@@ -71,7 +71,7 @@ describe("useCategories", () => {
     expect(screen.getByTestId("count")).toHaveTextContent("2");
     expect(screen.getByTestId("first-name")).toHaveTextContent("Hardware");
     expect(screen.getByTestId("error")).toHaveTextContent("no");
-    expect(httpClient).toHaveBeenCalledWith("/categories?type=product");
+    expect(httpClient).toHaveBeenCalledWith("/categories?type=product", {});
   });
 
   it("sets empty categories when api returns non-array", async () => {

--- a/client/src/components/pages/Store/hooks/__tests__/useCategories.test.jsx
+++ b/client/src/components/pages/Store/hooks/__tests__/useCategories.test.jsx
@@ -32,6 +32,7 @@ function TestComponent() {
     categories,
     loading,
     error,
+    forbidden,
     createCategory,
     updateCategory,
     deleteCategory,
@@ -49,6 +50,7 @@ function TestComponent() {
       <span data-testid="count">{categories.length}</span>
       <span data-testid="first-name">{categories[0]?.name ?? ""}</span>
       <span data-testid="error">{error ? "yes" : "no"}</span>
+      <span data-testid="forbidden">{forbidden ? "yes" : "no"}</span>
     </div>
   );
 }
@@ -244,6 +246,7 @@ describe("useCategories", () => {
 
     await waitFor(() => expect(screen.getByTestId("loading")).toHaveTextContent("no"));
     expect(screen.getByTestId("count")).toHaveTextContent("0");
+    expect(screen.getByTestId("forbidden")).toHaveTextContent("yes");
     expect(httpClient).not.toHaveBeenCalled();
   });
 });

--- a/client/src/components/pages/Store/hooks/__tests__/useOrders.test.jsx
+++ b/client/src/components/pages/Store/hooks/__tests__/useOrders.test.jsx
@@ -16,11 +16,6 @@ jest.mock("@heroui/react", () => ({
   addToast: (...args) => mockAddToast(...args),
 }));
 
-jest.mock("next-intl", () => {
-  const t = (key) => key;
-  return { useTranslations: () => t };
-});
-
 const handlers = {};
 
 function TestComponent() {

--- a/client/src/components/pages/Store/hooks/__tests__/useOrders.test.jsx
+++ b/client/src/components/pages/Store/hooks/__tests__/useOrders.test.jsx
@@ -86,7 +86,7 @@ describe("useOrders", () => {
       await handlers.fetchOrdersFiltered({ status: "paid" });
     });
 
-    expect(httpClient).toHaveBeenLastCalledWith("/orders/with-payments?status=paid");
+    expect(httpClient).toHaveBeenLastCalledWith("/orders/with-payments?status=paid", { skipForbiddenRedirect: false });
   });
 
   it("fetchOrdersFiltered sends sorting query params", async () => {
@@ -102,7 +102,7 @@ describe("useOrders", () => {
       await handlers.fetchOrdersFiltered({ sortBy: "total", sortOrder: "asc" });
     });
 
-    expect(httpClient).toHaveBeenLastCalledWith("/orders/with-payments?sortBy=total&sortOrder=asc");
+    expect(httpClient).toHaveBeenLastCalledWith("/orders/with-payments?sortBy=total&sortOrder=asc", { skipForbiddenRedirect: false });
   });
 
   it("fetchOrdersFiltered omits empty params", async () => {
@@ -118,7 +118,7 @@ describe("useOrders", () => {
       await handlers.fetchOrdersFiltered({});
     });
 
-    expect(httpClient).toHaveBeenLastCalledWith("/orders/with-payments");
+    expect(httpClient).toHaveBeenLastCalledWith("/orders/with-payments", { skipForbiddenRedirect: false });
   });
 
   it("shows connection toast and returns null when filtered fetch returns non-ok response", async () => {

--- a/client/src/components/pages/Store/hooks/__tests__/usePaymentCurrency.test.jsx
+++ b/client/src/components/pages/Store/hooks/__tests__/usePaymentCurrency.test.jsx
@@ -1,0 +1,82 @@
+import { act, useEffect } from "react";
+
+import { render, screen } from "@testing-library/react";
+
+import { httpClient, parseJsonResponse } from "@/lib/http";
+
+import { usePaymentCurrency } from "../usePaymentCurrency";
+
+jest.mock("@/lib/http", () => ({
+  httpClient: jest.fn(),
+  parseJsonResponse: jest.fn(),
+}));
+
+let mockCanReadPaymentCurrency = true;
+jest.mock("@/hooks/usePermission", () => ({
+  usePermission: () => mockCanReadPaymentCurrency,
+}));
+
+const handlers = {};
+
+function TestComponent() {
+  const { getPaymentCurrencyById, forbidden } = usePaymentCurrency();
+
+  useEffect(() => {
+    handlers.getPaymentCurrencyById = getPaymentCurrencyById;
+  }, [getPaymentCurrencyById]);
+
+  return (
+    <div>
+      <span data-testid="forbidden">{forbidden ? "yes" : "no"}</span>
+    </div>
+  );
+}
+
+describe("usePaymentCurrency", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCanReadPaymentCurrency = true;
+  });
+
+  it("fetches payment currency by id", async () => {
+    httpClient.mockResolvedValue({ ok: true });
+    parseJsonResponse.mockResolvedValueOnce({ id: "c1", acronym: "USD" });
+
+    render(<TestComponent />);
+
+    let result;
+    await act(async () => {
+      result = await handlers.getPaymentCurrencyById("c1");
+    });
+
+    expect(httpClient).toHaveBeenCalledWith("/payments/currencies/c1");
+    expect(result).toEqual({ id: "c1", acronym: "USD" });
+  });
+
+  it("returns null when called with no id", async () => {
+    render(<TestComponent />);
+
+    let result;
+    await act(async () => {
+      result = await handlers.getPaymentCurrencyById(null);
+    });
+
+    expect(result).toBeNull();
+    expect(httpClient).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch payment currency when the user lacks payments_read", async () => {
+    mockCanReadPaymentCurrency = false;
+
+    render(<TestComponent />);
+    expect(screen.getByTestId("forbidden")).toHaveTextContent("yes");
+
+    let result;
+    await act(async () => {
+      result = await handlers.getPaymentCurrencyById("c1");
+    });
+
+    expect(result).toBeNull();
+    expect(httpClient).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/components/pages/Store/hooks/__tests__/usePaymentCurrency.test.jsx
+++ b/client/src/components/pages/Store/hooks/__tests__/usePaymentCurrency.test.jsx
@@ -44,24 +44,24 @@ describe("usePaymentCurrency", () => {
 
     render(<TestComponent />);
 
-    let result;
+    let paymentCurrency;
     await act(async () => {
-      result = await handlers.getPaymentCurrencyById("c1");
+      paymentCurrency = await handlers.getPaymentCurrencyById("c1");
     });
 
     expect(httpClient).toHaveBeenCalledWith("/payments/currencies/c1");
-    expect(result).toEqual({ id: "c1", acronym: "USD" });
+    expect(paymentCurrency).toEqual({ id: "c1", acronym: "USD" });
   });
 
   it("returns null when called with no id", async () => {
     render(<TestComponent />);
 
-    let result;
+    let paymentCurrency;
     await act(async () => {
-      result = await handlers.getPaymentCurrencyById(null);
+      paymentCurrency = await handlers.getPaymentCurrencyById(null);
     });
 
-    expect(result).toBeNull();
+    expect(paymentCurrency).toBeNull();
     expect(httpClient).not.toHaveBeenCalled();
   });
 
@@ -71,12 +71,12 @@ describe("usePaymentCurrency", () => {
     render(<TestComponent />);
     expect(screen.getByTestId("forbidden")).toHaveTextContent("yes");
 
-    let result;
+    let paymentCurrency;
     await act(async () => {
-      result = await handlers.getPaymentCurrencyById("c1");
+      paymentCurrency = await handlers.getPaymentCurrencyById("c1");
     });
 
-    expect(result).toBeNull();
+    expect(paymentCurrency).toBeNull();
     expect(httpClient).not.toHaveBeenCalled();
   });
 });

--- a/client/src/components/pages/Store/hooks/__tests__/usePayments.test.jsx
+++ b/client/src/components/pages/Store/hooks/__tests__/usePayments.test.jsx
@@ -16,8 +16,8 @@ jest.mock("@heroui/react", () => ({
 }));
 
 jest.mock("next-intl", () => {
-  const t = (key) => key;
-  return { useTranslations: () => t };
+  const errorsTranslations = (key) => key;
+  return { useTranslations: () => errorsTranslations };
 });
 
 const handlers = {};

--- a/client/src/components/pages/Store/hooks/__tests__/usePayments.test.jsx
+++ b/client/src/components/pages/Store/hooks/__tests__/usePayments.test.jsx
@@ -23,12 +23,11 @@ jest.mock("next-intl", () => {
 const handlers = {};
 
 function TestComponent() {
-  const { payments, loading, error, refetch, getPaymentCurrencyById } = usePayments();
+  const { payments, loading, error, refetch } = usePayments();
 
   useEffect(() => {
     handlers.refetch = refetch;
-    handlers.getPaymentCurrencyById = getPaymentCurrencyById;
-  }, [refetch, getPaymentCurrencyById]);
+  }, [refetch]);
 
   return (
     <div>
@@ -92,38 +91,5 @@ describe("usePayments", () => {
     });
 
     await waitFor(() => expect(screen.getByTestId("count")).toHaveTextContent("2"));
-  });
-
-  it("fetches payment currency by id", async () => {
-    httpClient.mockResolvedValue({ ok: true });
-    parseJsonResponse.mockResolvedValueOnce([]);
-    parseJsonResponse.mockResolvedValueOnce({ id: "c1", acronym: "USD" });
-
-    render(<TestComponent />);
-    await waitFor(() => expect(screen.getByTestId("loading")).toHaveTextContent("no"));
-
-    let result;
-    await act(async () => {
-      result = await handlers.getPaymentCurrencyById("c1");
-    });
-
-    expect(httpClient).toHaveBeenCalledWith("/payments/currencies/c1");
-    expect(result).toEqual({ id: "c1", acronym: "USD" });
-  });
-
-  it("returns null when getPaymentCurrencyById called with no id", async () => {
-    httpClient.mockResolvedValue({ ok: true });
-    parseJsonResponse.mockResolvedValueOnce([]);
-
-    render(<TestComponent />);
-    await waitFor(() => expect(screen.getByTestId("loading")).toHaveTextContent("no"));
-
-    let result;
-    await act(async () => {
-      result = await handlers.getPaymentCurrencyById(null);
-    });
-
-    expect(result).toBeNull();
-    expect(httpClient).toHaveBeenCalledTimes(1);
   });
 });

--- a/client/src/components/pages/Store/hooks/__tests__/usePermissions.test.jsx
+++ b/client/src/components/pages/Store/hooks/__tests__/usePermissions.test.jsx
@@ -9,6 +9,11 @@ jest.mock("@/lib/http", () => ({
   parseJsonResponse: jest.fn(),
 }));
 
+let mockCanReadPermissions = true;
+jest.mock("@/hooks/usePermission", () => ({
+  usePermission: () => mockCanReadPermissions,
+}));
+
 function TestComponent({ enabled = true }) {
   const { permissions, loading, error } = usePermissions({ enabled });
 
@@ -26,6 +31,7 @@ describe("usePermissions", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.spyOn(console, "error").mockImplementation(() => {});
+    mockCanReadPermissions = true;
   });
 
   afterEach(() => {
@@ -79,5 +85,15 @@ describe("usePermissions", () => {
     await waitFor(() => expect(screen.getByTestId("loading")).toHaveTextContent("no"));
     expect(httpClient).not.toHaveBeenCalled();
     expect(screen.getByTestId("count")).toHaveTextContent("0");
+  });
+
+  it("does not fetch permissions when the user lacks permissions_read", async () => {
+    mockCanReadPermissions = false;
+
+    render(<TestComponent />);
+
+    await waitFor(() => expect(screen.getByTestId("loading")).toHaveTextContent("no"));
+    expect(screen.getByTestId("count")).toHaveTextContent("0");
+    expect(httpClient).not.toHaveBeenCalled();
   });
 });

--- a/client/src/components/pages/Store/hooks/__tests__/usePrinter.test.jsx
+++ b/client/src/components/pages/Store/hooks/__tests__/usePrinter.test.jsx
@@ -16,8 +16,8 @@ jest.mock("@heroui/react", () => ({
 }));
 
 jest.mock("next-intl", () => {
-  const t = (key) => key;
-  return { useTranslations: () => t };
+  const errorsTranslations = (key) => key;
+  return { useTranslations: () => errorsTranslations };
 });
 
 const handlers = {};

--- a/client/src/components/pages/Store/hooks/__tests__/usePrinter.test.jsx
+++ b/client/src/components/pages/Store/hooks/__tests__/usePrinter.test.jsx
@@ -285,8 +285,8 @@ describe("usePrinters", () => {
       await handlers.refetchAll();
     });
 
-    expect(httpClient).toHaveBeenCalledWith("/printers/available");
-    expect(httpClient).toHaveBeenCalledWith("/printers/configs");
+    expect(httpClient).toHaveBeenCalledWith("/printers/available", {});
+    expect(httpClient).toHaveBeenCalledWith("/printers/configs", {});
     expect(screen.getByTestId("available-count")).toHaveTextContent("1");
     expect(screen.getByTestId("config-count")).toHaveTextContent("1");
   });

--- a/client/src/components/pages/Store/hooks/__tests__/useUsers.test.jsx
+++ b/client/src/components/pages/Store/hooks/__tests__/useUsers.test.jsx
@@ -23,8 +23,8 @@ jest.mock("next-intl", () => {
 
 const handlers = {};
 
-function TestComponent() {
-  const { users, loading, error, addUser, updateUser, deleteUser } = useUsers();
+function TestComponent({ skipForbiddenRedirect } = {}) {
+  const { users, loading, error, forbidden, addUser, updateUser, deleteUser } = useUsers({ skipForbiddenRedirect });
 
   useEffect(() => {
     handlers.addUser = addUser;
@@ -38,6 +38,7 @@ function TestComponent() {
       <span data-testid="count">{users.length}</span>
       <span data-testid="first-name">{users[0]?.name ?? ""}</span>
       <span data-testid="error">{error ? "yes" : "no"}</span>
+      <span data-testid="forbidden">{forbidden ? "yes" : "no"}</span>
     </div>
   );
 }
@@ -64,6 +65,24 @@ describe("useUsers", () => {
 
     await waitFor(() => expect(screen.getByTestId("loading")).toHaveTextContent("no"));
     expect(screen.getByTestId("count")).toHaveTextContent("0");
+  });
+
+  it("sets forbidden when the response is 403", async () => {
+    httpClient.mockResolvedValueOnce({ ok: false, status: 403 });
+    render(<TestComponent skipForbiddenRedirect />);
+
+    await waitFor(() => expect(screen.getByTestId("loading")).toHaveTextContent("no"));
+    expect(screen.getByTestId("forbidden")).toHaveTextContent("yes");
+    expect(screen.getByTestId("count")).toHaveTextContent("0");
+  });
+
+  it("passes skipForbiddenRedirect through to httpClient", async () => {
+    httpClient.mockResolvedValueOnce({ ok: true });
+    parseJsonResponse.mockResolvedValueOnce([]);
+    render(<TestComponent skipForbiddenRedirect />);
+
+    await waitFor(() => expect(screen.getByTestId("loading")).toHaveTextContent("no"));
+    expect(httpClient).toHaveBeenCalledWith("/users", { skipForbiddenRedirect: true });
   });
 
   it("adds a user and refetches", async () => {

--- a/client/src/components/pages/Store/hooks/useCategories.jsx
+++ b/client/src/components/pages/Store/hooks/useCategories.jsx
@@ -96,6 +96,7 @@ export function useCategories(type = "product") {
     deleteCategory,
     loading,
     error,
+    forbidden: !canRead,
     refetch: fetchCategories,
   };
 }

--- a/client/src/components/pages/Store/hooks/useCategories.jsx
+++ b/client/src/components/pages/Store/hooks/useCategories.jsx
@@ -2,6 +2,7 @@
 import { useState, useEffect, useCallback } from "react";
 
 import { toArray } from "@/components/utils/array";
+import { usePermission } from "@/hooks/usePermission";
 import { httpClient, parseJsonResponse } from "@/lib/http";
 import { useFetchList } from "@/lib/http/useFetchList";
 
@@ -9,11 +10,13 @@ import { buildParsedHttpError } from "../utils/buildHttpError";
 
 export function useCategories(type = "product") {
   const { fetchList } = useFetchList();
+  const canRead = usePermission({ allOf: ["categories_read"] });
   const [categories, setCategories] = useState([]);
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(canRead);
   const [error, setError] = useState(null);
 
   const fetchCategories = useCallback(async () => {
+    if (!canRead) return;
     setLoading(true);
     setError(null);
 
@@ -27,7 +30,7 @@ export function useCategories(type = "product") {
     } finally {
       setLoading(false);
     }
-  }, [fetchList, type]);
+  }, [canRead, fetchList, type]);
 
   const createCategory = useCallback(
     async (name, categoryType) => {

--- a/client/src/components/pages/Store/hooks/useOrders.jsx
+++ b/client/src/components/pages/Store/hooks/useOrders.jsx
@@ -29,30 +29,33 @@ function buildOrdersQueryString(filters = {}) {
   return queryString ? `/orders/with-payments?${queryString}` : "/orders/with-payments";
 }
 
-export function useOrders() {
+export function useOrders({ skipForbiddenRedirect = false } = {}) {
   const { fetchList } = useFetchList();
   const [orders, setOrders] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+  const [forbidden, setForbidden] = useState(false);
 
   const fetchOrdersRequest = useCallback(async (filters = {}) => {
     setLoading(true);
     setError(null);
+    setForbidden(false);
 
     try {
       const endpoint = buildOrdersQueryString(filters);
-      const ordersData = await fetchList(endpoint);
+      const ordersData = await fetchList(endpoint, [], { skipForbiddenRedirect });
       if (ordersData === null) return null;
       setOrders(toArray(ordersData));
       return toArray(ordersData);
-    } catch (err) {
-      setError(err);
+    } catch (loadError) {
+      if (loadError?.status === 403) setForbidden(true);
+      setError(loadError);
       setOrders([]);
       return null;
     } finally {
       setLoading(false);
     }
-  }, [fetchList]);
+  }, [fetchList, skipForbiddenRedirect]);
 
   const fetchOrders = useCallback(async () => {
     await fetchOrdersRequest();
@@ -71,6 +74,7 @@ export function useOrders() {
     orders,
     loading,
     error,
+    forbidden,
     refetch: fetchOrders,
     fetchOrders,
     fetchOrdersFiltered,

--- a/client/src/components/pages/Store/hooks/usePaymentCurrency.jsx
+++ b/client/src/components/pages/Store/hooks/usePaymentCurrency.jsx
@@ -1,0 +1,31 @@
+"use client";
+import { useCallback, useState } from "react";
+
+import { usePermission } from "@/hooks/usePermission";
+import { httpClient, parseJsonResponse } from "@/lib/http";
+
+export function usePaymentCurrency() {
+  const canRead = usePermission({ allOf: ["payments_read"] });
+  const [error, setError] = useState(null);
+
+  const getPaymentCurrencyById = useCallback(
+    async (currencyId) => {
+      if (!canRead || !currencyId) return null;
+      try {
+        const paymentCurrencyResponse = await httpClient(`/payments/currencies/${currencyId}`);
+        return await parseJsonResponse(paymentCurrencyResponse, null);
+      } catch (paymentCurrencyError) {
+        console.error("Error fetching payment currency:", paymentCurrencyError);
+        setError(paymentCurrencyError);
+        throw paymentCurrencyError;
+      }
+    },
+    [canRead],
+  );
+
+  return {
+    getPaymentCurrencyById,
+    error,
+    forbidden: !canRead,
+  };
+}

--- a/client/src/components/pages/Store/hooks/usePayments.jsx
+++ b/client/src/components/pages/Store/hooks/usePayments.jsx
@@ -2,7 +2,6 @@
 import { useState, useEffect, useCallback } from "react";
 
 import { toArray } from "@/components/utils/array";
-import { httpClient, parseJsonResponse } from "@/lib/http";
 import { useFetchList } from "@/lib/http/useFetchList";
 
 export function usePayments() {
@@ -18,28 +17,13 @@ export function usePayments() {
       const paymentsData = await fetchList("/payments");
       if (paymentsData === null) return;
       setPayments(toArray(paymentsData));
-    } catch (error) {
-      console.error("Error fetching payments:", error);
-      setError(error);
+    } catch (paymentsLoadError) {
+      console.error("Error fetching payments:", paymentsLoadError);
+      setError(paymentsLoadError);
     } finally {
       setLoading(false);
     }
   }, [fetchList]);
-
-  const getPaymentCurrencyById = useCallback(
-    async (currencyId) => {
-      if (!currencyId) return null;
-      try {
-        const paymentCurrencyById = await httpClient(`/payments/currencies/${currencyId}`);
-        return await parseJsonResponse(paymentCurrencyById, null);
-      } catch (error) {
-        console.error("Error fetching payment currency:", error);
-        setError(error);
-        throw error;
-      }
-    },
-    [],
-  );
 
   useEffect(() => {
     fetchPayments();
@@ -50,6 +34,5 @@ export function usePayments() {
     loading,
     error,
     refetch: fetchPayments,
-    getPaymentCurrencyById,
   };
 }

--- a/client/src/components/pages/Store/hooks/usePermissions.jsx
+++ b/client/src/components/pages/Store/hooks/usePermissions.jsx
@@ -2,15 +2,18 @@
 import { useCallback, useEffect, useState } from "react";
 
 import { toArray } from "@/components/utils/array";
+import { usePermission } from "@/hooks/usePermission";
 import { httpClient, parseJsonResponse } from "@/lib/http";
 
 export function usePermissions({ enabled = true } = {}) {
+  const canReadPermissions = usePermission({ allOf: ["permissions_read"] });
+  const shouldFetch = enabled && canReadPermissions;
   const [permissions, setPermissions] = useState([]);
-  const [loading, setLoading] = useState(enabled);
+  const [loading, setLoading] = useState(shouldFetch);
   const [error, setError] = useState(null);
 
   const fetchPermissions = useCallback(async () => {
-    if (!enabled) {
+    if (!shouldFetch) {
       setPermissions([]);
       setError(null);
       setLoading(false);
@@ -23,13 +26,13 @@ export function usePermissions({ enabled = true } = {}) {
 
       const permissionsData = await parseJsonResponse(permissionsRequest);
       setPermissions(toArray(permissionsData));
-    } catch (error) {
-      console.error("Error fetching permissions:", error);
-      setError(error);
+    } catch (permissionsLoadError) {
+      console.error("Error fetching permissions:", permissionsLoadError);
+      setError(permissionsLoadError);
     } finally {
       setLoading(false);
     }
-  }, [enabled]);
+  }, [shouldFetch]);
 
   useEffect(() => {
     fetchPermissions();

--- a/client/src/components/pages/Store/hooks/useProducts.jsx
+++ b/client/src/components/pages/Store/hooks/useProducts.jsx
@@ -16,11 +16,12 @@ import { resolveImageUrl } from "../utils/resolveImageUrl";
 
 import { useProductVariants } from "./useProductVariants";
 
-export function useProducts() {
+export function useProducts({ skipForbiddenRedirect = false } = {}) {
   const productsTranslations = useTranslations("products");
   const [products, setProducts] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+  const [forbidden, setForbidden] = useState(false);
   const { upload, isUploading } = useUpload();
   const { updateVariant } = useProductVariants();
 
@@ -74,7 +75,8 @@ export function useProducts() {
     setLoading(true);
     setError(null);
     try {
-      const productsResponse = await httpClient("/products");
+      const productsResponse = await httpClient("/products", { skipForbiddenRedirect });
+      setForbidden(productsResponse.status === 403);
       if (!productsResponse.ok) return;
       const fetchedProducts = await parseJsonResponse(productsResponse, []);
       setProducts(toArray(fetchedProducts));
@@ -83,7 +85,7 @@ export function useProducts() {
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [skipForbiddenRedirect]);
 
   const addProduct = async (productForm) => {
     try {
@@ -161,6 +163,7 @@ export function useProducts() {
     deleteProduct,
     loading,
     error,
+    forbidden,
     refetch: fetchProducts,
   };
 }

--- a/client/src/components/pages/Store/hooks/useUsers.jsx
+++ b/client/src/components/pages/Store/hooks/useUsers.jsx
@@ -6,7 +6,6 @@ import { useTranslations } from "next-intl";
 
 import { toArray } from "@/components/utils/array";
 import { httpClient, parseJsonResponse } from "@/lib/http";
-import { useFetchList } from "@/lib/http/useFetchList";
 
 import { buildParsedHttpError } from "../utils/buildHttpError";
 
@@ -18,12 +17,12 @@ function isAdminPrivilegesRequired(requestError) {
   return requestError?.status === 403 && requestError?.responseMessage === "Admin privileges required";
 }
 
-export function useUsers() {
+export function useUsers({ skipForbiddenRedirect = false } = {}) {
   const usersTranslations = useTranslations("users");
-  const { fetchList } = useFetchList();
   const [users, setUsers] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+  const [forbidden, setForbidden] = useState(false);
 
   const showGenericMutationErrorToast = useCallback(() => {
     addToast({
@@ -59,13 +58,17 @@ export function useUsers() {
     setError(null);
 
     try {
-      const usersData = await fetchList("/users");
-      if (usersData === null) return;
+      const usersResponse = await httpClient("/users", { skipForbiddenRedirect });
+      setForbidden(usersResponse.status === 403);
+      if (!usersResponse.ok) return;
+      const usersData = await parseJsonResponse(usersResponse, []);
       setUsers(toArray(usersData));
+    } catch (loadError) {
+      setError(loadError);
     } finally {
       setLoading(false);
     }
-  }, [fetchList]);
+  }, [skipForbiddenRedirect]);
 
   const updateUser = async (user) => {
     try {
@@ -194,6 +197,7 @@ export function useUsers() {
     deleteUser,
     loading,
     error,
+    forbidden,
     refetch: fetchUsers,
   };
 }

--- a/client/src/lib/http/__tests__/httpClient.test.js
+++ b/client/src/lib/http/__tests__/httpClient.test.js
@@ -1,0 +1,56 @@
+import { httpClient } from "../httpClient";
+import { httpWrapper } from "../httpWrapper";
+
+jest.mock("../httpWrapper", () => ({
+  httpWrapper: jest.fn(),
+}));
+
+function mockResponse(status) {
+  return { ok: status >= 200 && status < 300, status };
+}
+
+describe("httpClient", () => {
+  let forbiddenListener;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    forbiddenListener = jest.fn();
+    window.addEventListener("auth:forbidden", forbiddenListener);
+  });
+
+  afterEach(() => {
+    window.removeEventListener("auth:forbidden", forbiddenListener);
+  });
+
+  it("dispatches auth:forbidden on a 403 by default", async () => {
+    httpWrapper.mockResolvedValueOnce(mockResponse(403));
+
+    await httpClient("/products");
+
+    expect(forbiddenListener).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not dispatch auth:forbidden on a 403 when skipForbiddenRedirect is true", async () => {
+    httpWrapper.mockResolvedValueOnce(mockResponse(403));
+
+    await httpClient("/products", { skipForbiddenRedirect: true });
+
+    expect(forbiddenListener).not.toHaveBeenCalled();
+  });
+
+  it("still dispatches auth:forbidden on a 403 when only skipRefresh is true", async () => {
+    httpWrapper.mockResolvedValueOnce(mockResponse(403));
+
+    await httpClient("/products", { skipRefresh: true });
+
+    expect(forbiddenListener).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not dispatch auth:forbidden on a successful response", async () => {
+    httpWrapper.mockResolvedValueOnce(mockResponse(200));
+
+    await httpClient("/products");
+
+    expect(forbiddenListener).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/lib/http/__tests__/useFetchList.test.js
+++ b/client/src/lib/http/__tests__/useFetchList.test.js
@@ -15,8 +15,8 @@ jest.mock("@heroui/react", () => ({
 }));
 
 jest.mock("next-intl", () => {
-  const t = (key) => key;
-  return { useTranslations: () => t };
+  const errorsTranslations = (key) => key;
+  return { useTranslations: () => errorsTranslations };
 });
 
 describe("useFetchList", () => {

--- a/client/src/lib/http/__tests__/useFetchList.test.js
+++ b/client/src/lib/http/__tests__/useFetchList.test.js
@@ -28,29 +28,29 @@ describe("useFetchList", () => {
     httpClient.mockResolvedValueOnce({ ok: true });
     parseJsonResponse.mockResolvedValueOnce([{ id: 1 }]);
 
-    const { result } = renderHook(() => useFetchList());
+    const { result: fetchListHook } = renderHook(() => useFetchList());
 
-    let data;
+    let fetchedList;
     await act(async () => {
-      data = await result.current.fetchList("/items");
+      fetchedList = await fetchListHook.current.fetchList("/items");
     });
 
-    expect(httpClient).toHaveBeenCalledWith("/items");
-    expect(data).toEqual([{ id: 1 }]);
+    expect(httpClient).toHaveBeenCalledWith("/items", {});
+    expect(fetchedList).toEqual([{ id: 1 }]);
     expect(mockAddToast).not.toHaveBeenCalled();
   });
 
   it("returns null and shows toast when response is not ok", async () => {
     httpClient.mockResolvedValueOnce({ ok: false });
 
-    const { result } = renderHook(() => useFetchList());
+    const { result: fetchListHook } = renderHook(() => useFetchList());
 
-    let data;
+    let fetchedList;
     await act(async () => {
-      data = await result.current.fetchList("/items");
+      fetchedList = await fetchListHook.current.fetchList("/items");
     });
 
-    expect(data).toBeNull();
+    expect(fetchedList).toBeNull();
     expect(mockAddToast).toHaveBeenCalledWith({
       title: "connectionErrorTitle",
       description: "connectionErrorDescription",
@@ -63,34 +63,47 @@ describe("useFetchList", () => {
     httpClient.mockResolvedValueOnce({ ok: true });
     parseJsonResponse.mockResolvedValueOnce(null);
 
-    const { result } = renderHook(() => useFetchList());
+    const { result: fetchListHook } = renderHook(() => useFetchList());
 
-    let data;
+    let fetchedList;
     await act(async () => {
-      data = await result.current.fetchList("/items", []);
+      fetchedList = await fetchListHook.current.fetchList("/items", []);
     });
 
     expect(parseJsonResponse).toHaveBeenCalledWith({ ok: true }, []);
-    expect(data).toBeNull();
+    expect(fetchedList).toBeNull();
   });
 
   it("defaults fallback to empty array", async () => {
     httpClient.mockResolvedValueOnce({ ok: true });
     parseJsonResponse.mockResolvedValueOnce([]);
 
-    const { result } = renderHook(() => useFetchList());
+    const { result: fetchListHook } = renderHook(() => useFetchList());
 
     await act(async () => {
-      await result.current.fetchList("/items");
+      await fetchListHook.current.fetchList("/items");
     });
 
     expect(parseJsonResponse).toHaveBeenCalledWith({ ok: true }, []);
   });
 
+  it("forwards options to httpClient, e.g. skipForbiddenRedirect", async () => {
+    httpClient.mockResolvedValueOnce({ ok: true });
+    parseJsonResponse.mockResolvedValueOnce([]);
+
+    const { result: fetchListHook } = renderHook(() => useFetchList());
+
+    await act(async () => {
+      await fetchListHook.current.fetchList("/items", [], { skipForbiddenRedirect: true });
+    });
+
+    expect(httpClient).toHaveBeenCalledWith("/items", { skipForbiddenRedirect: true });
+  });
+
   it("returns a stable fetchList reference between renders", () => {
-    const { result, rerender } = renderHook(() => useFetchList());
-    const first = result.current.fetchList;
+    const { result: fetchListHook, rerender } = renderHook(() => useFetchList());
+    const fetchListBeforeRerender = fetchListHook.current.fetchList;
     rerender();
-    expect(result.current.fetchList).toBe(first);
+    expect(fetchListHook.current.fetchList).toBe(fetchListBeforeRerender);
   });
 });

--- a/client/src/lib/http/httpClient.js
+++ b/client/src/lib/http/httpClient.js
@@ -17,7 +17,7 @@ async function refreshToken() {
 }
 
 export async function httpClient(endpoint, options = {}) {
-  const { skipRefresh = false, ...httpOptions } = options;
+  const { skipRefresh = false, skipForbiddenRedirect = false, ...httpOptions } = options;
 
   const AUTH_EXCLUDED_PATHS = ["/auth", "/wallet"];
 
@@ -26,24 +26,24 @@ export async function httpClient(endpoint, options = {}) {
     return !AUTH_EXCLUDED_PATHS.some((path) => endpoint.startsWith(path));
   };
 
-  const response = await httpWrapper(endpoint, httpOptions);
+  const initialResponse = await httpWrapper(endpoint, httpOptions);
 
-  if (shouldRefreshToken(response.status, endpoint, skipRefresh)) {
+  if (shouldRefreshToken(initialResponse.status, endpoint, skipRefresh)) {
     const refreshResponse = await refreshToken();
 
     if (refreshResponse.status === 401) {
       dispatchAuthEvent("auth:expired");
-      return response;
+      return initialResponse;
     }
     return await httpWrapper(endpoint, httpOptions);
   }
 
-  if (response.status === 401 && !skipRefresh) {
+  if (initialResponse.status === 401 && !skipRefresh) {
     const event = endpoint.startsWith("/wallet") ? "wallet:unauthorized" : "auth:expired";
     dispatchAuthEvent(event);
   }
-  if (response.status === 403 && !skipRefresh)
+  if (initialResponse.status === 403 && !skipForbiddenRedirect)
     dispatchAuthEvent("auth:forbidden");
 
-  return response;
+  return initialResponse;
 }

--- a/client/src/lib/http/useFetchList.js
+++ b/client/src/lib/http/useFetchList.js
@@ -7,20 +7,20 @@ import { useTranslations } from "next-intl";
 import { httpClient, parseJsonResponse } from "./index";
 
 export function useFetchList() {
-  const tErrors = useTranslations("errors");
+  const errorsTranslations = useTranslations("errors");
 
-  const fetchList = useCallback(async (url, fallback = []) => {
-    const listResponse = await httpClient(url);
+  const fetchList = useCallback(async (url, fallback = [], options = {}) => {
+    const listResponse = await httpClient(url, options);
     if (!listResponse.ok) {
       addToast({
-        title: tErrors("connectionErrorTitle"),
-        description: tErrors("connectionErrorDescription"),
+        title: errorsTranslations("connectionErrorTitle"),
+        description: errorsTranslations("connectionErrorDescription"),
         color: "danger",
       });
       return null;
     }
     return parseJsonResponse(listResponse, fallback);
-  }, [tErrors]);
+  }, [errorsTranslations]);
 
   return { fetchList };
 }

--- a/client/src/services/__tests__/shiftsService.test.js
+++ b/client/src/services/__tests__/shiftsService.test.js
@@ -34,7 +34,7 @@ describe("shiftsService", () => {
       const result = await getTurnOpen();
 
       expect(result).toEqual(shift);
-      expect(httpClient).toHaveBeenCalledWith("/shifts/open");
+      expect(httpClient).toHaveBeenCalledWith("/shifts/open", { skipForbiddenRedirect: true });
     });
 
     it("returns null when parseJsonResponse returns null", async () => {

--- a/client/src/services/__tests__/walletService.test.js
+++ b/client/src/services/__tests__/walletService.test.js
@@ -64,7 +64,7 @@ describe("walletService", () => {
 
       await logoutWallet();
 
-      expect(httpClient).toHaveBeenCalledWith("/wallet/logout", { method: "POST" });
+      expect(httpClient).toHaveBeenCalledWith("/wallet/logout", { method: "POST", skipForbiddenRedirect: true });
     });
   });
 

--- a/client/src/services/authService.js
+++ b/client/src/services/authService.js
@@ -69,6 +69,12 @@ export async function getUsers({ silentAuth = false } = {}) {
   return users ?? [];
 }
 
+export async function getPublicUsers() {
+  const publicUsersResponse = await httpClient("/users/public");
+  const publicUsers = await parseJsonResponse(publicUsersResponse, []);
+  return publicUsers ?? [];
+}
+
 export async function addUser(user) {
   const response = await httpClient("/users", {
     method: "POST",

--- a/client/src/services/shiftsService.js
+++ b/client/src/services/shiftsService.js
@@ -2,7 +2,7 @@ import { buildParsedHttpError } from "@/components/pages/Store/utils/buildHttpEr
 import { httpClient, parseJsonResponse } from "@/lib/http";
 
 export async function getTurnOpen() {
-  const openShiftResponse = await httpClient("/shifts/open");
+  const openShiftResponse = await httpClient("/shifts/open", { skipForbiddenRedirect: true });
   if (openShiftResponse.status === 204) return null;
   if (!openShiftResponse.ok) {
     throw await buildParsedHttpError(openShiftResponse, "Failed to get open shift");

--- a/client/src/services/walletService.js
+++ b/client/src/services/walletService.js
@@ -46,7 +46,7 @@ export const loginWallet = async (password) => {
 };
 
 export const logoutWallet = async () => {
-  const walletLogoutResponse = await httpClient("/wallet/logout", { method: "POST" });
+  const walletLogoutResponse = await httpClient("/wallet/logout", { method: "POST", skipForbiddenRedirect: true });
   return await parseJsonResponse(walletLogoutResponse, null);
 };
 

--- a/server/app/src/main/kotlin/pos/ambrosia/api/Currency.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/api/Currency.kt
@@ -14,14 +14,14 @@ import pos.ambrosia.services.CurrencyService
 import pos.ambrosia.utils.authorizePermission
 
 fun Application.configureCurrency() {
-    val service = CurrencyService()
+    val currencyService = CurrencyService()
 
     routing {
         route("/currencies") {
             authorizePermission("settings_read") {
                 get("") {
-                    val list = service.list()
-                    call.respond(HttpStatusCode.OK, list)
+                    val currencies = currencyService.list()
+                    call.respond(HttpStatusCode.OK, currencies)
                 }
             }
         }
@@ -29,28 +29,28 @@ fun Application.configureCurrency() {
         route("/base-currency") {
             authorizePermission("settings_read") {
                 get("") {
-                    val curr = service.getBaseCurrency()
-                    if (curr == null) {
+                    val baseCurrency = currencyService.getBaseCurrency()
+                    if (baseCurrency == null) {
                         call.respond(HttpStatusCode.NotFound, Message("Base currency not set"))
                     } else {
-                        call.respond(HttpStatusCode.OK, curr)
+                        call.respond(HttpStatusCode.OK, baseCurrency)
                     }
                 }
             }
             authorizePermission("settings_update") {
                 put("") {
-                    val req = call.receive<SetBaseCurrencyRequest>()
-                    if (req.acronym.isNullOrBlank()) {
+                    val setBaseCurrencyRequest = call.receive<SetBaseCurrencyRequest>()
+                    if (setBaseCurrencyRequest.acronym.isNullOrBlank()) {
                         call.respond(HttpStatusCode.BadRequest, Message("Acronym is required"))
                         return@put
                     }
-                    val ok = service.setBaseCurrencyByAcronym(req.acronym)
-                    if (!ok) {
-                        call.respond(HttpStatusCode.NotFound, Message("Unknown currency acronym: ${req.acronym}"))
+                    val wasUpdated = currencyService.setBaseCurrencyByAcronym(setBaseCurrencyRequest.acronym)
+                    if (!wasUpdated) {
+                        call.respond(HttpStatusCode.NotFound, Message("Unknown currency acronym: ${setBaseCurrencyRequest.acronym}"))
                         return@put
                     }
-                    val curr = service.getBaseCurrency()
-                    call.respond(HttpStatusCode.OK, curr ?: Message("Base currency updated"))
+                    val baseCurrency = currencyService.getBaseCurrency()
+                    call.respond(HttpStatusCode.OK, baseCurrency ?: Message("Base currency updated"))
                 }
             }
         }

--- a/server/app/src/main/kotlin/pos/ambrosia/api/Printers.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/api/Printers.kt
@@ -23,6 +23,7 @@ import pos.ambrosia.services.PrinterConfigService
 import pos.ambrosia.services.PrinterConfigUpdateStatus
 import pos.ambrosia.services.TicketTemplateService
 import pos.ambrosia.utils.PrintTicketException
+import pos.ambrosia.utils.authorizePermission
 
 fun Application.configurePrinters() {
     val ticketTemplateService = TicketTemplateService()
@@ -40,6 +41,19 @@ fun Route.printers(
     authenticate("auth-jwt") {
         get("/available") { call.respond(printService.getAvailablePrinters()) }
         get("/configs") { call.respond(printerConfigService.getPrinterConfigs()) }
+        post("/print") {
+            val printRequest = call.receive<PrintRequest>()
+
+            try {
+                val appConfig = configService.getConfig()
+                printService.printTicket(printRequest, appConfig)
+                call.respondText("Print job sent", status = HttpStatusCode.OK)
+            } catch (printError: Exception) {
+                throw PrintTicketException(printError.message ?: "An unknown error occurred during printing.")
+            }
+        }
+    }
+    authorizePermission("printer_update") {
         post("/configs") {
             val request = call.receive<PrinterConfigCreateRequest>()
             val configId = printerConfigService.createPrinterConfig(request)
@@ -104,17 +118,6 @@ fun Route.printers(
                     "Printer ${request.printerName} set for ${request.printerType}",
                     status = HttpStatusCode.OK,
                 )
-            }
-        }
-        post("/print") {
-            val request = call.receive<PrintRequest>()
-
-            try {
-                val config = configService.getConfig()
-                printService.printTicket(request, config)
-                call.respondText("Print job sent", status = HttpStatusCode.OK)
-            } catch (e: Exception) {
-                throw PrintTicketException(e.message ?: "An unknown error occurred during printing.")
             }
         }
     }

--- a/server/app/src/main/kotlin/pos/ambrosia/api/TicketTemplates.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/api/TicketTemplates.kt
@@ -15,6 +15,7 @@ import io.ktor.server.routing.routing
 import pos.ambrosia.models.TicketTemplate
 import pos.ambrosia.models.TicketTemplateRequest
 import pos.ambrosia.services.TicketTemplateService
+import pos.ambrosia.utils.authorizePermission
 
 fun Application.configureTicketTemplates() {
     val ticketTemplateService = TicketTemplateService()
@@ -23,16 +24,6 @@ fun Application.configureTicketTemplates() {
 
 fun Route.templatesAPI(ticketTemplateService: TicketTemplateService) {
     authenticate("auth-jwt") {
-        post {
-            val templateRequest = call.receive<TicketTemplateRequest>()
-            val templateId = ticketTemplateService.addTemplate(templateRequest)
-            if (templateId != null) {
-                call.respond(HttpStatusCode.Created, mapOf("id" to templateId))
-            } else {
-                call.respond(HttpStatusCode.Conflict, mapOf("error" to "Template name already exists"))
-            }
-        }
-
         get {
             val templates = ticketTemplateService.getTemplates()
             call.respond(templates)
@@ -45,6 +36,17 @@ fun Route.templatesAPI(ticketTemplateService: TicketTemplateService) {
                 call.respond(template)
             } else {
                 call.respond(HttpStatusCode.NotFound)
+            }
+        }
+    }
+    authorizePermission("printer_update") {
+        post {
+            val templateRequest = call.receive<TicketTemplateRequest>()
+            val templateId = ticketTemplateService.addTemplate(templateRequest)
+            if (templateId != null) {
+                call.respond(HttpStatusCode.Created, mapOf("id" to templateId))
+            } else {
+                call.respond(HttpStatusCode.Conflict, mapOf("error" to "Template name already exists"))
             }
         }
 

--- a/server/app/src/main/kotlin/pos/ambrosia/api/Users.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/api/Users.kt
@@ -61,6 +61,10 @@ fun Route.users(
         }
     }
 
+    get("/public") {
+        call.respond(HttpStatusCode.OK, userService.getUserIdentities())
+    }
+
     authenticate("auth-jwt") {
         get("/me") {
             val refreshToken =

--- a/server/app/src/main/kotlin/pos/ambrosia/api/Users.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/api/Users.kt
@@ -35,15 +35,15 @@ fun Route.users(
     tokenService: TokenService,
     permissionsService: PermissionsService,
 ) {
-    get("") {
-        val users = userService.getUsers()
-        if (users.isEmpty()) {
-            call.respond(HttpStatusCode.OK, "No users found")
-            return@get
-        }
-        call.respond(HttpStatusCode.OK, users)
-    }
     authorizePermission("users_read") {
+        get("") {
+            val users = userService.getUsers()
+            if (users.isEmpty()) {
+                call.respond(HttpStatusCode.OK, "No users found")
+                return@get
+            }
+            call.respond(HttpStatusCode.OK, users)
+        }
         get("/{id}") {
             val id = call.parameters["id"]
             if (id == null) {

--- a/server/app/src/main/kotlin/pos/ambrosia/models/AppModels.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/models/AppModels.kt
@@ -90,6 +90,13 @@ data class User(
 )
 
 @Serializable
+data class UserIdentity(
+    val id: String,
+    val name: String,
+    val role: String? = null,
+)
+
+@Serializable
 data class UpdateUserRequest(
     val name: String? = null,
     val pin: String? = null,

--- a/server/app/src/main/kotlin/pos/ambrosia/services/UsersService.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/services/UsersService.kt
@@ -13,6 +13,7 @@ import pos.ambrosia.db.tables.UsersTable
 import pos.ambrosia.logger
 import pos.ambrosia.models.UpdateUserRequest
 import pos.ambrosia.models.User
+import pos.ambrosia.models.UserIdentity
 import pos.ambrosia.utils.DuplicateUserNameException
 import pos.ambrosia.utils.LastAdminRemovalException
 import pos.ambrosia.utils.LastUserDeletionException
@@ -100,6 +101,20 @@ class UsersService(
                         roleId = row[UsersTable.roleId]?.value?.toString(),
                         email = row[UsersTable.email],
                         phone = row[UsersTable.phone],
+                    )
+                }
+        }
+
+    fun getUserIdentities(): List<UserIdentity> =
+        transaction {
+            (UsersTable leftJoin RolesTable)
+                .selectAll()
+                .where { UsersTable.isDeleted eq false }
+                .map { row ->
+                    UserIdentity(
+                        id = row[UsersTable.id].value.toString(),
+                        name = row[UsersTable.name],
+                        role = row.getOrNull(RolesTable.role),
                     )
                 }
         }

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/UserPrivilegeEscalationRouteTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/UserPrivilegeEscalationRouteTest.kt
@@ -57,6 +57,21 @@ class UserPrivilegeEscalationRouteTest {
         }
 
     @Test
+    fun `user public listing does not require authentication`() =
+        testApplication {
+            installAdminAuth()
+            val targetRoleId = ExposedTestDb.seedRole("target-role")
+            ExposedTestDb.seedUser("target-user", targetRoleId)
+            application {
+                install(ContentNegotiation) { json() }
+                handler()
+                configureUsers()
+            }
+
+            assertEquals(HttpStatusCode.OK, client.get("/users/public").status)
+        }
+
+    @Test
     fun `non admin with users update cannot assign an admin role`() =
         testApplication {
             val auth = installNonAdminAuth()

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/UserPrivilegeEscalationRouteTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/UserPrivilegeEscalationRouteTest.kt
@@ -41,7 +41,7 @@ class UserPrivilegeEscalationRouteTest {
     }
 
     @Test
-    fun `user list remains public while user by id requires authentication`() =
+    fun `user list and user by id both require authentication`() =
         testApplication {
             installAdminAuth()
             val targetRoleId = ExposedTestDb.seedRole("target-role")
@@ -52,7 +52,7 @@ class UserPrivilegeEscalationRouteTest {
                 configureUsers()
             }
 
-            assertEquals(HttpStatusCode.OK, client.get("/users").status)
+            assertEquals(HttpStatusCode.Unauthorized, client.get("/users").status)
             assertEquals(HttpStatusCode.Unauthorized, client.get("/users/$targetUserId").status)
         }
 

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/UsersServiceTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/UsersServiceTest.kt
@@ -83,4 +83,17 @@ class UsersServiceTest {
             assertEquals("****", user.refreshToken)
         }
     }
+
+    @Test
+    fun `getUserIdentities returns id, name and role`() {
+        runBlocking {
+            val roleId = ExposedTestDb.seedRole("Cashier", isAdmin = false)
+            val userId = ExposedTestDb.seedUser("cashier-user", roleId = roleId)
+
+            val identity = service.getUserIdentities().single { it.id == userId }
+
+            assertEquals("cashier-user", identity.name)
+            assertEquals("Cashier", identity.role)
+        }
+    }
 }

--- a/server/e2e_tests_py/tests/test_roles_users_permissions_e2e.py
+++ b/server/e2e_tests_py/tests/test_roles_users_permissions_e2e.py
@@ -85,7 +85,7 @@ class TestUsersPermissions:
     @pytest.mark.asyncio
     async def test_users_read_required_for_get_list(self, client_factory):
         """GET /users returns 403 without users_read permission."""
-        no_permission = await client_factory(permissions=["permissions_read"])
+        no_permission = await client_factory(permissions=BASELINE_PERMISSIONS)
         response = await no_permission.get("/users")
         assert_status_code(response, 403, "GET /users should require users_read")
 
@@ -97,7 +97,7 @@ class TestUsersPermissions:
     @pytest.mark.asyncio
     async def test_users_read_required_for_get_by_id(self, client_factory):
         """GET /users/{id} returns 403 without users_read permission."""
-        no_permission = await client_factory(permissions=["permissions_read"])
+        no_permission = await client_factory(permissions=BASELINE_PERMISSIONS)
         response = await no_permission.get(f"/users/{DUMMY_ID}")
         assert_status_code(response, 403, "GET /users/{id} should require users_read")
 

--- a/server/e2e_tests_py/tests/test_roles_users_permissions_e2e.py
+++ b/server/e2e_tests_py/tests/test_roles_users_permissions_e2e.py
@@ -18,20 +18,20 @@ class TestRolesPermissions:
     @pytest.mark.asyncio
     async def test_roles_read_required_for_get(self, client_factory):
         """GET /roles returns 403 without roles_read permission."""
-        no_perm = await client_factory(permissions=BASELINE_PERMISSIONS)
-        response = await no_perm.get("/roles")
+        no_permission = await client_factory(permissions=BASELINE_PERMISSIONS)
+        response = await no_permission.get("/roles")
         assert_status_code(response, 403, "GET /roles should require roles_read")
 
-        with_perm = await client_factory(permissions=["roles_read"])
-        response = await with_perm.get("/roles")
+        with_permission = await client_factory(permissions=["roles_read"])
+        response = await with_permission.get("/roles")
         assert response.status_code != 403, "roles_read should allow GET /roles"
         logger.info("✓ roles_read correctly gates GET /roles")
 
     @pytest.mark.asyncio
     async def test_roles_create_requires_admin(self, client_factory, admin_client):
         """POST /roles requires admin even when roles_create is requested."""
-        no_perm = await client_factory(permissions=BASELINE_PERMISSIONS)
-        response = await no_perm.post("/roles", json={"role": "test_role"})
+        no_permission = await client_factory(permissions=BASELINE_PERMISSIONS)
+        response = await no_permission.post("/roles", json={"role": "test_role"})
         assert_status_code(response, 403, "POST /roles should require roles_create")
 
         non_admin = await client_factory(permissions=["roles_create", "wallet_read"])
@@ -45,8 +45,8 @@ class TestRolesPermissions:
     @pytest.mark.asyncio
     async def test_roles_update_requires_admin(self, client_factory, admin_client):
         """PUT /roles/{id} requires admin even when roles_update is requested."""
-        no_perm = await client_factory(permissions=BASELINE_PERMISSIONS)
-        response = await no_perm.put(f"/roles/{DUMMY_ID}", json={"role": "updated"})
+        no_permission = await client_factory(permissions=BASELINE_PERMISSIONS)
+        response = await no_permission.put(f"/roles/{DUMMY_ID}", json={"role": "updated"})
         assert_status_code(response, 403, "PUT /roles/{id} should require roles_update")
 
         non_admin = await client_factory(permissions=["roles_update", "wallet_read"])
@@ -62,8 +62,8 @@ class TestRolesPermissions:
     @pytest.mark.asyncio
     async def test_roles_delete_requires_admin(self, client_factory, admin_client):
         """DELETE /roles/{id} requires admin even when roles_delete is requested."""
-        no_perm = await client_factory(permissions=BASELINE_PERMISSIONS)
-        response = await no_perm.delete(f"/roles/{DUMMY_ID}")
+        no_permission = await client_factory(permissions=BASELINE_PERMISSIONS)
+        response = await no_permission.delete(f"/roles/{DUMMY_ID}")
         assert_status_code(
             response, 403, "DELETE /roles/{id} should require roles_delete"
         )
@@ -83,16 +83,40 @@ class TestUsersPermissions:
     """Permission enforcement tests for /users."""
 
     @pytest.mark.asyncio
+    async def test_users_read_required_for_get_list(self, client_factory):
+        """GET /users returns 403 without users_read permission."""
+        no_permission = await client_factory(permissions=["permissions_read"])
+        response = await no_permission.get("/users")
+        assert_status_code(response, 403, "GET /users should require users_read")
+
+        with_permission = await client_factory(permissions=["users_read"])
+        response = await with_permission.get("/users")
+        assert response.status_code != 403, "users_read should allow GET /users"
+        logger.info("✓ users_read correctly gates GET /users")
+
+    @pytest.mark.asyncio
+    async def test_users_read_required_for_get_by_id(self, client_factory):
+        """GET /users/{id} returns 403 without users_read permission."""
+        no_permission = await client_factory(permissions=["permissions_read"])
+        response = await no_permission.get(f"/users/{DUMMY_ID}")
+        assert_status_code(response, 403, "GET /users/{id} should require users_read")
+
+        with_permission = await client_factory(permissions=["users_read"])
+        response = await with_permission.get(f"/users/{DUMMY_ID}")
+        assert response.status_code != 403, "users_read should allow GET /users/{id}"
+        logger.info("✓ users_read correctly gates GET /users/{id}")
+
+    @pytest.mark.asyncio
     async def test_users_create_required_for_post(self, client_factory):
         """POST /users returns 403 without users_create permission."""
-        no_perm = await client_factory(permissions=BASELINE_PERMISSIONS)
-        response = await no_perm.post(
+        no_permission = await client_factory(permissions=BASELINE_PERMISSIONS)
+        response = await no_permission.post(
             "/users", json={"name": "x", "pin": "0000", "role": DUMMY_ID}
         )
         assert_status_code(response, 403, "POST /users should require users_create")
 
-        with_perm = await client_factory(permissions=["users_create"])
-        response = await with_perm.post(
+        with_permission = await client_factory(permissions=["users_create"])
+        response = await with_permission.post(
             "/users", json={"name": "x", "pin": "0000", "role": DUMMY_ID}
         )
         assert response.status_code != 403, "users_create should allow POST /users"
@@ -101,14 +125,14 @@ class TestUsersPermissions:
     @pytest.mark.asyncio
     async def test_users_update_required_for_put(self, client_factory):
         """PUT /users/{id} returns 403 without users_update permission."""
-        no_perm = await client_factory(permissions=BASELINE_PERMISSIONS)
-        response = await no_perm.put(
+        no_permission = await client_factory(permissions=BASELINE_PERMISSIONS)
+        response = await no_permission.put(
             f"/users/{DUMMY_ID}", json={"name": "x", "pin": "0000"}
         )
         assert_status_code(response, 403, "PUT /users/{id} should require users_update")
 
-        with_perm = await client_factory(permissions=["users_update"])
-        response = await with_perm.put(
+        with_permission = await client_factory(permissions=["users_update"])
+        response = await with_permission.put(
             f"/users/{DUMMY_ID}", json={"name": "x", "pin": "0000"}
         )
         assert response.status_code != 403, "users_update should allow PUT /users/{id}"
@@ -117,14 +141,14 @@ class TestUsersPermissions:
     @pytest.mark.asyncio
     async def test_users_delete_required_for_delete(self, client_factory):
         """DELETE /users/{id} returns 403 without users_delete permission."""
-        no_perm = await client_factory(permissions=BASELINE_PERMISSIONS)
-        response = await no_perm.delete(f"/users/{DUMMY_ID}")
+        no_permission = await client_factory(permissions=BASELINE_PERMISSIONS)
+        response = await no_permission.delete(f"/users/{DUMMY_ID}")
         assert_status_code(
             response, 403, "DELETE /users/{id} should require users_delete"
         )
 
-        with_perm = await client_factory(permissions=["users_delete"])
-        response = await with_perm.delete(f"/users/{DUMMY_ID}")
+        with_permission = await client_factory(permissions=["users_delete"])
+        response = await with_permission.delete(f"/users/{DUMMY_ID}")
         assert response.status_code != 403, (
             "users_delete should allow DELETE /users/{id}"
         )

--- a/server/e2e_tests_py/tests/test_roles_users_permissions_e2e.py
+++ b/server/e2e_tests_py/tests/test_roles_users_permissions_e2e.py
@@ -46,7 +46,9 @@ class TestRolesPermissions:
     async def test_roles_update_requires_admin(self, client_factory, admin_client):
         """PUT /roles/{id} requires admin even when roles_update is requested."""
         no_permission = await client_factory(permissions=BASELINE_PERMISSIONS)
-        response = await no_permission.put(f"/roles/{DUMMY_ID}", json={"role": "updated"})
+        response = await no_permission.put(
+            f"/roles/{DUMMY_ID}", json={"role": "updated"}
+        )
         assert_status_code(response, 403, "PUT /roles/{id} should require roles_update")
 
         non_admin = await client_factory(permissions=["roles_update", "wallet_read"])


### PR DESCRIPTION
## Changes:

- Let individual fetches opt out of the global 403 redirect, the foundation the rest of this work builds on
- Stop the Store dashboard from crashing when a card's underlying permission is missing
- Stop Products from crashing when the user lacks categories_read
- Stop Roles from crashing when the user lacks permissions_read
- Auto-suggest cart-related permissions (products_read, categories_read, payments_read) when granting orders_create in the role editor
- Stop Orders and Cart from crashing when the user lacks payments_read
- Expose whether useCategories was blocked by a missing permission
- Stop the payment currency lookup from crashing Cart when payments_read is missing
- Show an explicit message in Cart when a permission is missing instead of crashing
- Require users_read for the users list endpoint, on both server and client
- Require printer_update for printer and ticket template mutations, without blocking routine printing, on both server and client
- Add settings_read to the permission catalog so it's grantable to non-admin roles, and clean up naming in Currency.kt
- Use meaningful names for translation, element, and event handler variables in the ticket template editor
- Use meaningful names in Cart, Store hooks, and useFetchList test mocks found during review
- Use a grantable baseline permission in the users_read e2e tests instead of the now admin-only permissions_read
- Add a public minimal users endpoint for the PIN login screen, replacing the now permission-gated users list it depended on, on both server and client
- Stop the open-shift check from redirecting to /unauthorized when shifts_read is missing
- Stop WalletGuard's automatic logout from redirecting to /unauthorized