### PR TITLE
Fix/background forbidden redirect

### DIFF
--- a/client/src/components/pages/Store/Products/VariantManager/VariantManager.jsx
+++ b/client/src/components/pages/Store/Products/VariantManager/VariantManager.jsx
@@ -48,6 +48,9 @@ export function VariantManager({
       const mutationResult = await variantMutation();
       if (mutationResult !== false && mutationResult !== null) await onRefresh?.();
       return mutationResult;
+    } catch (variantMutationError) {
+      notifyVariantError();
+      throw variantMutationError;
     } finally {
       setVariantMutating(variantId, false);
     }
@@ -57,6 +60,14 @@ export function VariantManager({
     addToast({
       description: productsTranslations(toastDescriptionKey),
       color: "success",
+    });
+  };
+
+  const notifyVariantError = () => {
+    addToast({
+      title: productsTranslations("toasts.genericErrorTitle"),
+      description: productsTranslations("toasts.genericErrorDescription"),
+      color: "danger",
     });
   };
 

--- a/client/src/components/pages/Store/Products/VariantManager/__tests__/VariantCard.test.jsx
+++ b/client/src/components/pages/Store/Products/VariantManager/__tests__/VariantCard.test.jsx
@@ -9,7 +9,7 @@ jest.mock("@/components/utils/storedAssetUrl", () => ({
 jest.mock("../VariantForm", () => ({
   VariantForm: ({ onSave, onCancel }) => (
     <div data-testid="variant-form">
-      <button onClick={() => onSave({ priceCents: 800, quantity: 2 })}>form-save</button>
+      <button onClick={() => onSave({ priceCents: 800, quantity: 2 }).catch(() => {})}>form-save</button>
       <button onClick={onCancel}>form-cancel</button>
     </div>
   ),
@@ -142,6 +142,15 @@ describe("VariantCard", () => {
     fireEvent.click(screen.getByTestId("edit-variant"));
     fireEvent.click(screen.getByText("form-save"));
     await waitFor(() => expect(onSave).toHaveBeenCalledWith("v1", expect.objectContaining({ priceCents: 800 })));
+  });
+
+  it("stays in edit mode when onSave rejects", async () => {
+    const onSave = jest.fn().mockRejectedValue(new Error("save failed"));
+    renderCard({ onSave });
+    fireEvent.click(screen.getByTestId("edit-variant"));
+    fireEvent.click(screen.getByText("form-save"));
+    await waitFor(() => expect(onSave).toHaveBeenCalled());
+    expect(screen.getByTestId("variant-form")).toBeInTheDocument();
   });
 
   it("shows delete confirmation when the delete button is clicked", () => {

--- a/client/src/components/pages/Store/Products/VariantManager/__tests__/VariantManager.test.jsx
+++ b/client/src/components/pages/Store/Products/VariantManager/__tests__/VariantManager.test.jsx
@@ -23,8 +23,8 @@ jest.mock("../OptionTypeManager", () => ({
 jest.mock("../VariantCard", () => ({
   VariantCard: ({ variant, onSave, onDelete }) => (
     <div data-testid={`variant-card-${variant.id}`}>
-      <button onClick={() => onSave(variant.id, { priceCents: 999 })}>save-{variant.id}</button>
-      <button onClick={() => onDelete(variant.id)}>delete-{variant.id}</button>
+      <button onClick={() => onSave(variant.id, { priceCents: 999 }).catch(() => {})}>save-{variant.id}</button>
+      <button onClick={() => onDelete(variant.id).catch(() => {})}>delete-{variant.id}</button>
     </div>
   ),
 }));
@@ -32,7 +32,7 @@ jest.mock("../VariantCard", () => ({
 jest.mock("../VariantForm", () => ({
   VariantForm: ({ onSave, onCancel }) => (
     <div data-testid="variant-form">
-      <button onClick={() => onSave({ priceCents: 500, quantity: 1, optionValueIds: [] })}>
+      <button onClick={() => onSave({ priceCents: 500, quantity: 1, optionValueIds: [] }).catch(() => {})}>
         form-save
       </button>
       <button onClick={onCancel}>form-cancel</button>
@@ -198,5 +198,21 @@ describe("VariantManager", () => {
       color: "success",
     });
     expect(onRefresh).toHaveBeenCalled();
+  });
+
+  it("shows a generic error toast and does not refresh when updateVariant rejects", async () => {
+    const updateVariant = jest.fn().mockRejectedValue(new Error("network error"));
+    const onRefresh = jest.fn().mockResolvedValue(undefined);
+    renderManager({ product: { options, variants }, variantActions: { update: updateVariant }, onRefresh });
+
+    fireEvent.click(screen.getByText("save-v1"));
+
+    await waitFor(() => expect(updateVariant).toHaveBeenCalledWith("p1", "v1", expect.anything()));
+    expect(mockAddToast).toHaveBeenCalledWith({
+      title: "toasts.genericErrorTitle",
+      description: "toasts.genericErrorDescription",
+      color: "danger",
+    });
+    expect(onRefresh).not.toHaveBeenCalled();
   });
 });

--- a/client/src/services/__tests__/adminNotificationsService.test.js
+++ b/client/src/services/__tests__/adminNotificationsService.test.js
@@ -28,7 +28,7 @@ describe("adminNotificationsService", () => {
   it("loads admin notifications with supported filters", async () => {
     await getAdminNotifications({ category: "wallet", unreadOnly: true, limit: 25, offset: 50 });
 
-    expect(httpClient).toHaveBeenCalledWith("/admin/notifications?limit=25&offset=50&unreadOnly=true&category=wallet");
+    expect(httpClient).toHaveBeenCalledWith("/admin/notifications?limit=25&offset=50&unreadOnly=true&category=wallet", { skipForbiddenRedirect: true });
     expect(parseJsonResponse).toHaveBeenCalledWith({ ok: true }, []);
   });
 
@@ -37,7 +37,10 @@ describe("adminNotificationsService", () => {
 
     await markAdminNotificationRead("notification-1");
 
-    expect(httpClient).toHaveBeenCalledWith("/admin/notifications/notification-1/read", { method: "POST" });
+    expect(httpClient).toHaveBeenCalledWith("/admin/notifications/notification-1/read", {
+      method: "POST",
+      skipForbiddenRedirect: true,
+    });
   });
 
   it("marks all notifications as read by category", async () => {
@@ -45,7 +48,10 @@ describe("adminNotificationsService", () => {
 
     await markAllAdminNotificationsRead("wallet");
 
-    expect(httpClient).toHaveBeenCalledWith("/admin/notifications/read-all?category=wallet", { method: "POST" });
+    expect(httpClient).toHaveBeenCalledWith("/admin/notifications/read-all?category=wallet", {
+      method: "POST",
+      skipForbiddenRedirect: true,
+    });
     expect(parseJsonResponse).toHaveBeenCalledWith({ ok: true }, { updated: 0 });
   });
 
@@ -54,7 +60,10 @@ describe("adminNotificationsService", () => {
 
     await deleteAdminNotification("notification-1");
 
-    expect(httpClient).toHaveBeenCalledWith("/admin/notifications/notification-1", { method: "DELETE" });
+    expect(httpClient).toHaveBeenCalledWith("/admin/notifications/notification-1", {
+      method: "DELETE",
+      skipForbiddenRedirect: true,
+    });
   });
 
   it("deletes all notifications by category for the current admin", async () => {
@@ -62,7 +71,10 @@ describe("adminNotificationsService", () => {
 
     await deleteAllAdminNotifications("wallet");
 
-    expect(httpClient).toHaveBeenCalledWith("/admin/notifications?category=wallet", { method: "DELETE" });
+    expect(httpClient).toHaveBeenCalledWith("/admin/notifications?category=wallet", {
+      method: "DELETE",
+      skipForbiddenRedirect: true,
+    });
     expect(parseJsonResponse).toHaveBeenCalledWith({ ok: true }, { deleted: 0 });
   });
 
@@ -77,11 +89,12 @@ describe("adminNotificationsService", () => {
       updatedAt: "2026-07-16T00:00:00Z",
     });
 
-    expect(httpClient).toHaveBeenNthCalledWith(1, "/admin/notification-preferences");
+    expect(httpClient).toHaveBeenNthCalledWith(1, "/admin/notification-preferences", { skipForbiddenRedirect: true });
     expect(httpClient).toHaveBeenNthCalledWith(2, "/admin/notification-preferences", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ category: "wallet", inAppEnabled: true, pushEnabled: false }),
+      skipForbiddenRedirect: true,
     });
   });
 
@@ -94,7 +107,7 @@ describe("adminNotificationsService", () => {
     });
     await deleteAdminPushSubscription("https://push.example/sub");
 
-    expect(httpClient).toHaveBeenNthCalledWith(1, "/admin/push/vapid-public-key");
+    expect(httpClient).toHaveBeenNthCalledWith(1, "/admin/push/vapid-public-key", { skipForbiddenRedirect: true });
     expect(httpClient).toHaveBeenNthCalledWith(2, "/admin/push/subscriptions", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -103,11 +116,13 @@ describe("adminNotificationsService", () => {
         keys: { p256dh: "key", auth: "auth" },
         userAgent: "agent",
       }),
+      skipForbiddenRedirect: true,
     });
     expect(httpClient).toHaveBeenNthCalledWith(3, "/admin/push/subscriptions?endpoint=https%3A%2F%2Fpush.example%2Fsub", {
       method: "DELETE",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ endpoint: "https://push.example/sub" }),
+      skipForbiddenRedirect: true,
     });
   });
 });

--- a/client/src/services/__tests__/ticketsService.test.js
+++ b/client/src/services/__tests__/ticketsService.test.js
@@ -1,0 +1,107 @@
+jest.mock("@/lib/http", () => ({
+  httpClient: jest.fn(),
+  parseJsonResponse: jest.fn(),
+}));
+
+import { httpClient, parseJsonResponse } from "@/lib/http";
+
+import {
+  getOrdersWithPayments,
+  getPaymentByTicketId,
+  getPaymentMethods,
+  getPayments,
+  getTickets,
+} from "../ticketsService";
+
+describe("ticketsService", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    httpClient.mockResolvedValue({ ok: true });
+    parseJsonResponse.mockResolvedValue([]);
+  });
+
+  it("loads tickets with skipForbiddenRedirect so a 403 does not force a global redirect", async () => {
+    parseJsonResponse.mockResolvedValueOnce([{ id: "ticket-1" }]);
+
+    const tickets = await getTickets();
+
+    expect(httpClient).toHaveBeenCalledWith("/tickets", { skipForbiddenRedirect: true });
+    expect(tickets).toEqual([{ id: "ticket-1" }]);
+  });
+
+  it("falls back to an empty array when getTickets receives no body", async () => {
+    parseJsonResponse.mockResolvedValueOnce(null);
+
+    const tickets = await getTickets();
+
+    expect(tickets).toEqual([]);
+  });
+
+  it("loads payments with skipForbiddenRedirect", async () => {
+    parseJsonResponse.mockResolvedValueOnce([{ id: "payment-1" }]);
+
+    const payments = await getPayments();
+
+    expect(httpClient).toHaveBeenCalledWith("/payments", { skipForbiddenRedirect: true });
+    expect(payments).toEqual([{ id: "payment-1" }]);
+  });
+
+  it("falls back to an empty array when getPayments receives no body", async () => {
+    parseJsonResponse.mockResolvedValueOnce(null);
+
+    const payments = await getPayments();
+
+    expect(payments).toEqual([]);
+  });
+
+  it("loads payment methods with skipForbiddenRedirect", async () => {
+    parseJsonResponse.mockResolvedValueOnce([{ id: "method-1" }]);
+
+    const paymentMethods = await getPaymentMethods();
+
+    expect(httpClient).toHaveBeenCalledWith("/payments/methods", { skipForbiddenRedirect: true });
+    expect(paymentMethods).toEqual([{ id: "method-1" }]);
+  });
+
+  it("falls back to an empty array when getPaymentMethods receives no body", async () => {
+    parseJsonResponse.mockResolvedValueOnce(null);
+
+    const paymentMethods = await getPaymentMethods();
+
+    expect(paymentMethods).toEqual([]);
+  });
+
+  it("loads payments for one ticket by id with skipForbiddenRedirect", async () => {
+    parseJsonResponse.mockResolvedValueOnce([{ paymentId: "payment-1" }]);
+
+    const ticketPayments = await getPaymentByTicketId("ticket-1");
+
+    expect(httpClient).toHaveBeenCalledWith("/payments/ticket-payments/by-ticket/ticket-1", { skipForbiddenRedirect: true });
+    expect(ticketPayments).toEqual([{ paymentId: "payment-1" }]);
+  });
+
+  it("returns null when getPaymentByTicketId receives no body", async () => {
+    parseJsonResponse.mockResolvedValueOnce(null);
+
+    const ticketPayments = await getPaymentByTicketId("ticket-1");
+
+    expect(ticketPayments).toBeNull();
+  });
+
+  it("loads orders with payments with skipForbiddenRedirect", async () => {
+    parseJsonResponse.mockResolvedValueOnce([{ id: "order-1" }]);
+
+    const orders = await getOrdersWithPayments();
+
+    expect(httpClient).toHaveBeenCalledWith("/orders/with-payments", { skipForbiddenRedirect: true });
+    expect(orders).toEqual([{ id: "order-1" }]);
+  });
+
+  it("falls back to an empty array when getOrdersWithPayments receives no body", async () => {
+    parseJsonResponse.mockResolvedValueOnce(null);
+
+    const orders = await getOrdersWithPayments();
+
+    expect(orders).toEqual([]);
+  });
+});

--- a/client/src/services/adminNotificationsService.js
+++ b/client/src/services/adminNotificationsService.js
@@ -9,13 +9,14 @@ export async function getAdminNotifications(filters = {}) {
   if (filters.category) queryParams.set("category", filters.category);
 
   const queryString = queryParams.toString();
-  const notificationsResponse = await httpClient(`/admin/notifications${queryString ? `?${queryString}` : ""}`);
+  const notificationsResponse = await httpClient(`/admin/notifications${queryString ? `?${queryString}` : ""}`, { skipForbiddenRedirect: true });
   return await parseJsonResponse(notificationsResponse, []);
 }
 
 export async function markAdminNotificationRead(notificationId) {
   const readNotificationResponse = await httpClient(`/admin/notifications/${notificationId}/read`, {
     method: "POST",
+    skipForbiddenRedirect: true,
   });
   return await parseJsonResponse(readNotificationResponse, null);
 }
@@ -24,6 +25,7 @@ export async function markAllAdminNotificationsRead(category) {
   const queryString = category ? `?category=${encodeURIComponent(category)}` : "";
   const readAllNotificationsResponse = await httpClient(`/admin/notifications/read-all${queryString}`, {
     method: "POST",
+    skipForbiddenRedirect: true,
   });
   return await parseJsonResponse(readAllNotificationsResponse, { updated: 0 });
 }
@@ -31,6 +33,7 @@ export async function markAllAdminNotificationsRead(category) {
 export async function deleteAdminNotification(notificationId) {
   const deleteNotificationResponse = await httpClient(`/admin/notifications/${notificationId}`, {
     method: "DELETE",
+    skipForbiddenRedirect: true,
   });
   return await parseJsonResponse(deleteNotificationResponse, null);
 }
@@ -39,12 +42,13 @@ export async function deleteAllAdminNotifications(category) {
   const queryString = category ? `?category=${encodeURIComponent(category)}` : "";
   const deleteAllNotificationsResponse = await httpClient(`/admin/notifications${queryString}`, {
     method: "DELETE",
+    skipForbiddenRedirect: true,
   });
   return await parseJsonResponse(deleteAllNotificationsResponse, { deleted: 0 });
 }
 
 export async function getAdminNotificationPreferences() {
-  const preferencesResponse = await httpClient("/admin/notification-preferences");
+  const preferencesResponse = await httpClient("/admin/notification-preferences", { skipForbiddenRedirect: true });
   return await parseJsonResponse(preferencesResponse, []);
 }
 
@@ -58,12 +62,13 @@ export async function updateAdminNotificationPreference(preference) {
     method: "PUT",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(preferenceRequest),
+    skipForbiddenRedirect: true,
   });
   return await parseJsonResponse(updatePreferenceResponse, null);
 }
 
 export async function getAdminPushVapidPublicKey() {
-  const vapidPublicKeyResponse = await httpClient("/admin/push/vapid-public-key");
+  const vapidPublicKeyResponse = await httpClient("/admin/push/vapid-public-key", { skipForbiddenRedirect: true });
   if (!vapidPublicKeyResponse?.ok) {
     throw new Error("admin-web-push-unavailable");
   }
@@ -75,6 +80,7 @@ export async function registerAdminPushSubscription(subscription) {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(subscription),
+    skipForbiddenRedirect: true,
   });
   return await parseJsonResponse(registerSubscriptionResponse, null);
 }
@@ -85,6 +91,7 @@ export async function deleteAdminPushSubscription(endpoint) {
     method: "DELETE",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ endpoint }),
+    skipForbiddenRedirect: true,
   });
   return await parseJsonResponse(deleteSubscriptionResponse, null);
 }

--- a/client/src/services/ticketsService.js
+++ b/client/src/services/ticketsService.js
@@ -1,30 +1,30 @@
 import { httpClient, parseJsonResponse } from "@/lib/http";
 
 export async function getTickets() {
-  const response = await httpClient("/tickets");
-  const tickets = await parseJsonResponse(response, []);
+  const ticketsResponse = await httpClient("/tickets", { skipForbiddenRedirect: true });
+  const tickets = await parseJsonResponse(ticketsResponse, []);
   return tickets ?? [];
 }
 
 export async function getPayments() {
-  const response = await httpClient("/payments");
-  const payments = await parseJsonResponse(response, []);
+  const paymentsResponse = await httpClient("/payments", { skipForbiddenRedirect: true });
+  const payments = await parseJsonResponse(paymentsResponse, []);
   return payments ?? [];
 }
 
 export async function getPaymentMethods() {
-  const response = await httpClient("/payments/methods");
-  const methods = await parseJsonResponse(response, []);
-  return methods ?? [];
+  const paymentMethodsResponse = await httpClient("/payments/methods", { skipForbiddenRedirect: true });
+  const paymentMethods = await parseJsonResponse(paymentMethodsResponse, []);
+  return paymentMethods ?? [];
 }
 
 export async function getPaymentByTicketId(id) {
-  const response = await httpClient(`/payments/ticket-payments/by-ticket/${id}`);
-  return await parseJsonResponse(response, null);
+  const ticketPaymentsResponse = await httpClient(`/payments/ticket-payments/by-ticket/${id}`, { skipForbiddenRedirect: true });
+  return await parseJsonResponse(ticketPaymentsResponse, null);
 }
 
 export async function getOrdersWithPayments() {
-  const response = await httpClient("/orders/with-payments");
-  const orders = await parseJsonResponse(response, []);
+  const ordersResponse = await httpClient("/orders/with-payments", { skipForbiddenRedirect: true });
+  const orders = await parseJsonResponse(ordersResponse, []);
   return orders ?? [];
 }


### PR DESCRIPTION
## Changes:

- Stop `ticketsService`'s background requests (tickets, payments, payment methods, orders) from forcing a redirect to `/unauthorized` on a 403 — these run globally via `TurnProvider` whenever a shift is open, so a missing permission previously broke navigation on every `/store/*` page, not just one.
- Stop `adminNotificationsService`'s requests from forcing the same unwanted redirect on a 403.
- Add error handling to `VariantManager`'s `executeVariantMutation`, which previously let unexpected mutation failures (e.g. network errors) fail silently; it now shows an error toast and keeps the edit form open instead of appearing to succeed.