### PR TITLE
Fix/cart categories block

### DIFF
--- a/client/src/components/pages/Store/Cart/Cart.jsx
+++ b/client/src/components/pages/Store/Cart/Cart.jsx
@@ -60,7 +60,7 @@ export function Cart() {
     [setDiscount, setDiscountType],
   );
   const { products, forbidden: productsForbidden, refetch: refetchProducts } = useProducts({ skipForbiddenRedirect: true });
-  const { categories, forbidden: categoriesForbidden } = useCategories();
+  const { categories } = useCategories();
 
   useEffect(() => {
     if (!isCartRestored || products.length === 0) return;
@@ -144,7 +144,6 @@ export function Cart() {
 
   const missingPermissions = [
     ...(productsForbidden ? ["products_read"] : []),
-    ...(categoriesForbidden ? ["categories_read"] : []),
     ...(paymentsForbidden ? ["payments_read"] : []),
   ];
 

--- a/client/src/components/pages/Store/Cart/__tests__/Cart.test.jsx
+++ b/client/src/components/pages/Store/Cart/__tests__/Cart.test.jsx
@@ -306,15 +306,15 @@ describe("Cart page", () => {
     expect(screen.queryByText("add-existing")).not.toBeInTheDocument();
   });
 
-  it("shows the permission-blocked message when categories are forbidden", async () => {
+  it("still renders the sale normally when categories are forbidden", async () => {
     mockCategoriesForbidden = true;
 
     await act(async () => {
       renderCart();
     });
 
-    expect(screen.getByText("permissionBlocked.title")).toBeInTheDocument();
-    expect(screen.getByText("permissionBlocked.categories")).toBeInTheDocument();
+    expect(screen.queryByText("permissionBlocked.title")).not.toBeInTheDocument();
+    expect(screen.getByText("add-existing")).toBeInTheDocument();
   });
 
   it("shows the permission-blocked message when payments are forbidden", async () => {

--- a/client/src/services/__tests__/shiftsService.test.js
+++ b/client/src/services/__tests__/shiftsService.test.js
@@ -70,6 +70,7 @@ describe("shiftsService", () => {
 
       expect(url).toBe("/shifts");
       expect(options.method).toBe("POST");
+      expect(options.skipForbiddenRedirect).toBe(true);
       expect(body.userId).toBe(42);
       expect(body.initialAmount).toBe(150);
     });
@@ -131,6 +132,7 @@ describe("shiftsService", () => {
 
       expect(url).toBe("/shifts/7/close");
       expect(options.method).toBe("POST");
+      expect(options.skipForbiddenRedirect).toBe(true);
       expect(body.finalAmount).toBe(150.5);
       expect(body.difference).toBe(-10.2);
     });

--- a/client/src/services/shiftsService.js
+++ b/client/src/services/shiftsService.js
@@ -32,6 +32,7 @@ export async function openTurn(userId, initialAmount = 0) {
       notes: "",
       initialAmount,
     }),
+    skipForbiddenRedirect: true,
   });
   if (openShiftResponse.status === 409) throw new Error("shift_already_open");
   if (!openShiftResponse.ok) {
@@ -46,6 +47,7 @@ export async function closeTurn(openTurnId, finalAmount = null, difference = nul
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body,
+    skipForbiddenRedirect: true,
   });
   if (!closeShiftResponse.ok) {
     throw await buildParsedHttpError(closeShiftResponse, "Failed to close shift");


### PR DESCRIPTION
## Changes:

- Stop categories_read from blocking the entire sale in Cart — the category filter degrades gracefully instead
- Stop opening and closing a shift from redirecting to /unauthorized when shifts_create or the underlying permission is missing