### PR TITLE
Fix/wallet forbidden access

### DIFF
--- a/client/src/components/pages/Store/Wallet/Wallet.jsx
+++ b/client/src/components/pages/Store/Wallet/Wallet.jsx
@@ -2,22 +2,38 @@
 
 import { useTranslations } from "next-intl";
 
+import { usePermission } from "@/hooks/usePermission";
 import WalletGuard from "@components/auth/WalletGuard";
 import { PageHeader } from "@components/shared/PageHeader";
+import { PermissionBlockedMessage } from "@components/shared/PermissionBlockedMessage";
 
 import { StoreWallet } from "./StoreWallet";
 
 export function Wallet() {
-  const t = useTranslations("wallet");
+  const walletTranslations = useTranslations("wallet");
+  const canReadWallet = usePermission({ allOf: ["wallet_read"] });
+
+  if (!canReadWallet) {
+    return (
+      <>
+        <PageHeader title={walletTranslations("title")} subtitle={walletTranslations("subtitle")} />
+        <PermissionBlockedMessage
+          title={walletTranslations("permissionBlocked.title")}
+          subtitle={walletTranslations("permissionBlocked.subtitle")}
+        />
+      </>
+    );
+  }
+
   return (
     <>
-      <PageHeader title={t("title")} subtitle={t("subtitle")} />
+      <PageHeader title={walletTranslations("title")} subtitle={walletTranslations("subtitle")} />
       <WalletGuard
         placeholder={<div className="min-h-screen gradient-fresh p-4" />}
-        title={t("access.title")}
-        passwordLabel={t("access.passwordLabel")}
-        confirmText={t("access.confirmText")}
-        cancelText={t("access.cancelText")}
+        title={walletTranslations("access.title")}
+        passwordLabel={walletTranslations("access.passwordLabel")}
+        confirmText={walletTranslations("access.confirmText")}
+        cancelText={walletTranslations("access.cancelText")}
       >
         <StoreWallet />
       </WalletGuard>

--- a/client/src/components/pages/Store/Wallet/__tests__/StoreWallet.test.jsx
+++ b/client/src/components/pages/Store/Wallet/__tests__/StoreWallet.test.jsx
@@ -54,6 +54,7 @@ function renderStoreWallet() {
   const mockAuthContext = {
     user: { userName: "testuser", userId: 1 },
     isAuth: true,
+    permissions: [{ name: "wallet_read" }],
   };
 
   return render(

--- a/client/src/components/pages/Store/Wallet/__tests__/Wallet.test.jsx
+++ b/client/src/components/pages/Store/Wallet/__tests__/Wallet.test.jsx
@@ -1,0 +1,64 @@
+import { render, screen } from "@testing-library/react";
+
+import { usePermission } from "@/hooks/usePermission";
+
+import { Wallet } from "../Wallet";
+
+jest.mock("@/hooks/usePermission", () => ({
+  usePermission: jest.fn(),
+}));
+
+jest.mock("next-intl", () => ({
+  useTranslations: () => (key) => key,
+}));
+
+jest.mock("@components/auth/WalletGuard", () => function MockWalletGuard({ children }) {
+  return <div data-testid="wallet-guard">{children}</div>;
+});
+
+jest.mock("../StoreWallet", () => ({
+  StoreWallet: () => <div data-testid="store-wallet" />,
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("Wallet", () => {
+  it("shows a permission-blocked message instead of WalletGuard when wallet_read is missing", () => {
+    usePermission.mockReturnValue(false);
+
+    render(<Wallet />);
+
+    expect(screen.getByText("permissionBlocked.title")).toBeInTheDocument();
+    expect(screen.getByText("permissionBlocked.subtitle")).toBeInTheDocument();
+    expect(screen.queryByTestId("wallet-guard")).not.toBeInTheDocument();
+  });
+
+  it("calls usePermission with wallet_read", () => {
+    usePermission.mockReturnValue(true);
+
+    render(<Wallet />);
+
+    expect(usePermission).toHaveBeenCalledWith({ allOf: ["wallet_read"] });
+  });
+
+  it("renders WalletGuard and StoreWallet when wallet_read is granted", () => {
+    usePermission.mockReturnValue(true);
+
+    render(<Wallet />);
+
+    expect(screen.getByTestId("wallet-guard")).toBeInTheDocument();
+    expect(screen.getByTestId("store-wallet")).toBeInTheDocument();
+    expect(screen.queryByText("permissionBlocked.title")).not.toBeInTheDocument();
+  });
+
+  it("always renders the page header", () => {
+    usePermission.mockReturnValue(false);
+
+    render(<Wallet />);
+
+    expect(screen.getByText("title")).toBeInTheDocument();
+    expect(screen.getByText("subtitle")).toBeInTheDocument();
+  });
+});

--- a/client/src/components/pages/Store/Wallet/locales/en.js
+++ b/client/src/components/pages/Store/Wallet/locales/en.js
@@ -20,6 +20,10 @@ const walletEn = {
       confirmText: "Access",
       cancelText: "Cancel",
     },
+    permissionBlocked: {
+      title: "You can't access the wallet",
+      subtitle: "Ask an administrator to grant you the Access wallet permission.",
+    },
     passwordChange: {
       title: "Wallet password",
       description: "Change the password used to unlock wallet actions.",

--- a/client/src/components/pages/Store/Wallet/locales/es.js
+++ b/client/src/components/pages/Store/Wallet/locales/es.js
@@ -20,6 +20,10 @@ const walletEs = {
       confirmText: "Entrar",
       cancelText: "Cancelar",
     },
+    permissionBlocked: {
+      title: "No puedes acceder a la billetera",
+      subtitle: "Pídele a un administrador que te otorgue el permiso de acceder a billetera.",
+    },
     passwordChange: {
       title: "Contraseña de Wallet",
       description: "Cambia la contraseña usada para desbloquear acciones de la wallet.",


### PR DESCRIPTION
## Changes:
- Require `wallet_read` to reach `/store/wallet`; a role without it now sees a permission-blocked message instead of the wallet password prompt, matching the same pattern already used on Users/Products/Orders.

**Screenshots**:

<img width="1690" height="902" alt="imagen" src="https://github.com/user-attachments/assets/6edfd577-dca2-4b4d-9d57-4f2855433508" />
