### PR TITLE
Fix/settings read navigation

### DIFF
--- a/client/src/components/hooks/__tests__/useCurrency.test.jsx
+++ b/client/src/components/hooks/__tests__/useCurrency.test.jsx
@@ -47,7 +47,7 @@ describe("useCurrency", () => {
       await waitFor(() => {
         expect(screen.getByTestId("acronym")).toHaveTextContent("MXN");
       });
-      expect(httpClient).toHaveBeenCalledWith("/base-currency");
+      expect(httpClient).toHaveBeenCalledWith("/base-currency", { skipForbiddenRedirect: true });
     });
 
     it("falls back to DEFAULT_CURRENCY when API returns null", async () => {
@@ -162,6 +162,7 @@ describe("useCurrency", () => {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ acronym: "EUR" }),
+        skipForbiddenRedirect: true,
       });
     });
 
@@ -174,6 +175,7 @@ describe("useCurrency", () => {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ acronym: "MXN" }),
+        skipForbiddenRedirect: true,
       });
     });
 
@@ -184,6 +186,7 @@ describe("useCurrency", () => {
 
       expect(httpClient).toHaveBeenCalledWith("/base-currency", expect.objectContaining({
         body: JSON.stringify({ acronym: "USD" }),
+        skipForbiddenRedirect: true,
       }));
     });
 

--- a/client/src/components/hooks/useCurrency.jsx
+++ b/client/src/components/hooks/useCurrency.jsx
@@ -42,8 +42,8 @@ export function useCurrency() {
 
   const fetchCurrency = useCallback(async ({ isCancelled } = {}) => {
     try {
-      const response = await httpClient("/base-currency");
-      const base = await parseJsonResponse(response, null);
+      const baseCurrencyResponse = await httpClient("/base-currency", { skipForbiddenRedirect: true });
+      const base = await parseJsonResponse(baseCurrencyResponse, null);
       if (!isCancelled?.()) setCurrency(parseCurrencyData(base));
     } catch {
       if (!isCancelled?.()) setCurrency(DEFAULT_CURRENCY);
@@ -95,16 +95,17 @@ export function useCurrency() {
           ? acronymOrObj
           : acronymOrObj?.acronym || DEFAULT_CURRENCY.acronym;
 
-      const updateConfigResponse = await httpClient(`/base-currency`, {
+      const updateCurrencyResponse = await httpClient(`/base-currency`, {
         method: "PUT",
         headers: {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({ acronym }),
+        skipForbiddenRedirect: true,
       });
 
       fetchCurrency();
-      return await parseJsonResponse(updateConfigResponse, null);
+      return await parseJsonResponse(updateCurrencyResponse, null);
     },
     [fetchCurrency],
   );

--- a/client/src/components/pages/Store/Settings/Currency/CurrencyCard.jsx
+++ b/client/src/components/pages/Store/Settings/Currency/CurrencyCard.jsx
@@ -3,10 +3,12 @@
 import { Card, CardBody, CardHeader } from "@heroui/react";
 import { useTranslations } from "next-intl";
 
+import { usePermission } from "@/hooks/usePermission";
 import { CurrencyInput } from "@components/shared/CurrencyInput";
 
 export function CurrencyCard({ selectedCurrency, currencies, onCurrencyChange }) {
   const settingsTranslations = useTranslations("settings");
+  const canUpdateSettings = usePermission({ allOf: ["settings_update"] });
 
   return (
     <Card shadow="none" className="rounded-lg p-6 shadow-lg">
@@ -23,6 +25,7 @@ export function CurrencyCard({ selectedCurrency, currencies, onCurrencyChange })
           label={settingsTranslations("cardCurrency.currencyLabel")}
           selectedKey={selectedCurrency}
           onSelectionChange={onCurrencyChange}
+          isDisabled={!canUpdateSettings}
         />
       </CardBody>
     </Card>

--- a/client/src/components/pages/Store/Settings/Currency/__tests__/Currency.test.jsx
+++ b/client/src/components/pages/Store/Settings/Currency/__tests__/Currency.test.jsx
@@ -5,6 +5,10 @@ import { I18nProvider } from "@i18n/I18nProvider";
 
 import { Currency } from "../Currency";
 
+jest.mock("@/hooks/usePermission", () => ({
+  usePermission: () => true,
+}));
+
 jest.mock("@heroui/react", () => {
   const actual = jest.requireActual("@heroui/react");
   const Autocomplete = ({

--- a/client/src/components/pages/Store/Settings/Currency/__tests__/CurrencyCard.test.jsx
+++ b/client/src/components/pages/Store/Settings/Currency/__tests__/CurrencyCard.test.jsx
@@ -1,13 +1,18 @@
 import { render, screen, act, fireEvent, waitFor } from "@testing-library/react";
 
+import { usePermission } from "@/hooks/usePermission";
 import { I18nProvider } from "@i18n/I18nProvider";
 
 import { CurrencyCard } from "../CurrencyCard";
 
+jest.mock("@/hooks/usePermission", () => ({
+  usePermission: jest.fn(),
+}));
+
 jest.mock("@heroui/react", () => {
   const actual = jest.requireActual("@heroui/react");
   const Autocomplete = ({
-    children, label, onSelectionChange, selectedKey, defaultFilter,
+    children, label, onSelectionChange, selectedKey, defaultFilter, isDisabled,
   }) => {
     const [inputValue, setInputValue] = require("react").useState("");
     const filteredChildren = require("react").Children.toArray(children).filter((child) => (
@@ -21,11 +26,13 @@ jest.mock("@heroui/react", () => {
           id="currency-search"
           aria-label={label}
           value={inputValue}
+          disabled={isDisabled}
           onChange={(event) => setInputValue(event.target.value)}
         />
         <select
           aria-label={`${label} options`}
           value={selectedKey ?? ""}
+          disabled={isDisabled}
           onChange={(event) => onSelectionChange(event.target.value)}
         >
           <option value="">Select currency</option>
@@ -68,6 +75,7 @@ beforeEach(() => {
     originalError.call(console, ...args);
   };
   jest.clearAllMocks();
+  usePermission.mockReturnValue(true);
 });
 
 afterEach(() => {
@@ -113,6 +121,25 @@ describe("CurrencyCard", () => {
       await act(async () => { renderCard({ selectedCurrency: "EUR" }); });
       const select = screen.getByLabelText("cardCurrency.currencyLabel options");
       expect(select.value).toBe("EUR");
+    });
+  });
+
+  describe("Permission gating", () => {
+    it("keeps the currency visible but disabled for a role without settings_update", async () => {
+      usePermission.mockReturnValue(false);
+      await act(async () => { renderCard({ selectedCurrency: "EUR" }); });
+
+      const select = screen.getByLabelText("cardCurrency.currencyLabel options");
+      expect(select.value).toBe("EUR");
+      expect(select).toBeDisabled();
+    });
+
+    it("enables the currency selector for a role with settings_update", async () => {
+      usePermission.mockReturnValue(true);
+      await act(async () => { renderCard(); });
+
+      const select = screen.getByLabelText("cardCurrency.currencyLabel options");
+      expect(select).not.toBeDisabled();
     });
   });
 

--- a/client/src/components/pages/Store/Settings/NwcConnection/NwcConnectionCardUnlocked.jsx
+++ b/client/src/components/pages/Store/Settings/NwcConnection/NwcConnectionCardUnlocked.jsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 
 import { addToast, Button, Card, CardBody, CardHeader, Input } from "@heroui/react";
 
+import { RequirePermission } from "@/hooks/usePermission";
 import { NWC_URI_REGEX } from "@/lib/nwcUri";
 import { updateNwcUri } from "@/services/walletService";
 import WalletGuard from "@components/auth/WalletGuard";
@@ -62,26 +63,30 @@ export function NwcConnectionCardUnlocked({ onHide, nwcConnectionTranslations })
               {nwcConnectionTranslations("nwcConnection.description")}
             </p>
 
-            <Input
-              label={nwcConnectionTranslations("nwcConnection.uriLabel")}
-              placeholder="nostr+walletconnect://..."
-              value={nwcUri}
-              onValueChange={handleUriChange}
-              isInvalid={!!uriError}
-              errorMessage={uriError}
-              classNames={{ input: "font-mono text-xs" }}
-            />
+            <RequirePermission allOf={["settings_update"]}>
+              <Input
+                label={nwcConnectionTranslations("nwcConnection.uriLabel")}
+                placeholder="nostr+walletconnect://..."
+                value={nwcUri}
+                onValueChange={handleUriChange}
+                isInvalid={!!uriError}
+                errorMessage={uriError}
+                classNames={{ input: "font-mono text-xs" }}
+              />
+            </RequirePermission>
 
             <div className="flex gap-2">
-              <Button
-                color="primary"
-                className="bg-green-800 h-8 min-w-16 px-3 rounded-small sm:h-10 sm:min-w-20 sm:px-4 sm:rounded-medium"
-                isDisabled={!nwcUri || submitting}
-                isLoading={submitting}
-                onPress={handleSubmit}
-              >
-                {nwcConnectionTranslations("nwcConnection.submitButton")}
-              </Button>
+              <RequirePermission allOf={["settings_update"]}>
+                <Button
+                  color="primary"
+                  className="bg-green-800 h-8 min-w-16 px-3 rounded-small sm:h-10 sm:min-w-20 sm:px-4 sm:rounded-medium"
+                  isDisabled={!nwcUri || submitting}
+                  isLoading={submitting}
+                  onPress={handleSubmit}
+                >
+                  {nwcConnectionTranslations("nwcConnection.submitButton")}
+                </Button>
+              </RequirePermission>
               <Button
                 variant="bordered"
                 isDisabled={submitting}

--- a/client/src/components/pages/Store/Settings/NwcConnection/__tests__/NwcConnectionCard.test.jsx
+++ b/client/src/components/pages/Store/Settings/NwcConnection/__tests__/NwcConnectionCard.test.jsx
@@ -2,6 +2,10 @@ import { render, screen, fireEvent } from "@testing-library/react";
 
 import { NwcConnectionCard } from "../NwcConnectionCard";
 
+jest.mock("@/hooks/usePermission", () => ({
+  RequirePermission: ({ children }) => children,
+}));
+
 jest.mock("@heroui/react", () => ({
   addToast: jest.fn(),
   Button: ({ onPress, children, ...props }) => (

--- a/client/src/components/pages/Store/Settings/NwcConnection/__tests__/NwcConnectionCardUnlocked.test.jsx
+++ b/client/src/components/pages/Store/Settings/NwcConnection/__tests__/NwcConnectionCardUnlocked.test.jsx
@@ -4,6 +4,10 @@ import * as walletService from "@/services/walletService";
 
 import { NwcConnectionCardUnlocked } from "../NwcConnectionCardUnlocked";
 
+jest.mock("@/hooks/usePermission", () => ({
+  RequirePermission: ({ children }) => children,
+}));
+
 jest.mock("@heroui/react", () => ({
   addToast: jest.fn(),
   Button: ({ onPress, children, isDisabled, ...props }) => (

--- a/client/src/components/pages/Store/Settings/Settings.jsx
+++ b/client/src/components/pages/Store/Settings/Settings.jsx
@@ -33,9 +33,13 @@ export function Settings() {
           <Currency />
           <Language />
           <Display />
-          <Seed />
-          <NwcConnectionCard />
-          <Tutorials />
+          {isAdmin && (
+            <>
+              <Seed />
+              <NwcConnectionCard />
+              <Tutorials />
+            </>
+          )}
         </div>
 
         <div className="flex flex-col gap-6">

--- a/client/src/components/pages/Store/Settings/StoreInfo/StoreInfoCard.jsx
+++ b/client/src/components/pages/Store/Settings/StoreInfo/StoreInfoCard.jsx
@@ -5,9 +5,8 @@ import Image from "next/image";
 import { Button, Card, CardBody, CardFooter, CardHeader } from "@heroui/react";
 import { useTranslations } from "next-intl";
 
+import { storedAssetUrl } from "@/components/utils/storedAssetUrl";
 import { RequirePermission } from "@/hooks/usePermission";
-
-import { storedAssetUrl } from "../../../../utils/storedAssetUrl";
 
 export function StoreInfoCard({ data, onEdit }) {
   const settingsTranslations = useTranslations("settings");

--- a/client/src/components/pages/Store/Settings/StoreInfo/StoreInfoCard.jsx
+++ b/client/src/components/pages/Store/Settings/StoreInfo/StoreInfoCard.jsx
@@ -5,6 +5,8 @@ import Image from "next/image";
 import { Button, Card, CardBody, CardFooter, CardHeader } from "@heroui/react";
 import { useTranslations } from "next-intl";
 
+import { RequirePermission } from "@/hooks/usePermission";
+
 import { storedAssetUrl } from "../../../../utils/storedAssetUrl";
 
 export function StoreInfoCard({ data, onEdit }) {
@@ -94,13 +96,15 @@ export function StoreInfoCard({ data, onEdit }) {
       </CardBody>
 
       <CardFooter className="flex justify-end">
-        <Button
-          color="primary"
-          className="h-8 min-w-16 px-3 rounded-small sm:h-10 sm:min-w-20 sm:px-4 sm:rounded-medium"
-          onPress={onEdit}
-        >
-          {settingsTranslations("cardInfo.edit")}
-        </Button>
+        <RequirePermission allOf={["settings_update"]}>
+          <Button
+            color="primary"
+            className="h-8 min-w-16 px-3 rounded-small sm:h-10 sm:min-w-20 sm:px-4 sm:rounded-medium"
+            onPress={onEdit}
+          >
+            {settingsTranslations("cardInfo.edit")}
+          </Button>
+        </RequirePermission>
       </CardFooter>
     </Card>
   );

--- a/client/src/components/pages/Store/Settings/StoreInfo/__tests__/StoreInfo.test.jsx
+++ b/client/src/components/pages/Store/Settings/StoreInfo/__tests__/StoreInfo.test.jsx
@@ -7,6 +7,10 @@ import * as configurationsProvider from "@providers/configurations/configuration
 
 import { StoreInfo } from "../StoreInfo";
 
+jest.mock("@/hooks/usePermission", () => ({
+  RequirePermission: ({ children }) => children,
+}));
+
 const mockUpdateConfig = jest.fn();
 const mockUpload = jest.fn();
 

--- a/client/src/components/pages/Store/Settings/StoreInfo/__tests__/StoreInfoCard.test.jsx
+++ b/client/src/components/pages/Store/Settings/StoreInfo/__tests__/StoreInfoCard.test.jsx
@@ -5,6 +5,10 @@ import { I18nProvider } from "@i18n/I18nProvider";
 
 import { StoreInfoCard } from "../StoreInfoCard";
 
+jest.mock("@/hooks/usePermission", () => ({
+  RequirePermission: ({ children }) => children,
+}));
+
 const mockData = {
   businessName: "Mi Tienda Test",
   businessType: "store",

--- a/client/src/components/pages/Store/Settings/__tests__/Settings.test.jsx
+++ b/client/src/components/pages/Store/Settings/__tests__/Settings.test.jsx
@@ -208,14 +208,13 @@ afterEach(() => {
 
 describe("Settings page", () => {
   describe("Rendering", () => {
-    it("renders store info, currency, languages, and tutorials cards", async () => {
+    it("renders store info, currency, and language cards", async () => {
       await act(async () => {
         renderSettings();
       });
       expect(screen.getByText("cardInfo.title")).toBeInTheDocument();
       expect(screen.getByText("cardCurrency.title")).toBeInTheDocument();
       expect(screen.getByText("cardLanguage.title")).toBeInTheDocument();
-      expect(screen.getByText("cardTours.title")).toBeInTheDocument();
     });
 
     it("renders notification preferences card only for admins", async () => {
@@ -421,7 +420,76 @@ describe("Settings page", () => {
     });
   });
 
+  describe("Permission gating", () => {
+    it("hides the StoreInfo edit button and disables the Currency selector for a role without settings_update", async () => {
+      await act(async () => {
+        renderSettings();
+      });
+
+      expect(screen.queryByText("cardInfo.edit")).not.toBeInTheDocument();
+      expect(screen.getByText("cardCurrency.currencyLabel")).toBeInTheDocument();
+      expect(screen.getByRole("combobox", { name: "cardCurrency.currencyLabel" })).toBeDisabled();
+    });
+
+    it("shows the StoreInfo edit button and enables the Currency selector for a role with settings_update", async () => {
+      jest.spyOn(useAuthHook, "useAuth").mockReturnValue({
+        isAuth: true,
+        isLoading: false,
+        user: { userId: "user-1", name: "Tester" },
+        permissions: [{ name: "settings_update" }],
+        logout: jest.fn(),
+      });
+
+      await act(async () => {
+        renderSettings();
+      });
+
+      expect(screen.getByText("cardInfo.edit")).toBeInTheDocument();
+      expect(screen.getByRole("combobox", { name: "cardCurrency.currencyLabel" })).not.toBeDisabled();
+    });
+
+    it("hides Seed, NwcConnection, and Tutorials for a non-admin role", async () => {
+      await act(async () => {
+        renderSettings();
+      });
+
+      expect(screen.queryByText("cardSeed.title")).not.toBeInTheDocument();
+      expect(screen.queryByText("nwcConnection.manageButton")).not.toBeInTheDocument();
+      expect(screen.queryByText("cardTours.title")).not.toBeInTheDocument();
+    });
+
+    it("shows Seed, NwcConnection, and Tutorials for an admin role", async () => {
+      jest.spyOn(useNavigationHook, "useNavigation").mockReturnValue({
+        availableFeatures: {},
+        availableNavigation: defaultNavigation,
+        isAuth: true,
+        isAdmin: true,
+        isLoading: false,
+        user: { userName: "admin", isAdmin: true },
+        logout: mockLogout,
+      });
+
+      await act(async () => {
+        renderSettings();
+      });
+
+      expect(screen.getByText("cardSeed.title")).toBeInTheDocument();
+      expect(screen.getByText("nwcConnection.manageButton")).toBeInTheDocument();
+      expect(screen.getByText("cardTours.title")).toBeInTheDocument();
+    });
+  });
+
   describe("User Interactions", () => {
+    beforeEach(() => {
+      jest.spyOn(useAuthHook, "useAuth").mockReturnValue({
+        isAuth: true,
+        isLoading: false,
+        user: { userId: "user-1", name: "Tester" },
+        permissions: [{ name: "settings_update" }],
+        logout: jest.fn(),
+      });
+    });
+
     it("opens edit modal when edit button is clicked", async () => {
       const user = userEvent.setup();
 

--- a/client/src/components/pages/Store/hooks/__tests__/usePrinter.test.jsx
+++ b/client/src/components/pages/Store/hooks/__tests__/usePrinter.test.jsx
@@ -320,8 +320,8 @@ describe("usePrinters", () => {
       await handlers.refetchAll();
     });
 
-    expect(httpClient).toHaveBeenCalledWith("/printers/available", {});
-    expect(httpClient).toHaveBeenCalledWith("/printers/configs", {});
+    expect(httpClient).toHaveBeenCalledWith("/printers/available", { skipForbiddenRedirect: true });
+    expect(httpClient).toHaveBeenCalledWith("/printers/configs", { skipForbiddenRedirect: true });
     expect(screen.getByTestId("available-count")).toHaveTextContent("1");
     expect(screen.getByTestId("config-count")).toHaveTextContent("1");
   });

--- a/client/src/components/pages/Store/hooks/__tests__/useTemplates.test.jsx
+++ b/client/src/components/pages/Store/hooks/__tests__/useTemplates.test.jsx
@@ -70,6 +70,16 @@ describe("useTemplates", () => {
     expect(screen.getByTestId("first-name")).toHaveTextContent("Default");
   });
 
+  it("loads templates with skipForbiddenRedirect so a 403 does not force a global redirect", async () => {
+    httpClient.mockResolvedValueOnce({ ok: true });
+    parseJsonResponse.mockResolvedValueOnce([]);
+
+    render(<TestComponent />);
+
+    await waitFor(() => expect(screen.getByTestId("loading")).toHaveTextContent("no"));
+    expect(httpClient).toHaveBeenCalledWith("/templates", { skipForbiddenRedirect: true });
+  });
+
   it("sets empty templates when apiClient returns non-array", async () => {
     httpClient.mockResolvedValueOnce({ ok: true });
     parseJsonResponse.mockResolvedValueOnce({ ok: true });

--- a/client/src/components/pages/Store/hooks/usePrinter.jsx
+++ b/client/src/components/pages/Store/hooks/usePrinter.jsx
@@ -18,7 +18,7 @@ export function usePrinters() {
     setError(null);
 
     try {
-      const printersData = await fetchList("/printers/available");
+      const printersData = await fetchList("/printers/available", [], { skipForbiddenRedirect: true });
       setAvailablePrinters(toArray(printersData));
     } catch (error) {
       console.error("Error fetching printers:", error);
@@ -33,7 +33,7 @@ export function usePrinters() {
     setError(null);
 
     try {
-      const printerDataConfigs = await fetchList("/printers/configs");
+      const printerDataConfigs = await fetchList("/printers/configs", [], { skipForbiddenRedirect: true });
       setPrinterConfigs(toArray(printerDataConfigs));
     } catch (error) {
       console.error("Error fetching printer configs:", error);

--- a/client/src/components/pages/Store/hooks/useTemplates.jsx
+++ b/client/src/components/pages/Store/hooks/useTemplates.jsx
@@ -15,7 +15,7 @@ export function useTemplates() {
     setLoading(true);
     setError(null);
     try {
-      const templatesData = await fetchList("/templates");
+      const templatesData = await fetchList("/templates", [], { skipForbiddenRedirect: true });
       setTemplates(toArray(templatesData));
     } catch (error) {
       console.error("Error fetching templates:", error);

--- a/client/src/components/shared/CurrencyInput.jsx
+++ b/client/src/components/shared/CurrencyInput.jsx
@@ -16,6 +16,7 @@ export function CurrencyInput({
   size,
   isInvalid,
   errorMessage,
+  isDisabled,
 }) {
   return (
     <Autocomplete
@@ -27,6 +28,7 @@ export function CurrencyInput({
       onSelectionChange={onSelectionChange}
       isInvalid={isInvalid}
       errorMessage={errorMessage}
+      isDisabled={isDisabled}
       isClearable
       allowsCustomValue={false}
       menuTrigger="focus"

--- a/client/src/lib/__tests__/features.test.js
+++ b/client/src/lib/__tests__/features.test.js
@@ -14,4 +14,14 @@ describe("getAvailableFeatures", () => {
     const available = getAvailableFeatures(true, false, [{ name: "wallet_read" }], "store");
     expect(findRoute(available, "/store/reports")).toBeUndefined();
   });
+
+  it("includes /store/settings for a non-admin user with settings_read", () => {
+    const available = getAvailableFeatures(true, false, [{ name: "settings_read" }], "store");
+    expect(findRoute(available, "/store/settings")).toBeDefined();
+  });
+
+  it("excludes /store/settings for a user without settings_read, even with settings_update", () => {
+    const available = getAvailableFeatures(true, false, [{ name: "settings_update" }], "store");
+    expect(findRoute(available, "/store/settings")).toBeUndefined();
+  });
 });

--- a/client/src/lib/features.js
+++ b/client/src/lib/features.js
@@ -28,7 +28,7 @@ export const features = {
       { path: "/store/wallet", requiresAuth: true, requiresAdmin: false, types: ["store"], permissions: ["wallet_read"] },
       { path: "/store/reports", requiresAuth: true, requiresAdmin: false, types: ["store"], permissions: ["reports_read"] },
       { path: "/store/notifications", requiresAuth: true, requiresAdmin: true, types: ["store"] },
-      { path: "/store/settings", requiresAuth: true, requiresAdmin: false, types: ["store"], permissions: ["settings_update"] },
+      { path: "/store/settings", requiresAuth: true, requiresAdmin: false, types: ["store"], permissions: ["settings_read"] },
     ],
     navItems: [
       { path: "/store/users", label: "users", icon: "users", showInNavbar: true },

--- a/client/src/services/__tests__/walletService.test.js
+++ b/client/src/services/__tests__/walletService.test.js
@@ -20,6 +20,7 @@ import {
   getIncomingTransactions,
   getOutgoingTransactions,
   getSeed,
+  updateNwcUri,
   closeChannel,
 } from "../walletService";
 
@@ -353,7 +354,7 @@ describe("walletService", () => {
 
       await getSeed();
 
-      expect(httpClient).toHaveBeenCalledWith("/wallet/seed");
+      expect(httpClient).toHaveBeenCalledWith("/wallet/seed", { skipForbiddenRedirect: true });
     });
 
     it("throws with the server code when the backend does not support seed export", async () => {
@@ -368,6 +369,46 @@ describe("walletService", () => {
         message: "Seed export is not available with NWC backend",
         status: 501,
         code: "unsupported_operation",
+      });
+    });
+  });
+
+  describe("updateNwcUri", () => {
+    it("calls /wallet/updatenwcuri with trimmed nwcUri in body", async () => {
+      httpClient.mockResolvedValue(makeResponse(200));
+      parseJsonResponse.mockResolvedValue({ message: "NWC backend reconfigured" });
+
+      await updateNwcUri("  nostr+walletconnect://abc  ");
+
+      expect(httpClient).toHaveBeenCalledWith("/wallet/updatenwcuri", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ nwcUri: "nostr+walletconnect://abc" }),
+        skipForbiddenRedirect: true,
+      });
+    });
+
+    it("returns the parsed response body", async () => {
+      httpClient.mockResolvedValue(makeResponse(200));
+      parseJsonResponse.mockResolvedValue({ message: "NWC backend reconfigured" });
+
+      const updateNwcUriResult = await updateNwcUri("nostr+walletconnect://abc");
+
+      expect(updateNwcUriResult).toEqual({ message: "NWC backend reconfigured" });
+    });
+
+    it("throws structured error when response is not ok", async () => {
+      httpClient.mockResolvedValue(makeResponse(400, false));
+      parseJsonResponse.mockResolvedValue({
+        message: "Invalid NWC URI",
+        code: "nwc_connection_failed",
+        source: "ambrosia",
+      });
+
+      await expect(updateNwcUri("nostr+walletconnect://abc")).rejects.toMatchObject({
+        message: "Invalid NWC URI",
+        status: 400,
+        code: "nwc_connection_failed",
       });
     });
   });

--- a/client/src/services/walletService.js
+++ b/client/src/services/walletService.js
@@ -217,6 +217,7 @@ export async function updateNwcUri(nwcUri) {
       "Content-Type": "application/json",
     },
     body: JSON.stringify({ nwcUri: nwcUri.trim() }),
+    skipForbiddenRedirect: true,
   });
   const nwcUriUpdateBody = await parseJsonResponse(nwcUriUpdateResponse, null);
   if (!nwcUriUpdateResponse.ok) {
@@ -230,7 +231,7 @@ export async function updateNwcUri(nwcUri) {
 }
 
 export async function getSeed() {
-  const seedResponse = await httpClient("/wallet/seed");
+  const seedResponse = await httpClient("/wallet/seed", { skipForbiddenRedirect: true });
   const seedResponseBody = await parseJsonResponse(seedResponse, null);
   if (!seedResponse.ok) {
     throw createWalletServiceError(seedResponseBody?.message || "Seed not available", {


### PR DESCRIPTION
## Changes:

- Gate `/store/settings` navigation by `settings_read` instead of `settings_update`, fixing a phantom-permission bug where a role granted only view access to Settings couldn't reach the page at all.
- Require `settings_update` to edit StoreInfo in Settings; the read-only gate above no longer implies write access.
- Require `settings_update` to edit Currency (keeps the current value visible but disables the selector), and stop Currency's requests from redirecting to `/unauthorized` on a 403.
- Require `settings_update` to edit NwcConnection, and stop NwcConnection/Seed requests from redirecting to `/unauthorized` on a 403.
- Stop Printers and TicketTemplates list requests from redirecting to `/unauthorized` on a 403 (their write actions were already gated).
- Hide Seed, NwcConnection, and Tutorials from non-admin roles in Settings, since the wallet operations they surface require admin regardless of any RBAC permission.