### PR TITLE
Feat(db): Add initial freelance schema migrations

### DIFF
--- a/server/app/src/main/kotlin/pos/ambrosia/db/tables/ClientsTable.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/db/tables/ClientsTable.kt
@@ -1,0 +1,33 @@
+package pos.ambrosia.db.tables
+
+import org.jetbrains.exposed.v1.core.dao.id.EntityID
+import org.jetbrains.exposed.v1.dao.java.UUIDEntity
+import org.jetbrains.exposed.v1.dao.java.UUIDEntityClass
+import pos.ambrosia.db.SQLiteUUIDTable
+import java.util.UUID
+
+object ClientsTable : SQLiteUUIDTable("clients") {
+    val name = varchar("name", 255)
+    val currencyId = reference("currency_id", CurrencyTable)
+    val hourlyRateCents = integer("hourly_rate_cents")
+    val billingCycle = varchar("billing_cycle", 20)
+    val paymentMethod = varchar("payment_method", 20)
+    val payoutAccountId = optReference("payout_account_id", PayoutAccountsTable)
+    val isDeleted = bool("is_deleted").default(false)
+    val createdAt = varchar("created_at", 50)
+}
+
+class ClientEntity(
+    id: EntityID<UUID>,
+) : UUIDEntity(id) {
+    companion object : UUIDEntityClass<ClientEntity>(ClientsTable)
+
+    var name by ClientsTable.name
+    var currencyId by ClientsTable.currencyId
+    var hourlyRateCents by ClientsTable.hourlyRateCents
+    var billingCycle by ClientsTable.billingCycle
+    var paymentMethod by ClientsTable.paymentMethod
+    var payoutAccountId by ClientsTable.payoutAccountId
+    var isDeleted by ClientsTable.isDeleted
+    var createdAt by ClientsTable.createdAt
+}

--- a/server/app/src/main/kotlin/pos/ambrosia/db/tables/ConfigTable.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/db/tables/ConfigTable.kt
@@ -9,6 +9,7 @@ import org.jetbrains.exposed.v1.dao.IntEntityClass
 object ConfigTable : IntIdTable("config") {
     val businessType = varchar("business_type", 20).default("restaurant")
     val businessName = varchar("business_name", 255)
+    val businessProfession = varchar("business_profession", 255).nullable()
     val businessAddress = text("business_address").nullable()
     val businessPhone = varchar("business_phone", 50).nullable()
     val businessEmail = varchar("business_email", 255).nullable()
@@ -25,6 +26,7 @@ class ConfigEntity(
 
     var businessType by ConfigTable.businessType
     var businessName by ConfigTable.businessName
+    var businessProfession by ConfigTable.businessProfession
     var businessAddress by ConfigTable.businessAddress
     var businessPhone by ConfigTable.businessPhone
     var businessEmail by ConfigTable.businessEmail

--- a/server/app/src/main/kotlin/pos/ambrosia/db/tables/InvoicesTable.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/db/tables/InvoicesTable.kt
@@ -1,0 +1,75 @@
+package pos.ambrosia.db.tables
+
+import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.core.dao.id.EntityID
+import org.jetbrains.exposed.v1.dao.java.UUIDEntity
+import org.jetbrains.exposed.v1.dao.java.UUIDEntityClass
+import pos.ambrosia.db.SQLiteUUIDTable
+import java.util.UUID
+
+object InvoicesTable : SQLiteUUIDTable("invoices") {
+    val invoiceYear = integer("invoice_year")
+    val invoiceNumber = varchar("invoice_number", 50).uniqueIndex()
+    val clientId = reference("client_id", ClientsTable)
+    val status = varchar("status", 20).default("pending")
+    val currencyId = reference("currency_id", CurrencyTable)
+    val periodStart = varchar("period_start", 20)
+    val periodEnd = varchar("period_end", 20)
+    val totalCents = integer("total_cents")
+    val payoutSnapshot = text("payout_snapshot").nullable()
+    val paymentMethod = varchar("payment_method", 20)
+    val paymentHash = text("payment_hash").nullable()
+    val bolt11 = text("bolt11").nullable()
+    val createdAt = varchar("created_at", 50)
+}
+
+class InvoiceEntity(
+    id: EntityID<UUID>,
+) : UUIDEntity(id) {
+    companion object : UUIDEntityClass<InvoiceEntity>(InvoicesTable)
+
+    var invoiceYear by InvoicesTable.invoiceYear
+    var invoiceNumber by InvoicesTable.invoiceNumber
+    var clientId by InvoicesTable.clientId
+    var status by InvoicesTable.status
+    var currencyId by InvoicesTable.currencyId
+    var periodStart by InvoicesTable.periodStart
+    var periodEnd by InvoicesTable.periodEnd
+    var totalCents by InvoicesTable.totalCents
+    var payoutSnapshot by InvoicesTable.payoutSnapshot
+    var paymentMethod by InvoicesTable.paymentMethod
+    var paymentHash by InvoicesTable.paymentHash
+    var bolt11 by InvoicesTable.bolt11
+    var createdAt by InvoicesTable.createdAt
+}
+
+object InvoiceLineItemsTable : SQLiteUUIDTable("invoice_line_items") {
+    val invoiceId = reference("invoice_id", InvoicesTable)
+    val projectId = reference("project_id", ProjectsTable)
+    val taskId = reference("task_id", TasksTable)
+    val quantityMinutes = integer("quantity_minutes")
+    val rateCents = integer("rate_cents")
+    val amountCents = integer("amount_cents")
+    val createdAt = varchar("created_at", 50)
+}
+
+class InvoiceLineItemEntity(
+    id: EntityID<UUID>,
+) : UUIDEntity(id) {
+    companion object : UUIDEntityClass<InvoiceLineItemEntity>(InvoiceLineItemsTable)
+
+    var invoiceId by InvoiceLineItemsTable.invoiceId
+    var projectId by InvoiceLineItemsTable.projectId
+    var taskId by InvoiceLineItemsTable.taskId
+    var quantityMinutes by InvoiceLineItemsTable.quantityMinutes
+    var rateCents by InvoiceLineItemsTable.rateCents
+    var amountCents by InvoiceLineItemsTable.amountCents
+    var createdAt by InvoiceLineItemsTable.createdAt
+}
+
+object InvoicePaymentsTable : Table("invoice_payments") {
+    val paymentId = reference("payment_id", PaymentsTable)
+    val invoiceId = reference("invoice_id", InvoicesTable)
+
+    override val primaryKey = PrimaryKey(paymentId, invoiceId)
+}

--- a/server/app/src/main/kotlin/pos/ambrosia/db/tables/PayoutAccountsTable.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/db/tables/PayoutAccountsTable.kt
@@ -1,0 +1,39 @@
+package pos.ambrosia.db.tables
+
+import org.jetbrains.exposed.v1.core.dao.id.EntityID
+import org.jetbrains.exposed.v1.dao.java.UUIDEntity
+import org.jetbrains.exposed.v1.dao.java.UUIDEntityClass
+import pos.ambrosia.db.SQLiteUUIDTable
+import java.util.UUID
+
+object PayoutAccountsTable : SQLiteUUIDTable("payout_accounts") {
+    val type = varchar("type", 20)
+    val accountHolder = varchar("account_holder", 255).nullable()
+    val bankName = varchar("bank_name", 255).nullable()
+    val accountNumber = varchar("account_number", 255).nullable()
+    val currencyId = optReference("currency_id", CurrencyTable)
+    val swift = varchar("swift", 50).nullable()
+    val iban = varchar("iban", 50).nullable()
+    val clabe = varchar("clabe", 50).nullable()
+    val lightningAddress = varchar("lightning_address", 255).nullable()
+    val isDeleted = bool("is_deleted").default(false)
+    val createdAt = varchar("created_at", 50)
+}
+
+class PayoutAccountEntity(
+    id: EntityID<UUID>,
+) : UUIDEntity(id) {
+    companion object : UUIDEntityClass<PayoutAccountEntity>(PayoutAccountsTable)
+
+    var type by PayoutAccountsTable.type
+    var accountHolder by PayoutAccountsTable.accountHolder
+    var bankName by PayoutAccountsTable.bankName
+    var accountNumber by PayoutAccountsTable.accountNumber
+    var currencyId by PayoutAccountsTable.currencyId
+    var swift by PayoutAccountsTable.swift
+    var iban by PayoutAccountsTable.iban
+    var clabe by PayoutAccountsTable.clabe
+    var lightningAddress by PayoutAccountsTable.lightningAddress
+    var isDeleted by PayoutAccountsTable.isDeleted
+    var createdAt by PayoutAccountsTable.createdAt
+}

--- a/server/app/src/main/kotlin/pos/ambrosia/db/tables/ProjectsTable.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/db/tables/ProjectsTable.kt
@@ -1,0 +1,31 @@
+package pos.ambrosia.db.tables
+
+import org.jetbrains.exposed.v1.core.dao.id.EntityID
+import org.jetbrains.exposed.v1.dao.java.UUIDEntity
+import org.jetbrains.exposed.v1.dao.java.UUIDEntityClass
+import pos.ambrosia.db.SQLiteUUIDTable
+import java.util.UUID
+
+object ProjectsTable : SQLiteUUIDTable("projects") {
+    val clientId = reference("client_id", ClientsTable)
+    val name = varchar("name", 255)
+    val status = varchar("status", 20).default("pending")
+    val hourlyRateCents = integer("hourly_rate_cents").nullable()
+    val isBillable = bool("is_billable").default(true)
+    val isDeleted = bool("is_deleted").default(false)
+    val createdAt = varchar("created_at", 50)
+}
+
+class ProjectEntity(
+    id: EntityID<UUID>,
+) : UUIDEntity(id) {
+    companion object : UUIDEntityClass<ProjectEntity>(ProjectsTable)
+
+    var clientId by ProjectsTable.clientId
+    var name by ProjectsTable.name
+    var status by ProjectsTable.status
+    var hourlyRateCents by ProjectsTable.hourlyRateCents
+    var isBillable by ProjectsTable.isBillable
+    var isDeleted by ProjectsTable.isDeleted
+    var createdAt by ProjectsTable.createdAt
+}

--- a/server/app/src/main/kotlin/pos/ambrosia/db/tables/TasksTable.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/db/tables/TasksTable.kt
@@ -1,0 +1,25 @@
+package pos.ambrosia.db.tables
+
+import org.jetbrains.exposed.v1.core.dao.id.EntityID
+import org.jetbrains.exposed.v1.dao.java.UUIDEntity
+import org.jetbrains.exposed.v1.dao.java.UUIDEntityClass
+import pos.ambrosia.db.SQLiteUUIDTable
+import java.util.UUID
+
+object TasksTable : SQLiteUUIDTable("tasks") {
+    val name = varchar("name", 255)
+    val isBillable = bool("is_billable").default(true)
+    val isDeleted = bool("is_deleted").default(false)
+    val createdAt = varchar("created_at", 50)
+}
+
+class TaskEntity(
+    id: EntityID<UUID>,
+) : UUIDEntity(id) {
+    companion object : UUIDEntityClass<TaskEntity>(TasksTable)
+
+    var name by TasksTable.name
+    var isBillable by TasksTable.isBillable
+    var isDeleted by TasksTable.isDeleted
+    var createdAt by TasksTable.createdAt
+}

--- a/server/app/src/main/kotlin/pos/ambrosia/db/tables/TimeEntriesTable.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/db/tables/TimeEntriesTable.kt
@@ -1,0 +1,41 @@
+package pos.ambrosia.db.tables
+
+import org.jetbrains.exposed.v1.core.dao.id.EntityID
+import org.jetbrains.exposed.v1.dao.java.UUIDEntity
+import org.jetbrains.exposed.v1.dao.java.UUIDEntityClass
+import pos.ambrosia.db.SQLiteUUIDTable
+import java.util.UUID
+
+object TimeEntriesTable : SQLiteUUIDTable("time_entries") {
+    val projectId = reference("project_id", ProjectsTable)
+    val taskId = reference("task_id", TasksTable)
+    val userId = reference("user_id", UsersTable)
+    val entryDate = varchar("entry_date", 20)
+    val startTime = varchar("start_time", 20).nullable()
+    val endTime = varchar("end_time", 20).nullable()
+    val description = text("description").nullable()
+    val durationMinutes = integer("duration_minutes")
+    val rateCents = integer("rate_cents").nullable()
+    val invoiceId = optReference("invoice_id", InvoicesTable)
+    val isLocked = bool("is_locked").default(false)
+    val createdAt = varchar("created_at", 50)
+}
+
+class TimeEntryEntity(
+    id: EntityID<UUID>,
+) : UUIDEntity(id) {
+    companion object : UUIDEntityClass<TimeEntryEntity>(TimeEntriesTable)
+
+    var projectId by TimeEntriesTable.projectId
+    var taskId by TimeEntriesTable.taskId
+    var userId by TimeEntriesTable.userId
+    var entryDate by TimeEntriesTable.entryDate
+    var startTime by TimeEntriesTable.startTime
+    var endTime by TimeEntriesTable.endTime
+    var description by TimeEntriesTable.description
+    var durationMinutes by TimeEntriesTable.durationMinutes
+    var rateCents by TimeEntriesTable.rateCents
+    var invoiceId by TimeEntriesTable.invoiceId
+    var isLocked by TimeEntriesTable.isLocked
+    var createdAt by TimeEntriesTable.createdAt
+}

--- a/server/app/src/main/resources/db/migration/V43__add_freelance_businesstype.sql
+++ b/server/app/src/main/resources/db/migration/V43__add_freelance_businesstype.sql
@@ -1,0 +1,25 @@
+PRAGMA foreign_keys = OFF; 
+
+CREATE TABLE config__new (
+  id INTEGER PRIMARY KEY CHECK (id = 1),
+  business_type TEXT NOT NULL DEFAULT 'restaurant' CHECK (business_type IN ('store','restaurant','freelance')),
+  business_name TEXT NOT NULL,
+  business_profession TEXT,
+  business_address TEXT,
+  business_phone TEXT,
+  business_email TEXT,
+  business_tax_id TEXT,
+  business_logo_url TEXT,
+  business_type_confirmed BOOLEAN NOT NULL DEFAULT 0,
+  timezone TEXT NOT NULL DEFAULT 'America/Mexico_City'
+);
+
+INSERT INTO config__new (id, business_type, business_name, business_address, business_phone, business_email, business_tax_id, business_logo_url, business_type_confirmed, timezone)
+SELECT id, business_type, business_name, business_address, business_phone, business_email, business_tax_id, business_logo_url, business_type_confirmed, timezone
+FROM config
+WHERE id = 1 ;
+
+DROP TABLE config; 
+ALTER TABLE config__new RENAME TO config;
+
+PRAGMA foreign_keys = ON;

--- a/server/app/src/main/resources/db/migration/V44__add_freelance_tables.sql
+++ b/server/app/src/main/resources/db/migration/V44__add_freelance_tables.sql
@@ -1,106 +1,129 @@
 PRAGMA foreign_keys = OFF;
 
 CREATE TABLE clients (
-	"id" BLOB NOT NULL,
-	"name" TEXT,
-	"currency_id (FK)" BLOB,
-	"hourly_rate_cents" INTEGER,
-	"billing_cycle" TEXT,
-	"payment_method" TEXT,
-	"payment_account_id (FK)" BLOB,
-	"is_deleted" INTEGER,
-	PRIMARY KEY("id")
+	id BLOB NOT NULL,
+	name TEXT NOT NULL,
+	currency_id BLOB NOT NULL,
+	hourly_rate_cents INTEGER NOT NULL CHECK (hourly_rate_cents >= 0),
+	billing_cycle TEXT NOT NULL CHECK (billing_cycle IN ('weekly', 'biweekly', 'monthly')),
+	payment_method TEXT NOT NULL CHECK (payment_method IN ('bank', 'lightning')),
+	payout_account_id BLOB,
+	is_deleted BOOLEAN NOT NULL DEFAULT 0,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+	PRIMARY KEY(id),
+	FOREIGN KEY (currency_id) REFERENCES currency(id) ON DELETE RESTRICT,
+	FOREIGN KEY (payout_account_id) REFERENCES payout_accounts(id) ON DELETE RESTRICT
 );
 
 CREATE TABLE projects (
-	"id" BLOB NOT NULL,
-	"client_id" BLOB,
-	"name" TEXT,
-	"status" TEXT,
-	"hourly_rate_cents" INTEGER,
-	"is_billable" INTEGER,
-	"is_deleted" INTEGER,
-	PRIMARY KEY("id"),
-	FOREIGN KEY ("client_id") REFERENCES "clients"("id")
-	ON UPDATE NO ACTION ON DELETE NO ACTION
+	id BLOB NOT NULL,
+	client_id BLOB NOT NULL,
+	name TEXT NOT NULL,
+	status TEXT NOT NULL DEFAULT 'pending'
+		CHECK (status IN ('pending', 'in_progress', 'done', 'paid', 'cancelled')),
+	hourly_rate_cents INTEGER CHECK (hourly_rate_cents >= 0),
+	is_billable BOOLEAN NOT NULL DEFAULT 1,
+	is_deleted BOOLEAN NOT NULL DEFAULT 0,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+	PRIMARY KEY(id),
+	FOREIGN KEY (client_id) REFERENCES clients(id) ON DELETE RESTRICT
 );
 
 CREATE TABLE tasks (
-	"id" BLOB NOT NULL,
-	"name" TEXT,
-	"is_nullable" INTEGER,
-	"is_deleted" INTEGER,
-	PRIMARY KEY("id")
+	id BLOB NOT NULL,
+	name TEXT NOT NULL,
+	is_billable BOOLEAN NOT NULL DEFAULT 1,
+	is_deleted BOOLEAN NOT NULL DEFAULT 0,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+	PRIMARY KEY(id)
 );
 
 CREATE TABLE time_entries (
-	"id" BLOB NOT NULL,
-	"project_id" BLOB,
-	"task_id" BLOB,
-	"user_id (FK)" BLOB,
-	"entry_date" TEXT,
-	"description" TEXT,
-	"duration_minutes" INTEGER,
-	"rate_cents" INTEGER,
-	"invoice_id" BLOB,
-	"is_locked" INTEGER,
-	PRIMARY KEY("id"),
-	FOREIGN KEY ("project_id") REFERENCES "projects"("id")
-	ON UPDATE NO ACTION ON DELETE NO ACTION,
-	FOREIGN KEY ("task_id") REFERENCES "tasks"("id")
-	ON UPDATE NO ACTION ON DELETE NO ACTION,
-	FOREIGN KEY ("invoice_id") REFERENCES "invoices"("id")
-	ON UPDATE NO ACTION ON DELETE NO ACTION
+	id BLOB NOT NULL,
+	project_id BLOB NOT NULL,
+	task_id BLOB NOT NULL,
+	user_id BLOB NOT NULL,
+	entry_date TEXT NOT NULL,
+  start_time TEXT,
+  end_time TEXT,
+	description TEXT,
+	duration_minutes INTEGER NOT NULL CHECK (duration_minutes >= 0),
+	rate_cents INTEGER CHECK (rate_cents >= 0),
+	invoice_id BLOB,
+	is_locked BOOLEAN NOT NULL DEFAULT 0,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+	PRIMARY KEY(id),
+	FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE RESTRICT,
+	FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE RESTRICT,
+	FOREIGN KEY (invoice_id) REFERENCES invoices(id) ON DELETE RESTRICT,
+	FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE RESTRICT
 );
 
 CREATE TABLE payout_accounts (
-	"id" BLOB NOT NULL,
-	"type" TEXT,
-	"swift" TEXT,
-	"iban" TEXT,
-	"clabe" TEXT,
-	"lightning_address" TEXT,
-	"is_deleted" INTEGER,
-	PRIMARY KEY("id")
+    id BLOB NOT NULL,
+    type TEXT NOT NULL CHECK (type IN ('bank', 'lightning')),
+    account_holder TEXT,
+    bank_name TEXT,
+    account_number TEXT,
+    currency_id BLOB,
+    swift TEXT,
+    iban TEXT,
+    clabe TEXT,
+    lightning_address TEXT,
+    is_deleted BOOLEAN NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (id),
+    FOREIGN KEY (currency_id)
+        REFERENCES currency(id)
+        ON DELETE RESTRICT
 );
 
 CREATE TABLE invoices (
-	"id" BLOB NOT NULL,
-	"invoice_number" TEXT,
-	"client_id" BLOB,
-	"status" TEXT,
-	"currency_id (FK)" BLOB,
-	"period_start" TEXT,
-	"period_end" TEXT,
-	"total_cents" INTEGER,
-	"payment_method (FK)" TEXT,
-	"payment_hash" TEXT,
-	"bolt11" TEXT,
-	PRIMARY KEY("id"),
-	FOREIGN KEY ("client_id") REFERENCES "clients"("id")
-	ON UPDATE NO ACTION ON DELETE NO ACTION
+	id BLOB NOT NULL,
+	invoice_year INTEGER NOT NULL CHECK (invoice_year >= 0),
+  invoice_number TEXT NOT NULL UNIQUE,
+	client_id BLOB NOT NULL,
+	status TEXT NOT NULL DEFAULT 'pending'
+		CHECK (status IN ('pending', 'generated', 'sent', 'paid', 'expired')),
+	currency_id BLOB NOT NULL,
+	period_start TEXT NOT NULL,
+	period_end TEXT NOT NULL,
+	total_cents INTEGER NOT NULL CHECK (total_cents >= 0),
+  payout_snapshot TEXT
+    CHECK (
+        payout_snapshot IS NULL
+        OR json_valid(payout_snapshot)
+    ),
+	payment_method TEXT NOT NULL CHECK (payment_method IN ('bank', 'lightning')),
+	payment_hash TEXT,
+	bolt11 TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+	PRIMARY KEY(id),
+	FOREIGN KEY (client_id) REFERENCES clients(id) ON DELETE RESTRICT,
+	FOREIGN KEY (currency_id) REFERENCES currency(id) ON DELETE RESTRICT
 );
 
 CREATE TABLE invoice_line_items (
-	"id" BLOB NOT NULL,
-	"invoice_id" BLOB,
-	"project_id" BLOB,
-	"quantity_minutes" INTEGER,
-	"rate_cents" INTEGER,
-	"amount_cents" INTEGER,
-	PRIMARY KEY("id"),
-	FOREIGN KEY ("invoice_id") REFERENCES "invoices"("id")
-	ON UPDATE NO ACTION ON DELETE NO ACTION,
-	FOREIGN KEY ("project_id") REFERENCES "projects"("id")
-	ON UPDATE NO ACTION ON DELETE NO ACTION
+	id BLOB NOT NULL,
+	invoice_id BLOB NOT NULL,
+	project_id BLOB NOT NULL,
+	task_id BLOB NOT NULL,
+	quantity_minutes INTEGER NOT NULL CHECK (quantity_minutes >= 0),
+	rate_cents INTEGER NOT NULL CHECK (rate_cents >= 0),
+	amount_cents INTEGER NOT NULL CHECK (amount_cents >= 0),
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+	PRIMARY KEY(id),
+	FOREIGN KEY (invoice_id) REFERENCES invoices(id) ON DELETE RESTRICT,
+	FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE RESTRICT,
+	FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE RESTRICT
 );
 
 CREATE TABLE invoice_payments (
-	"payment_id (FK)" BLOB NOT NULL,
-	"invoice_id" BLOB,
-	PRIMARY KEY("payment_id (FK)"),
-	FOREIGN KEY ("invoice_id") REFERENCES "invoices"("id")
-	ON UPDATE NO ACTION ON DELETE NO ACTION
+	payment_id BLOB NOT NULL,
+	invoice_id BLOB NOT NULL,
+	PRIMARY KEY(payment_id, invoice_id),
+	FOREIGN KEY (invoice_id) REFERENCES invoices(id) ON DELETE RESTRICT,
+	FOREIGN KEY (payment_id) REFERENCES payments(id) ON DELETE RESTRICT
 );
 
 PRAGMA foreign_keys = ON;

--- a/server/app/src/main/resources/db/migration/V44__add_freelance_tables.sql
+++ b/server/app/src/main/resources/db/migration/V44__add_freelance_tables.sql
@@ -1,0 +1,106 @@
+PRAGMA foreign_keys = OFF;
+
+CREATE TABLE clients (
+	"id" BLOB NOT NULL,
+	"name" TEXT,
+	"currency_id (FK)" BLOB,
+	"hourly_rate_cents" INTEGER,
+	"billing_cycle" TEXT,
+	"payment_method" TEXT,
+	"payment_account_id (FK)" BLOB,
+	"is_deleted" INTEGER,
+	PRIMARY KEY("id")
+);
+
+CREATE TABLE projects (
+	"id" BLOB NOT NULL,
+	"client_id" BLOB,
+	"name" TEXT,
+	"status" TEXT,
+	"hourly_rate_cents" INTEGER,
+	"is_billable" INTEGER,
+	"is_deleted" INTEGER,
+	PRIMARY KEY("id"),
+	FOREIGN KEY ("client_id") REFERENCES "clients"("id")
+	ON UPDATE NO ACTION ON DELETE NO ACTION
+);
+
+CREATE TABLE tasks (
+	"id" BLOB NOT NULL,
+	"name" TEXT,
+	"is_nullable" INTEGER,
+	"is_deleted" INTEGER,
+	PRIMARY KEY("id")
+);
+
+CREATE TABLE time_entries (
+	"id" BLOB NOT NULL,
+	"project_id" BLOB,
+	"task_id" BLOB,
+	"user_id (FK)" BLOB,
+	"entry_date" TEXT,
+	"description" TEXT,
+	"duration_minutes" INTEGER,
+	"rate_cents" INTEGER,
+	"invoice_id" BLOB,
+	"is_locked" INTEGER,
+	PRIMARY KEY("id"),
+	FOREIGN KEY ("project_id") REFERENCES "projects"("id")
+	ON UPDATE NO ACTION ON DELETE NO ACTION,
+	FOREIGN KEY ("task_id") REFERENCES "tasks"("id")
+	ON UPDATE NO ACTION ON DELETE NO ACTION,
+	FOREIGN KEY ("invoice_id") REFERENCES "invoices"("id")
+	ON UPDATE NO ACTION ON DELETE NO ACTION
+);
+
+CREATE TABLE payout_accounts (
+	"id" BLOB NOT NULL,
+	"type" TEXT,
+	"swift" TEXT,
+	"iban" TEXT,
+	"clabe" TEXT,
+	"lightning_address" TEXT,
+	"is_deleted" INTEGER,
+	PRIMARY KEY("id")
+);
+
+CREATE TABLE invoices (
+	"id" BLOB NOT NULL,
+	"invoice_number" TEXT,
+	"client_id" BLOB,
+	"status" TEXT,
+	"currency_id (FK)" BLOB,
+	"period_start" TEXT,
+	"period_end" TEXT,
+	"total_cents" INTEGER,
+	"payment_method (FK)" TEXT,
+	"payment_hash" TEXT,
+	"bolt11" TEXT,
+	PRIMARY KEY("id"),
+	FOREIGN KEY ("client_id") REFERENCES "clients"("id")
+	ON UPDATE NO ACTION ON DELETE NO ACTION
+);
+
+CREATE TABLE invoice_line_items (
+	"id" BLOB NOT NULL,
+	"invoice_id" BLOB,
+	"project_id" BLOB,
+	"quantity_minutes" INTEGER,
+	"rate_cents" INTEGER,
+	"amount_cents" INTEGER,
+	PRIMARY KEY("id"),
+	FOREIGN KEY ("invoice_id") REFERENCES "invoices"("id")
+	ON UPDATE NO ACTION ON DELETE NO ACTION,
+	FOREIGN KEY ("project_id") REFERENCES "projects"("id")
+	ON UPDATE NO ACTION ON DELETE NO ACTION
+);
+
+CREATE TABLE invoice_payments (
+	"payment_id (FK)" BLOB NOT NULL,
+	"invoice_id" BLOB,
+	PRIMARY KEY("payment_id (FK)"),
+	FOREIGN KEY ("invoice_id") REFERENCES "invoices"("id")
+	ON UPDATE NO ACTION ON DELETE NO ACTION
+);
+
+PRAGMA foreign_keys = ON;

--- a/server/app/src/main/resources/db/migration/V45__add_freelance_permissions.sql
+++ b/server/app/src/main/resources/db/migration/V45__add_freelance_permissions.sql
@@ -1,0 +1,82 @@
+PRAGMA foreign_keys = ON;
+
+WITH permission_specs (name, description) AS (
+    VALUES
+        ('clients_read', 'List and view freelance clients'),
+        ('clients_create', 'Create freelance clients'),
+        ('clients_update', 'Update freelance clients'),
+        ('clients_delete', 'Delete freelance clients'),
+        ('projects_read', 'List and view freelance projects'),
+        ('projects_create', 'Create freelance projects'),
+        ('projects_update', 'Update freelance projects'),
+        ('projects_delete', 'Delete freelance projects'),
+        ('tasks_read', 'List and view freelance tasks'),
+        ('tasks_create', 'Create freelance tasks'),
+        ('tasks_update', 'Update freelance tasks'),
+        ('tasks_delete', 'Delete freelance tasks'),
+        ('time_entries_read', 'List and view freelance time entries'),
+        ('time_entries_create', 'Create freelance time entries'),
+        ('time_entries_update', 'Update freelance time entries'),
+        ('time_entries_delete', 'Delete freelance time entries'),
+        ('payout_accounts_read', 'List and view freelance payout accounts'),
+        ('payout_accounts_create', 'Create freelance payout accounts'),
+        ('payout_accounts_update', 'Update freelance payout accounts'),
+        ('payout_accounts_delete', 'Delete freelance payout accounts'),
+        ('invoices_read', 'List and view freelance invoices'),
+        ('invoices_create', 'Create freelance invoices'),
+        ('invoices_update', 'Update freelance invoices'),
+        ('invoices_pay', 'Register payments for freelance invoices'),
+        ('freelance_reports_read', 'View freelance reports'),
+        ('freelance_reports_export', 'Export freelance reports')
+)
+INSERT INTO permissions (id, name, description, enabled)
+SELECT
+    lower(hex(randomblob(4))) || '-' ||
+    lower(hex(randomblob(2))) || '-' ||
+    lower(hex(randomblob(2))) || '-' ||
+    lower(hex(randomblob(2))) || '-' ||
+    lower(hex(randomblob(6))),
+    name,
+    description,
+    1
+FROM permission_specs;
+
+INSERT INTO role_permissions (role_id, permission_id)
+SELECT r.id, p.id
+FROM roles r
+CROSS JOIN permissions p
+WHERE r.isAdmin = 1
+  AND p.name IN (
+      'clients_read',
+      'clients_create',
+      'clients_update',
+      'clients_delete',
+      'projects_read',
+      'projects_create',
+      'projects_update',
+      'projects_delete',
+      'tasks_read',
+      'tasks_create',
+      'tasks_update',
+      'tasks_delete',
+      'time_entries_read',
+      'time_entries_create',
+      'time_entries_update',
+      'time_entries_delete',
+      'payout_accounts_read',
+      'payout_accounts_create',
+      'payout_accounts_update',
+      'payout_accounts_delete',
+      'invoices_read',
+      'invoices_create',
+      'invoices_update',
+      'invoices_pay',
+      'freelance_reports_read',
+      'freelance_reports_export'
+  )
+  AND NOT EXISTS (
+      SELECT 1
+      FROM role_permissions rp
+      WHERE rp.role_id = r.id
+        AND rp.permission_id = p.id
+  );


### PR DESCRIPTION
## Summary

Completes and improves the database schema and Exposed mappings for the new Freelance business type.

## Changes

### Configuration

- Updates the `config` migration with support for:

  - `business_type = 'freelance'`
  - `business_profession`
  - Preservation of existing business information, `business_type_confirmed`, and `timezone`

- Updates `ConfigTable` and `ConfigEntity` to expose `business_profession`.

### Freelance schema

- Completes the following domain tables:

  - `clients`
  - `projects`
  - `tasks`
  - `time_entries`
  - `payout_accounts`
  - `invoices`
  - `invoice_line_items`
  - `invoice_payments`

- Improves the schema definitions by:

  - Fixing invalid column names containing `(FK)`
  - Adding missing foreign-key relationships
  - Using explicit `ON DELETE RESTRICT` policies
  - Adding required `NOT NULL` constraints
  - Adding boolean defaults
  - Adding `created_at` timestamps to domain records
  - Adding enum-style `CHECK` constraints
  - Preventing negative durations, rates, amounts, quantities, and invoice years
  - Adding optional start and end times to time entries
  - Completing bank and Lightning payout-account fields
  - Adding invoice-year and globally unique invoice-number support
  - Adding and validating the invoice payout snapshot
  - Converting `invoice_payments` into a composite-key junction table
  - Linking invoice line items to their corresponding tasks
  - Defining project and invoice status workflows

### Exposed mappings

- Adds Exposed table definitions and DAO entities for:

  - Clients
  - Projects
  - Tasks
  - Time entries
  - Payout accounts
  - Invoices
  - Invoice line items

- Adds an Exposed composite-key table mapping for `invoice_payments`.
- Aligns Exposed column names, types, nullability, defaults, relationships, and unique indexes with the Flyway schema.
- Uses the existing `SQLiteUUIDTable` convention for UUID-backed entities.

### Permissions

- Adds a separate Flyway migration for Freelance permissions:

  - CRUD permissions for clients, projects, tasks, time entries, and payout accounts
  - Read, create, update, and payment permissions for invoices
  - Read and export permissions for Freelance reports
  - Automatic assignment of the new permissions to admin roles

- Keeps the configuration, domain schema, and permission changes in separate Flyway migrations, following the updated implementation decision.

### Documentation

- Updates `freelancer-architecture.md` as planning and implementation context for the Freelance module and issue #651.

## Validation

- Verified the migrations with SQLite.
- Verified foreign-key integrity.
- Verified permission creation and admin-role assignment.
- Confirmed malformed or negative values are rejected by the applicable constraints.
- Compiled the Kotlin server successfully.
- Ran `ktlintCheck` successfully.
- Ran the server test suite successfully.
- Confirmed there are no SQL or Kotlin formatting errors.