### PR TITLE
Fix/dashboard empty permission state

### DIFF
--- a/client/src/components/pages/Store/Store.jsx
+++ b/client/src/components/pages/Store/Store.jsx
@@ -7,6 +7,7 @@ import { useTranslations } from "next-intl";
 import { useCurrency } from "@/components/hooks/useCurrency";
 import { usePermission } from "@/hooks/usePermission";
 import { PageHeader } from "@components/shared/PageHeader";
+import { PermissionBlockedMessage } from "@components/shared/PermissionBlockedMessage";
 
 import { useOrders } from "./hooks/useOrders";
 import { useProducts } from "./hooks/useProducts";
@@ -53,25 +54,32 @@ export function Store() {
     <>
       <PageHeader title={dashboardTranslations("title")} subtitle={dashboardTranslations("subtitle")} />
 
-      <div className="bg-white rounded-lg shadow-lg p-4 lg:p-8">
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-          {STATS.map((stat) => (
-            <Card key={stat.id} shadow="none" className="border border-gray-200 rounded-lg">
-              <CardHeader>
-                <div className="flex flex-col">
-                  <h3 className="text-lg font-semibold text-foreground mb-2">{stat.name}</h3>
-                </div>
-              </CardHeader>
-              <CardBody>
-                <div className="flex justify-between items-center">
-                  <p className="text-2xl font-bold text-green-900">{stat.quantity}</p>
-                  <stat.icon className="w-10 h-10 text-green-800 opacity-50" />
-                </div>
-              </CardBody>
-            </Card>
-          ))}
+      {STATS.length === 0 ? (
+        <PermissionBlockedMessage
+          title={dashboardTranslations("permissionBlocked.title")}
+          subtitle={dashboardTranslations("permissionBlocked.subtitle")}
+        />
+      ) : (
+        <div className="bg-white rounded-lg shadow-lg p-4 lg:p-8">
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            {STATS.map((stat) => (
+              <Card key={stat.id} shadow="none" className="border border-gray-200 rounded-lg">
+                <CardHeader>
+                  <div className="flex flex-col">
+                    <h3 className="text-lg font-semibold text-foreground mb-2">{stat.name}</h3>
+                  </div>
+                </CardHeader>
+                <CardBody>
+                  <div className="flex justify-between items-center">
+                    <p className="text-2xl font-bold text-green-900">{stat.quantity}</p>
+                    <stat.icon className="w-10 h-10 text-green-800 opacity-50" />
+                  </div>
+                </CardBody>
+              </Card>
+            ))}
+          </div>
         </div>
-      </div>
+      )}
     </>
   );
 }

--- a/client/src/components/pages/Store/__tests__/Store.test.jsx
+++ b/client/src/components/pages/Store/__tests__/Store.test.jsx
@@ -26,6 +26,7 @@ jest.mock("lucide-react", () => ({
   ClipboardClock: () => <div>ClipboardClock Icon</div>,
   Box: () => <div>Box Icon</div>,
   Wallet: () => <div>Wallet Icon</div>,
+  ShieldAlert: () => <div>ShieldAlert Icon</div>,
 }));
 
 jest.mock("@/lib/http", () => ({
@@ -401,5 +402,39 @@ describe("Store Dashboard", () => {
     });
 
     expect(screen.getByText("stats.users")).toBeInTheDocument();
+  });
+
+  it("shows the permission blocked message when users, products, and orders are all forbidden", async () => {
+    jest.spyOn(useUsersHook, "useUsers").mockReturnValue({
+      users: [],
+      loading: false,
+      error: null,
+      forbidden: true,
+      refetch: jest.fn(),
+    });
+    jest.spyOn(useProductsHook, "useProducts").mockReturnValue({
+      products: [],
+      loading: false,
+      error: null,
+      forbidden: true,
+      refetch: jest.fn(),
+    });
+    jest.spyOn(useOrdersHook, "useOrders").mockReturnValue({
+      orders: [],
+      loading: false,
+      error: null,
+      forbidden: true,
+      refetch: jest.fn(),
+    });
+
+    await act(async () => {
+      renderStore();
+    });
+
+    expect(screen.getByText("permissionBlocked.title")).toBeInTheDocument();
+    expect(screen.getByText("permissionBlocked.subtitle")).toBeInTheDocument();
+    expect(screen.queryByText("stats.users")).not.toBeInTheDocument();
+    expect(screen.queryByText("stats.products")).not.toBeInTheDocument();
+    expect(screen.queryByText("stats.sales")).not.toBeInTheDocument();
   });
 });

--- a/client/src/components/pages/Store/locales/en.js
+++ b/client/src/components/pages/Store/locales/en.js
@@ -37,6 +37,10 @@ const storeEn = {
       sales: "Sales",
       revenue: "Revenue",
     },
+    permissionBlocked: {
+      title: "You can't view any dashboard stats",
+      subtitle: "Ask an administrator to grant you permission to view users, products, or sales.",
+    },
   },
   ...usersEn,
   ...productsEn,

--- a/client/src/components/pages/Store/locales/es.js
+++ b/client/src/components/pages/Store/locales/es.js
@@ -37,6 +37,10 @@ const storeEs = {
       sales: "Ventas",
       revenue: "Ingresos",
     },
+    permissionBlocked: {
+      title: "No puedes ver ninguna estadística del panel",
+      subtitle: "Pídele a un administrador que te otorgue permiso para ver usuarios, productos o ventas.",
+    },
   },
   ...usersEs,
   ...productsEs,


### PR DESCRIPTION
## Changes:

- Show a `PermissionBlockedMessage` on the `/store` dashboard instead of an empty white box when a role has none of `users_read`, `products_read`, or `orders_read`