### PR TITLE
Feat(freelance): Add client and project services and API

### DIFF
--- a/server/app/src/main/kotlin/pos/ambrosia/Api.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/Api.kt
@@ -24,6 +24,7 @@ import pos.ambrosia.api.configureAdminNotificationsWebsocket
 import pos.ambrosia.api.configureAuth
 import pos.ambrosia.api.configureCategories
 import pos.ambrosia.api.configureCheckout
+import pos.ambrosia.api.configureClients
 import pos.ambrosia.api.configureConfig
 import pos.ambrosia.api.configureCurrency
 import pos.ambrosia.api.configureDishes
@@ -38,6 +39,7 @@ import pos.ambrosia.api.configurePhoenixWebhook
 import pos.ambrosia.api.configurePrinters
 import pos.ambrosia.api.configureProductVariants
 import pos.ambrosia.api.configureProducts
+import pos.ambrosia.api.configureProjects
 import pos.ambrosia.api.configureReports
 import pos.ambrosia.api.configureRoles
 import pos.ambrosia.api.configureRouting
@@ -106,6 +108,8 @@ class Api {
         configureStoreOrders()
         configureCheckout()
         configureCategories()
+        configureClients()
+        configureProjects()
         configureCurrency()
         configureInitialSetup()
         if (environment.config.propertyOrNull("nwc-uri") == null) {

--- a/server/app/src/main/kotlin/pos/ambrosia/api/Clients.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/api/Clients.kt
@@ -1,0 +1,126 @@
+package pos.ambrosia.api
+
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.Application
+import io.ktor.server.request.receive
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.delete
+import io.ktor.server.routing.get
+import io.ktor.server.routing.post
+import io.ktor.server.routing.put
+import io.ktor.server.routing.route
+import io.ktor.server.routing.routing
+import pos.ambrosia.models.FreelanceClientUpsert
+import pos.ambrosia.models.FreelanceProjectUpsert
+import pos.ambrosia.services.ClientService
+import pos.ambrosia.services.ProjectService
+import pos.ambrosia.utils.authorizePermission
+
+fun Application.configureClients() {
+    val clientService = ClientService()
+    val projectService = ProjectService()
+    routing { route("/clients") { clients(clientService, projectService) } }
+}
+
+fun Route.clients(
+    clientService: ClientService,
+    projectService: ProjectService,
+) {
+    authorizePermission("clients_read") {
+        get("") {
+            val clients = clientService.getClients()
+            if (clients.isEmpty()) {
+                call.respond(HttpStatusCode.OK, "No clients found")
+                return@get
+            }
+            call.respond(HttpStatusCode.OK, clients)
+        }
+
+        get("/{id}") {
+            val clientId =
+                call.parameters["id"]
+                    ?: return@get call.respond(HttpStatusCode.BadRequest, "Missing or malformed ID")
+            val client =
+                clientService.getClientById(clientId)
+                    ?: return@get call.respond(HttpStatusCode.NotFound, "Client not found")
+            call.respond(HttpStatusCode.OK, client)
+        }
+
+        get("/{id}/projects") {
+            val clientId =
+                call.parameters["id"]
+                    ?: return@get call.respond(HttpStatusCode.BadRequest, "Missing or malformed ID")
+            val projects =
+                projectService.getProjectsByClientId(clientId)
+                    ?: return@get call.respond(HttpStatusCode.NotFound, "Client not found")
+            if (projects.isEmpty()) {
+                call.respond(HttpStatusCode.OK, "No projects found")
+                return@get
+            }
+            call.respond(HttpStatusCode.OK, projects)
+        }
+    }
+
+    authorizePermission("clients_create") {
+        post("") {
+            val clientRequest = call.receive<FreelanceClientUpsert>()
+            val createdClientId = clientService.addClient(clientRequest)
+            if (createdClientId == null) {
+                call.respond(HttpStatusCode.BadRequest, "Invalid client data")
+                return@post
+            }
+            call.respond(
+                HttpStatusCode.Created,
+                mapOf("id" to createdClientId, "message" to "Client added successfully"),
+            )
+        }
+    }
+
+    authorizePermission("projects_create") {
+        post("/{id}/projects") {
+            val clientId =
+                call.parameters["id"]
+                    ?: return@post call.respond(HttpStatusCode.BadRequest, "Missing or malformed ID")
+            val projectRequest = call.receive<FreelanceProjectUpsert>()
+            val createdProjectId = projectService.addProject(clientId, projectRequest)
+            if (createdProjectId == null) {
+                call.respond(HttpStatusCode.BadRequest, "Invalid project data")
+                return@post
+            }
+            call.respond(
+                HttpStatusCode.Created,
+                mapOf("id" to createdProjectId, "message" to "Project added successfully"),
+            )
+        }
+    }
+
+    authorizePermission("clients_update") {
+        put("/{id}") {
+            val clientId =
+                call.parameters["id"]
+                    ?: return@put call.respond(HttpStatusCode.BadRequest, "Missing or malformed ID")
+            val clientRequest = call.receive<FreelanceClientUpsert>()
+            val clientWasUpdated = clientService.updateClient(clientId, clientRequest)
+            if (!clientWasUpdated) {
+                call.respond(HttpStatusCode.NotFound, "Client with ID: $clientId not found or invalid")
+                return@put
+            }
+            call.respond(HttpStatusCode.OK, mapOf("id" to clientId, "message" to "Client updated successfully"))
+        }
+    }
+
+    authorizePermission("clients_delete") {
+        delete("/{id}") {
+            val clientId =
+                call.parameters["id"]
+                    ?: return@delete call.respond(HttpStatusCode.BadRequest, "Missing or malformed ID")
+            val clientWasDeleted = clientService.deleteClient(clientId)
+            if (!clientWasDeleted) {
+                call.respond(HttpStatusCode.NotFound, "Client not found")
+                return@delete
+            }
+            call.respond(HttpStatusCode.NoContent)
+        }
+    }
+}

--- a/server/app/src/main/kotlin/pos/ambrosia/api/Projects.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/api/Projects.kt
@@ -1,0 +1,63 @@
+package pos.ambrosia.api
+
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.Application
+import io.ktor.server.request.receive
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.delete
+import io.ktor.server.routing.get
+import io.ktor.server.routing.put
+import io.ktor.server.routing.route
+import io.ktor.server.routing.routing
+import pos.ambrosia.models.FreelanceProjectUpsert
+import pos.ambrosia.services.ProjectService
+import pos.ambrosia.utils.authorizePermission
+
+fun Application.configureProjects() {
+    val projectService = ProjectService()
+    routing { route("/projects") { projects(projectService) } }
+}
+
+fun Route.projects(projectService: ProjectService) {
+    authorizePermission("projects_read") {
+        get("/{id}") {
+            val projectId =
+                call.parameters["id"]
+                    ?: return@get call.respond(HttpStatusCode.BadRequest, "Missing or malformed ID")
+            val project =
+                projectService.getProjectById(projectId)
+                    ?: return@get call.respond(HttpStatusCode.NotFound, "Project not found")
+            call.respond(HttpStatusCode.OK, project)
+        }
+    }
+
+    authorizePermission("projects_update") {
+        put("/{id}") {
+            val projectId =
+                call.parameters["id"]
+                    ?: return@put call.respond(HttpStatusCode.BadRequest, "Missing or malformed ID")
+            val projectRequest = call.receive<FreelanceProjectUpsert>()
+            val projectWasUpdated = projectService.updateProject(projectId, projectRequest)
+            if (!projectWasUpdated) {
+                call.respond(HttpStatusCode.NotFound, "Project with ID: $projectId not found or invalid")
+                return@put
+            }
+            call.respond(HttpStatusCode.OK, mapOf("id" to projectId, "message" to "Project updated successfully"))
+        }
+    }
+
+    authorizePermission("projects_delete") {
+        delete("/{id}") {
+            val projectId =
+                call.parameters["id"]
+                    ?: return@delete call.respond(HttpStatusCode.BadRequest, "Missing or malformed ID")
+            val projectWasDeleted = projectService.deleteProject(projectId)
+            if (!projectWasDeleted) {
+                call.respond(HttpStatusCode.NotFound, "Project not found")
+                return@delete
+            }
+            call.respond(HttpStatusCode.NoContent)
+        }
+    }
+}

--- a/server/app/src/main/kotlin/pos/ambrosia/models/AppModels.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/models/AppModels.kt
@@ -503,6 +503,49 @@ data class Config(
 )
 
 @Serializable
+data class FreelanceClient(
+    val id: String,
+    val name: String,
+    val currencyId: String,
+    val hourlyRateCents: Int,
+    val billingCycle: String,
+    val paymentMethod: String,
+    val payoutAccountId: String? = null,
+    val isDeleted: Boolean = false,
+    val createdAt: String,
+)
+
+@Serializable
+data class FreelanceClientUpsert(
+    val name: String,
+    val currencyId: String,
+    val hourlyRateCents: Int,
+    val billingCycle: String,
+    val paymentMethod: String,
+    val payoutAccountId: String? = null,
+)
+
+@Serializable
+data class FreelanceProject(
+    val id: String,
+    val clientId: String,
+    val name: String,
+    val status: String,
+    val hourlyRateCents: Int? = null,
+    val isBillable: Boolean = true,
+    val isDeleted: Boolean = false,
+    val createdAt: String,
+)
+
+@Serializable
+data class FreelanceProjectUpsert(
+    val name: String,
+    val status: String = "pending",
+    val hourlyRateCents: Int? = null,
+    val isBillable: Boolean = true,
+)
+
+@Serializable
 data class ProductOptionValue(
     val id: String? = null,
     val optionTypeId: String? = null,

--- a/server/app/src/main/kotlin/pos/ambrosia/services/ClientService.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/services/ClientService.kt
@@ -1,0 +1,137 @@
+package pos.ambrosia.services
+
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.dao.id.EntityID
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import pos.ambrosia.db.tables.ClientEntity
+import pos.ambrosia.db.tables.ClientsTable
+import pos.ambrosia.db.tables.CurrencyTable
+import pos.ambrosia.db.tables.PayoutAccountsTable
+import pos.ambrosia.logger
+import pos.ambrosia.models.FreelanceClient
+import pos.ambrosia.models.FreelanceClientUpsert
+import java.time.LocalDateTime
+import java.util.UUID
+
+class ClientService {
+    private val validBillingCycles = setOf("weekly", "biweekly", "monthly")
+    private val validPaymentMethods = setOf("bank", "lightning")
+
+    private fun parseUuid(value: String): UUID? =
+        try {
+            UUID.fromString(value)
+        } catch (_: IllegalArgumentException) {
+            null
+        }
+
+    private fun currencyExists(currencyId: String): Boolean {
+        val currencyUuid = parseUuid(currencyId) ?: return false
+        return !CurrencyTable
+            .selectAll()
+            .where { CurrencyTable.id eq EntityID(currencyUuid, CurrencyTable) }
+            .empty()
+    }
+
+    private fun payoutAccountExists(payoutAccountId: String?): Boolean {
+        if (payoutAccountId.isNullOrBlank()) return true
+        val payoutAccountUuid = parseUuid(payoutAccountId) ?: return false
+        return !PayoutAccountsTable
+            .selectAll()
+            .where {
+                (PayoutAccountsTable.id eq EntityID(payoutAccountUuid, PayoutAccountsTable)) and
+                    (PayoutAccountsTable.isDeleted eq false)
+            }.empty()
+    }
+
+    private fun isValidClientRequest(clientRequest: FreelanceClientUpsert): Boolean =
+        clientRequest.name.isNotBlank() &&
+            clientRequest.hourlyRateCents >= 0 &&
+            clientRequest.billingCycle in validBillingCycles &&
+            clientRequest.paymentMethod in validPaymentMethods &&
+            currencyExists(clientRequest.currencyId) &&
+            payoutAccountExists(clientRequest.payoutAccountId)
+
+    private fun toClientModel(clientEntity: ClientEntity): FreelanceClient =
+        FreelanceClient(
+            id = clientEntity.id.value.toString(),
+            name = clientEntity.name,
+            currencyId = clientEntity.currencyId.value.toString(),
+            hourlyRateCents = clientEntity.hourlyRateCents,
+            billingCycle = clientEntity.billingCycle,
+            paymentMethod = clientEntity.paymentMethod,
+            payoutAccountId = clientEntity.payoutAccountId?.value?.toString(),
+            isDeleted = clientEntity.isDeleted,
+            createdAt = clientEntity.createdAt,
+        )
+
+    fun getClients(): List<FreelanceClient> =
+        transaction {
+            ClientEntity
+                .find { ClientsTable.isDeleted eq false }
+                .map { clientEntity -> toClientModel(clientEntity) }
+        }
+
+    fun getClientById(clientId: String): FreelanceClient? =
+        transaction {
+            val clientUuid = parseUuid(clientId) ?: return@transaction null
+            val clientEntity = ClientEntity.findById(clientUuid) ?: return@transaction null
+            if (clientEntity.isDeleted) return@transaction null
+            toClientModel(clientEntity)
+        }
+
+    fun addClient(clientRequest: FreelanceClientUpsert): String? =
+        transaction {
+            if (!isValidClientRequest(clientRequest)) return@transaction null
+
+            val clientId =
+                ClientEntity
+                    .new(UUID.randomUUID()) {
+                        name = clientRequest.name
+                        currencyId = EntityID(UUID.fromString(clientRequest.currencyId), CurrencyTable)
+                        hourlyRateCents = clientRequest.hourlyRateCents
+                        billingCycle = clientRequest.billingCycle
+                        paymentMethod = clientRequest.paymentMethod
+                        payoutAccountId =
+                            clientRequest.payoutAccountId?.let { EntityID(UUID.fromString(it), PayoutAccountsTable) }
+                        isDeleted = false
+                        createdAt = LocalDateTime.now().toString()
+                    }.id.value
+                    .toString()
+            logger.info("Freelance client created: $clientId")
+            clientId
+        }
+
+    fun updateClient(
+        clientId: String,
+        clientRequest: FreelanceClientUpsert,
+    ): Boolean =
+        transaction {
+            val clientUuid = parseUuid(clientId) ?: return@transaction false
+            if (!isValidClientRequest(clientRequest)) return@transaction false
+
+            val clientEntity = ClientEntity.findById(clientUuid) ?: return@transaction false
+            if (clientEntity.isDeleted) return@transaction false
+
+            clientEntity.name = clientRequest.name
+            clientEntity.currencyId = EntityID(UUID.fromString(clientRequest.currencyId), CurrencyTable)
+            clientEntity.hourlyRateCents = clientRequest.hourlyRateCents
+            clientEntity.billingCycle = clientRequest.billingCycle
+            clientEntity.paymentMethod = clientRequest.paymentMethod
+            clientEntity.payoutAccountId = clientRequest.payoutAccountId?.let { EntityID(UUID.fromString(it), PayoutAccountsTable) }
+            logger.info("Freelance client updated: $clientId")
+            true
+        }
+
+    fun deleteClient(clientId: String): Boolean =
+        transaction {
+            val clientUuid = parseUuid(clientId) ?: return@transaction false
+            val clientEntity = ClientEntity.findById(clientUuid) ?: return@transaction false
+            if (clientEntity.isDeleted) return@transaction false
+
+            clientEntity.isDeleted = true
+            logger.info("Freelance client soft deleted: $clientId")
+            true
+        }
+}

--- a/server/app/src/main/kotlin/pos/ambrosia/services/ProjectService.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/services/ProjectService.kt
@@ -1,0 +1,130 @@
+package pos.ambrosia.services
+
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.dao.id.EntityID
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import pos.ambrosia.db.tables.ClientsTable
+import pos.ambrosia.db.tables.ProjectEntity
+import pos.ambrosia.db.tables.ProjectsTable
+import pos.ambrosia.logger
+import pos.ambrosia.models.FreelanceProject
+import pos.ambrosia.models.FreelanceProjectUpsert
+import java.time.LocalDateTime
+import java.util.UUID
+
+class ProjectService {
+    private val validStatuses = setOf("pending", "in_progress", "done", "paid", "cancelled")
+
+    private fun parseUuid(value: String): UUID? =
+        try {
+            UUID.fromString(value)
+        } catch (_: IllegalArgumentException) {
+            null
+        }
+
+    private fun clientExists(clientId: String): Boolean {
+        val clientUuid = parseUuid(clientId) ?: return false
+        return !ClientsTable
+            .selectAll()
+            .where {
+                (ClientsTable.id eq EntityID(clientUuid, ClientsTable)) and
+                    (ClientsTable.isDeleted eq false)
+            }.empty()
+    }
+
+    private fun isValidProjectRequest(projectRequest: FreelanceProjectUpsert): Boolean =
+        projectRequest.name.isNotBlank() &&
+            projectRequest.status in validStatuses &&
+            projectRequest.hourlyRateCents?.let { hourlyRateCents -> hourlyRateCents >= 0 } != false
+
+    private fun toProjectModel(projectEntity: ProjectEntity): FreelanceProject =
+        FreelanceProject(
+            id = projectEntity.id.value.toString(),
+            clientId = projectEntity.clientId.value.toString(),
+            name = projectEntity.name,
+            status = projectEntity.status,
+            hourlyRateCents = projectEntity.hourlyRateCents,
+            isBillable = projectEntity.isBillable,
+            isDeleted = projectEntity.isDeleted,
+            createdAt = projectEntity.createdAt,
+        )
+
+    fun getProjectsByClientId(clientId: String): List<FreelanceProject>? =
+        transaction {
+            val clientUuid = parseUuid(clientId) ?: return@transaction null
+            if (!clientExists(clientId)) return@transaction null
+
+            ProjectEntity
+                .find {
+                    (ProjectsTable.clientId eq EntityID(clientUuid, ClientsTable)) and
+                        (ProjectsTable.isDeleted eq false)
+                }.map { projectEntity -> toProjectModel(projectEntity) }
+        }
+
+    fun getProjectById(projectId: String): FreelanceProject? =
+        transaction {
+            val projectUuid = parseUuid(projectId) ?: return@transaction null
+            val projectEntity = ProjectEntity.findById(projectUuid) ?: return@transaction null
+            if (projectEntity.isDeleted) return@transaction null
+            if (!clientExists(projectEntity.clientId.value.toString())) return@transaction null
+            toProjectModel(projectEntity)
+        }
+
+    fun addProject(
+        clientId: String,
+        projectRequest: FreelanceProjectUpsert,
+    ): String? =
+        transaction {
+            val clientUuid = parseUuid(clientId) ?: return@transaction null
+            if (!clientExists(clientId)) return@transaction null
+            if (!isValidProjectRequest(projectRequest)) return@transaction null
+
+            val projectId =
+                ProjectEntity
+                    .new(UUID.randomUUID()) {
+                        this.clientId = EntityID(clientUuid, ClientsTable)
+                        name = projectRequest.name
+                        status = projectRequest.status
+                        hourlyRateCents = projectRequest.hourlyRateCents
+                        isBillable = projectRequest.isBillable
+                        isDeleted = false
+                        createdAt = LocalDateTime.now().toString()
+                    }.id.value
+                    .toString()
+            logger.info("Freelance project created: $projectId for client $clientId")
+            projectId
+        }
+
+    fun updateProject(
+        projectId: String,
+        projectRequest: FreelanceProjectUpsert,
+    ): Boolean =
+        transaction {
+            val projectUuid = parseUuid(projectId) ?: return@transaction false
+            if (!isValidProjectRequest(projectRequest)) return@transaction false
+
+            val projectEntity = ProjectEntity.findById(projectUuid) ?: return@transaction false
+            if (projectEntity.isDeleted) return@transaction false
+            if (!clientExists(projectEntity.clientId.value.toString())) return@transaction false
+
+            projectEntity.name = projectRequest.name
+            projectEntity.status = projectRequest.status
+            projectEntity.hourlyRateCents = projectRequest.hourlyRateCents
+            projectEntity.isBillable = projectRequest.isBillable
+            logger.info("Freelance project updated: $projectId")
+            true
+        }
+
+    fun deleteProject(projectId: String): Boolean =
+        transaction {
+            val projectUuid = parseUuid(projectId) ?: return@transaction false
+            val projectEntity = ProjectEntity.findById(projectUuid) ?: return@transaction false
+            if (projectEntity.isDeleted) return@transaction false
+
+            projectEntity.isDeleted = true
+            logger.info("Freelance project soft deleted: $projectId")
+            true
+        }
+}

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/ClientServiceTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/ClientServiceTest.kt
@@ -15,17 +15,17 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class ClientServiceTest {
-    private lateinit var dbFile: File
+    private lateinit var databaseFile: File
     private val service = ClientService()
 
     @Before
     fun setUp() {
-        dbFile = ExposedTestDb.connect()
+        databaseFile = ExposedTestDb.connect()
     }
 
     @After
     fun tearDown() {
-        ExposedTestDb.cleanup(dbFile)
+        ExposedTestDb.cleanup(databaseFile)
     }
 
     @Test

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/ClientServiceTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/ClientServiceTest.kt
@@ -1,0 +1,159 @@
+package pos.ambrosia.utest
+
+import org.junit.After
+import org.junit.Before
+import pos.ambrosia.models.FreelanceClientUpsert
+import pos.ambrosia.services.ClientService
+import pos.ambrosia.utils.ExposedTestDb
+import java.io.File
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class ClientServiceTest {
+    private lateinit var dbFile: File
+    private val service = ClientService()
+
+    @Before
+    fun setUp() {
+        dbFile = ExposedTestDb.connect()
+    }
+
+    @After
+    fun tearDown() {
+        ExposedTestDb.cleanup(dbFile)
+    }
+
+    @Test
+    fun `addClient returns id for valid request`() {
+        val currencyId = ExposedTestDb.seedCurrency("USD")
+        val payoutAccountId = ExposedTestDb.seedPayoutAccount(currencyId = currencyId)
+
+        val clientId =
+            service.addClient(
+                FreelanceClientUpsert(
+                    name = "Acme",
+                    currencyId = currencyId,
+                    hourlyRateCents = 7500,
+                    billingCycle = "monthly",
+                    paymentMethod = "bank",
+                    payoutAccountId = payoutAccountId,
+                ),
+            )
+
+        assertNotNull(clientId)
+        val client = service.getClientById(clientId)
+        assertNotNull(client)
+        assertEquals("Acme", client.name)
+        assertEquals(payoutAccountId, client.payoutAccountId)
+    }
+
+    @Test
+    fun `addClient rejects invalid request values`() {
+        val currencyId = ExposedTestDb.seedCurrency("USD")
+        val deletedPayoutAccountId = ExposedTestDb.seedPayoutAccount(currencyId = currencyId, isDeleted = true)
+        val validRequest =
+            FreelanceClientUpsert(
+                name = "Acme",
+                currencyId = currencyId,
+                hourlyRateCents = 7500,
+                billingCycle = "monthly",
+                paymentMethod = "bank",
+            )
+
+        assertNull(service.addClient(validRequest.copy(name = "   ")))
+        assertNull(service.addClient(validRequest.copy(hourlyRateCents = -1)))
+        assertNull(service.addClient(validRequest.copy(billingCycle = "yearly")))
+        assertNull(service.addClient(validRequest.copy(paymentMethod = "cash")))
+        assertNull(service.addClient(validRequest.copy(currencyId = UUID.randomUUID().toString())))
+        assertNull(service.addClient(validRequest.copy(payoutAccountId = deletedPayoutAccountId)))
+    }
+
+    @Test
+    fun `getClients excludes deleted clients`() {
+        ExposedTestDb.seedFreelanceClient(name = "Active")
+        ExposedTestDb.seedFreelanceClient(name = "Deleted", isDeleted = true)
+
+        val clients = service.getClients()
+
+        assertEquals(1, clients.size)
+        assertEquals("Active", clients[0].name)
+    }
+
+    @Test
+    fun `getClientById returns null for invalid missing or deleted client`() {
+        val deletedClientId = ExposedTestDb.seedFreelanceClient(isDeleted = true)
+
+        assertNull(service.getClientById("not-a-uuid"))
+        assertNull(service.getClientById(UUID.randomUUID().toString()))
+        assertNull(service.getClientById(deletedClientId))
+    }
+
+    @Test
+    fun `updateClient updates active client`() {
+        val currencyId = ExposedTestDb.seedCurrency("USD")
+        val clientId = ExposedTestDb.seedFreelanceClient(currencyId = currencyId)
+
+        val clientWasUpdated =
+            service.updateClient(
+                clientId,
+                FreelanceClientUpsert(
+                    name = "Updated",
+                    currencyId = currencyId,
+                    hourlyRateCents = 9000,
+                    billingCycle = "weekly",
+                    paymentMethod = "lightning",
+                ),
+            )
+
+        assertTrue(clientWasUpdated)
+        val client = service.getClientById(clientId)
+        assertNotNull(client)
+        assertEquals("Updated", client.name)
+        assertEquals(9000, client.hourlyRateCents)
+        assertEquals("weekly", client.billingCycle)
+        assertEquals("lightning", client.paymentMethod)
+    }
+
+    @Test
+    fun `updateClient returns false for invalid missing or deleted client`() {
+        val currencyId = ExposedTestDb.seedCurrency("USD")
+        val deletedClientId = ExposedTestDb.seedFreelanceClient(currencyId = currencyId, isDeleted = true)
+        val validRequest =
+            FreelanceClientUpsert(
+                name = "Updated",
+                currencyId = currencyId,
+                hourlyRateCents = 9000,
+                billingCycle = "weekly",
+                paymentMethod = "lightning",
+            )
+
+        assertFalse(service.updateClient("not-a-uuid", validRequest))
+        assertFalse(service.updateClient(UUID.randomUUID().toString(), validRequest))
+        assertFalse(service.updateClient(deletedClientId, validRequest))
+        assertFalse(service.updateClient(deletedClientId, validRequest.copy(name = " ")))
+    }
+
+    @Test
+    fun `deleteClient soft deletes client`() {
+        val clientId = ExposedTestDb.seedFreelanceClient()
+
+        val clientWasDeleted = service.deleteClient(clientId)
+
+        assertTrue(clientWasDeleted)
+        assertNull(service.getClientById(clientId))
+    }
+
+    @Test
+    fun `deleteClient returns false for invalid missing or already deleted client`() {
+        val deletedClientId = ExposedTestDb.seedFreelanceClient(isDeleted = true)
+
+        assertFalse(service.deleteClient("not-a-uuid"))
+        assertFalse(service.deleteClient(UUID.randomUUID().toString()))
+        assertFalse(service.deleteClient(deletedClientId))
+    }
+}

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/FreelanceRoutesTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/FreelanceRoutesTest.kt
@@ -1,0 +1,210 @@
+package pos.ambrosia.utest
+
+import io.ktor.client.request.delete
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.put
+import io.ktor.client.request.setBody
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.install
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.testing.testApplication
+import org.junit.After
+import org.junit.Before
+import pos.ambrosia.api.configureClients
+import pos.ambrosia.api.configureProjects
+import pos.ambrosia.api.handler
+import pos.ambrosia.services.PermissionsService
+import pos.ambrosia.utils.ExposedTestDb
+import pos.ambrosia.utils.installAdminAuth
+import pos.ambrosia.utils.withAuthCookies
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class FreelanceRoutesTest {
+    private lateinit var databaseFile: File
+
+    @Before
+    fun setUp() {
+        databaseFile = ExposedTestDb.connect()
+    }
+
+    @After
+    fun tearDown() {
+        ExposedTestDb.cleanup(databaseFile)
+    }
+
+    @Test
+    fun `client routes create list get update and soft delete clients`() =
+        testApplication {
+            val authCookies = installAdminAuth()
+            grantFreelancePermissions("admin-test-role", clientPermissions)
+            val currencyId = ExposedTestDb.seedCurrency("USD")
+            val clientId = ExposedTestDb.seedFreelanceClient(currencyId = currencyId)
+            application {
+                install(ContentNegotiation) { json() }
+                handler()
+                configureClients()
+            }
+
+            val createClientResponse =
+                client.post("/clients") {
+                    withAuthCookies(authCookies)
+                    header(HttpHeaders.ContentType, "application/json")
+                    setBody(
+                        """{
+                            "name":"Acme",
+                            "currencyId":"$currencyId",
+                            "hourlyRateCents":7500,
+                            "billingCycle":"monthly",
+                            "paymentMethod":"bank"
+                        }""",
+                    )
+                }
+            val listClientsResponse = client.get("/clients") { withAuthCookies(authCookies) }
+            val getClientResponse = client.get("/clients/$clientId") { withAuthCookies(authCookies) }
+            val updateClientResponse =
+                client.put("/clients/$clientId") {
+                    withAuthCookies(authCookies)
+                    header(HttpHeaders.ContentType, "application/json")
+                    setBody(
+                        """{
+                            "name":"Updated",
+                            "currencyId":"$currencyId",
+                            "hourlyRateCents":9000,
+                            "billingCycle":"weekly",
+                            "paymentMethod":"lightning"
+                        }""",
+                    )
+                }
+            val deleteClientResponse = client.delete("/clients/$clientId") { withAuthCookies(authCookies) }
+            val getDeletedClientResponse = client.get("/clients/$clientId") { withAuthCookies(authCookies) }
+
+            assertEquals(HttpStatusCode.Created, createClientResponse.status)
+            assertEquals(HttpStatusCode.OK, listClientsResponse.status)
+            assertEquals(HttpStatusCode.OK, getClientResponse.status)
+            assertEquals(HttpStatusCode.OK, updateClientResponse.status)
+            assertEquals(HttpStatusCode.NoContent, deleteClientResponse.status)
+            assertEquals(HttpStatusCode.NotFound, getDeletedClientResponse.status)
+        }
+
+    @Test
+    fun `client project routes create and list projects under a client`() =
+        testApplication {
+            val authCookies = installAdminAuth()
+            grantFreelancePermissions("admin-test-role", clientPermissions + projectPermissions)
+            val clientId = ExposedTestDb.seedFreelanceClient()
+            application {
+                install(ContentNegotiation) { json() }
+                handler()
+                configureClients()
+            }
+
+            val createProjectResponse =
+                client.post("/clients/$clientId/projects") {
+                    withAuthCookies(authCookies)
+                    header(HttpHeaders.ContentType, "application/json")
+                    setBody(
+                        """{
+                            "name":"Website",
+                            "status":"in_progress",
+                            "hourlyRateCents":8000,
+                            "isBillable":true
+                        }""",
+                    )
+                }
+            val listProjectsResponse = client.get("/clients/$clientId/projects") { withAuthCookies(authCookies) }
+            val missingClientProjectsResponse =
+                client.get("/clients/00000000-0000-0000-0000-000000000000/projects") {
+                    withAuthCookies(authCookies)
+                }
+
+            assertEquals(HttpStatusCode.Created, createProjectResponse.status)
+            assertEquals(HttpStatusCode.OK, listProjectsResponse.status)
+            assertEquals(HttpStatusCode.NotFound, missingClientProjectsResponse.status)
+        }
+
+    @Test
+    fun `project routes get update and soft delete projects`() =
+        testApplication {
+            val authCookies = installAdminAuth()
+            grantFreelancePermissions("admin-test-role", projectPermissions)
+            val projectId = ExposedTestDb.seedFreelanceProject()
+            application {
+                install(ContentNegotiation) { json() }
+                handler()
+                configureProjects()
+            }
+
+            val getProjectResponse = client.get("/projects/$projectId") { withAuthCookies(authCookies) }
+            val updateProjectResponse =
+                client.put("/projects/$projectId") {
+                    withAuthCookies(authCookies)
+                    header(HttpHeaders.ContentType, "application/json")
+                    setBody(
+                        """{
+                            "name":"Updated",
+                            "status":"done",
+                            "hourlyRateCents":8500,
+                            "isBillable":false
+                        }""",
+                    )
+                }
+            val deleteProjectResponse = client.delete("/projects/$projectId") { withAuthCookies(authCookies) }
+            val getDeletedProjectResponse = client.get("/projects/$projectId") { withAuthCookies(authCookies) }
+
+            assertEquals(HttpStatusCode.OK, getProjectResponse.status)
+            assertEquals(HttpStatusCode.OK, updateProjectResponse.status)
+            assertEquals(HttpStatusCode.NoContent, deleteProjectResponse.status)
+            assertEquals(HttpStatusCode.NotFound, getDeletedProjectResponse.status)
+        }
+
+    @Test
+    fun `freelance routes require matching permissions`() =
+        testApplication {
+            val authCookies = installAdminAuth()
+            application {
+                install(ContentNegotiation) { json() }
+                handler()
+                configureClients()
+                configureProjects()
+            }
+            val projectId = ExposedTestDb.seedFreelanceProject()
+
+            assertEquals(HttpStatusCode.Forbidden, client.get("/clients") { withAuthCookies(authCookies) }.status)
+            assertEquals(
+                HttpStatusCode.Forbidden,
+                client.get("/projects/$projectId") { withAuthCookies(authCookies) }.status,
+            )
+        }
+
+    private fun grantFreelancePermissions(
+        roleName: String,
+        permissions: List<String>,
+    ) {
+        val roleId = ExposedTestDb.seedRole(roleName, isAdmin = true)
+        permissions.forEach { permissionName -> ExposedTestDb.seedPermission(permissionName) }
+        PermissionsService().replaceRolePermissions(roleId, permissions)
+    }
+
+    private companion object {
+        val clientPermissions =
+            listOf(
+                "clients_read",
+                "clients_create",
+                "clients_update",
+                "clients_delete",
+            )
+        val projectPermissions =
+            listOf(
+                "projects_read",
+                "projects_create",
+                "projects_update",
+                "projects_delete",
+            )
+    }
+}

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/ProjectServiceTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/ProjectServiceTest.kt
@@ -15,17 +15,17 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class ProjectServiceTest {
-    private lateinit var dbFile: File
+    private lateinit var databaseFile: File
     private val service = ProjectService()
 
     @Before
     fun setUp() {
-        dbFile = ExposedTestDb.connect()
+        databaseFile = ExposedTestDb.connect()
     }
 
     @After
     fun tearDown() {
-        ExposedTestDb.cleanup(dbFile)
+        ExposedTestDb.cleanup(databaseFile)
     }
 
     @Test

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/ProjectServiceTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/ProjectServiceTest.kt
@@ -1,0 +1,175 @@
+package pos.ambrosia.utest
+
+import org.junit.After
+import org.junit.Before
+import pos.ambrosia.models.FreelanceProjectUpsert
+import pos.ambrosia.services.ProjectService
+import pos.ambrosia.utils.ExposedTestDb
+import java.io.File
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class ProjectServiceTest {
+    private lateinit var dbFile: File
+    private val service = ProjectService()
+
+    @Before
+    fun setUp() {
+        dbFile = ExposedTestDb.connect()
+    }
+
+    @After
+    fun tearDown() {
+        ExposedTestDb.cleanup(dbFile)
+    }
+
+    @Test
+    fun `addProject returns id for valid request`() {
+        val clientId = ExposedTestDb.seedFreelanceClient()
+
+        val projectId =
+            service.addProject(
+                clientId,
+                FreelanceProjectUpsert(
+                    name = "Website",
+                    status = "in_progress",
+                    hourlyRateCents = 8000,
+                    isBillable = true,
+                ),
+            )
+
+        assertNotNull(projectId)
+        val project = service.getProjectById(projectId)
+        assertNotNull(project)
+        assertEquals(clientId, project.clientId)
+        assertEquals("Website", project.name)
+        assertEquals(8000, project.hourlyRateCents)
+    }
+
+    @Test
+    fun `addProject preserves null hourly rate for client inheritance`() {
+        val clientId = ExposedTestDb.seedFreelanceClient(hourlyRateCents = 9000)
+
+        val projectId =
+            service.addProject(
+                clientId,
+                FreelanceProjectUpsert(
+                    name = "Inherited Rate",
+                    hourlyRateCents = null,
+                ),
+            )
+
+        assertNotNull(projectId)
+        assertNull(service.getProjectById(projectId)?.hourlyRateCents)
+    }
+
+    @Test
+    fun `addProject rejects invalid request values`() {
+        val clientId = ExposedTestDb.seedFreelanceClient()
+        val deletedClientId = ExposedTestDb.seedFreelanceClient(isDeleted = true)
+        val validRequest = FreelanceProjectUpsert(name = "Website")
+
+        assertNull(service.addProject("not-a-uuid", validRequest))
+        assertNull(service.addProject(UUID.randomUUID().toString(), validRequest))
+        assertNull(service.addProject(deletedClientId, validRequest))
+        assertNull(service.addProject(clientId, validRequest.copy(name = "  ")))
+        assertNull(service.addProject(clientId, validRequest.copy(status = "unknown")))
+        assertNull(service.addProject(clientId, validRequest.copy(hourlyRateCents = -1)))
+    }
+
+    @Test
+    fun `getProjectsByClientId returns active projects for active client`() {
+        val clientId = ExposedTestDb.seedFreelanceClient()
+        ExposedTestDb.seedFreelanceProject(clientId = clientId, name = "Active")
+        ExposedTestDb.seedFreelanceProject(clientId = clientId, name = "Deleted", isDeleted = true)
+
+        val projects = service.getProjectsByClientId(clientId)
+
+        assertNotNull(projects)
+        assertEquals(1, projects.size)
+        assertEquals("Active", projects[0].name)
+    }
+
+    @Test
+    fun `getProjectsByClientId returns null for invalid missing or deleted client`() {
+        val deletedClientId = ExposedTestDb.seedFreelanceClient(isDeleted = true)
+
+        assertNull(service.getProjectsByClientId("not-a-uuid"))
+        assertNull(service.getProjectsByClientId(UUID.randomUUID().toString()))
+        assertNull(service.getProjectsByClientId(deletedClientId))
+    }
+
+    @Test
+    fun `getProjectById returns null for invalid missing deleted or deleted parent client`() {
+        val deletedProjectId = ExposedTestDb.seedFreelanceProject(isDeleted = true)
+        val deletedClientId = ExposedTestDb.seedFreelanceClient(isDeleted = true)
+        val orphanedProjectId = ExposedTestDb.seedFreelanceProject(clientId = deletedClientId)
+
+        assertNull(service.getProjectById("not-a-uuid"))
+        assertNull(service.getProjectById(UUID.randomUUID().toString()))
+        assertNull(service.getProjectById(deletedProjectId))
+        assertNull(service.getProjectById(orphanedProjectId))
+    }
+
+    @Test
+    fun `updateProject updates active project`() {
+        val projectId = ExposedTestDb.seedFreelanceProject()
+
+        val projectWasUpdated =
+            service.updateProject(
+                projectId,
+                FreelanceProjectUpsert(
+                    name = "Updated",
+                    status = "done",
+                    hourlyRateCents = 8500,
+                    isBillable = false,
+                ),
+            )
+
+        assertTrue(projectWasUpdated)
+        val project = service.getProjectById(projectId)
+        assertNotNull(project)
+        assertEquals("Updated", project.name)
+        assertEquals("done", project.status)
+        assertEquals(8500, project.hourlyRateCents)
+        assertFalse(project.isBillable)
+    }
+
+    @Test
+    fun `updateProject returns false for invalid missing deleted or deleted parent project`() {
+        val deletedProjectId = ExposedTestDb.seedFreelanceProject(isDeleted = true)
+        val deletedClientId = ExposedTestDb.seedFreelanceClient(isDeleted = true)
+        val orphanedProjectId = ExposedTestDb.seedFreelanceProject(clientId = deletedClientId)
+        val validRequest = FreelanceProjectUpsert(name = "Updated")
+
+        assertFalse(service.updateProject("not-a-uuid", validRequest))
+        assertFalse(service.updateProject(UUID.randomUUID().toString(), validRequest))
+        assertFalse(service.updateProject(deletedProjectId, validRequest))
+        assertFalse(service.updateProject(orphanedProjectId, validRequest))
+        assertFalse(service.updateProject(orphanedProjectId, validRequest.copy(status = "unknown")))
+    }
+
+    @Test
+    fun `deleteProject soft deletes project`() {
+        val projectId = ExposedTestDb.seedFreelanceProject()
+
+        val projectWasDeleted = service.deleteProject(projectId)
+
+        assertTrue(projectWasDeleted)
+        assertNull(service.getProjectById(projectId))
+    }
+
+    @Test
+    fun `deleteProject returns false for invalid missing or already deleted project`() {
+        val deletedProjectId = ExposedTestDb.seedFreelanceProject(isDeleted = true)
+
+        assertFalse(service.deleteProject("not-a-uuid"))
+        assertFalse(service.deleteProject(UUID.randomUUID().toString()))
+        assertFalse(service.deleteProject(deletedProjectId))
+    }
+}

--- a/server/app/src/test/kotlin/pos/ambrosia/utils/ExposedTestDb.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utils/ExposedTestDb.kt
@@ -35,12 +35,12 @@ import pos.ambrosia.db.tables.OrderEntity
 import pos.ambrosia.db.tables.OrderProductsTable
 import pos.ambrosia.db.tables.OrdersDishesTable
 import pos.ambrosia.db.tables.OrdersTable
-import pos.ambrosia.db.tables.PayoutAccountEntity
-import pos.ambrosia.db.tables.PayoutAccountsTable
 import pos.ambrosia.db.tables.PaymentEntity
 import pos.ambrosia.db.tables.PaymentMethodEntity
 import pos.ambrosia.db.tables.PaymentMethodsTable
 import pos.ambrosia.db.tables.PaymentsTable
+import pos.ambrosia.db.tables.PayoutAccountEntity
+import pos.ambrosia.db.tables.PayoutAccountsTable
 import pos.ambrosia.db.tables.PermissionEntity
 import pos.ambrosia.db.tables.PermissionsTable
 import pos.ambrosia.db.tables.PrinterConfigEntity
@@ -68,7 +68,6 @@ import pos.ambrosia.db.tables.SpacesTable
 import pos.ambrosia.db.tables.SupplierEntity
 import pos.ambrosia.db.tables.SuppliersTable
 import pos.ambrosia.db.tables.TasksTable
-import pos.ambrosia.db.tables.TimeEntriesTable
 import pos.ambrosia.db.tables.TicketEntity
 import pos.ambrosia.db.tables.TicketPaymentsTable
 import pos.ambrosia.db.tables.TicketTemplateElementEntity
@@ -77,6 +76,7 @@ import pos.ambrosia.db.tables.TicketTemplateEntity
 import pos.ambrosia.db.tables.TicketTemplatesTable
 import pos.ambrosia.db.tables.TicketsDishTable
 import pos.ambrosia.db.tables.TicketsTable
+import pos.ambrosia.db.tables.TimeEntriesTable
 import pos.ambrosia.db.tables.UserEntity
 import pos.ambrosia.db.tables.UsersTable
 import pos.ambrosia.db.tables.VariantOptionValuesTable

--- a/server/app/src/test/kotlin/pos/ambrosia/utils/ExposedTestDb.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utils/ExposedTestDb.kt
@@ -13,6 +13,8 @@ import pos.ambrosia.db.tables.AdminNotificationsTable
 import pos.ambrosia.db.tables.BaseCurrencyTable
 import pos.ambrosia.db.tables.CategoriesTable
 import pos.ambrosia.db.tables.CategoryEntity
+import pos.ambrosia.db.tables.ClientEntity
+import pos.ambrosia.db.tables.ClientsTable
 import pos.ambrosia.db.tables.ConfigEntity
 import pos.ambrosia.db.tables.ConfigTable
 import pos.ambrosia.db.tables.CurrencyEntity
@@ -25,11 +27,16 @@ import pos.ambrosia.db.tables.DishesTable
 import pos.ambrosia.db.tables.IngredientEntity
 import pos.ambrosia.db.tables.IngredientSuppliersTable
 import pos.ambrosia.db.tables.IngredientsTable
+import pos.ambrosia.db.tables.InvoiceLineItemsTable
+import pos.ambrosia.db.tables.InvoicePaymentsTable
+import pos.ambrosia.db.tables.InvoicesTable
 import pos.ambrosia.db.tables.OrderDishEntity
 import pos.ambrosia.db.tables.OrderEntity
 import pos.ambrosia.db.tables.OrderProductsTable
 import pos.ambrosia.db.tables.OrdersDishesTable
 import pos.ambrosia.db.tables.OrdersTable
+import pos.ambrosia.db.tables.PayoutAccountEntity
+import pos.ambrosia.db.tables.PayoutAccountsTable
 import pos.ambrosia.db.tables.PaymentEntity
 import pos.ambrosia.db.tables.PaymentMethodEntity
 import pos.ambrosia.db.tables.PaymentMethodsTable
@@ -46,6 +53,8 @@ import pos.ambrosia.db.tables.ProductOptionValuesTable
 import pos.ambrosia.db.tables.ProductVariantEntity
 import pos.ambrosia.db.tables.ProductVariantsTable
 import pos.ambrosia.db.tables.ProductsTable
+import pos.ambrosia.db.tables.ProjectEntity
+import pos.ambrosia.db.tables.ProjectsTable
 import pos.ambrosia.db.tables.PushSubscriptionsTable
 import pos.ambrosia.db.tables.RefundEntity
 import pos.ambrosia.db.tables.RefundsTable
@@ -58,6 +67,8 @@ import pos.ambrosia.db.tables.SpaceEntity
 import pos.ambrosia.db.tables.SpacesTable
 import pos.ambrosia.db.tables.SupplierEntity
 import pos.ambrosia.db.tables.SuppliersTable
+import pos.ambrosia.db.tables.TasksTable
+import pos.ambrosia.db.tables.TimeEntriesTable
 import pos.ambrosia.db.tables.TicketEntity
 import pos.ambrosia.db.tables.TicketPaymentsTable
 import pos.ambrosia.db.tables.TicketTemplateElementEntity
@@ -120,6 +131,14 @@ object ExposedTestDb {
                 AdminNotificationReceiptsTable,
                 AdminNotificationPreferencesTable,
                 PushSubscriptionsTable,
+                PayoutAccountsTable,
+                ClientsTable,
+                ProjectsTable,
+                TasksTable,
+                InvoicesTable,
+                TimeEntriesTable,
+                InvoiceLineItemsTable,
+                InvoicePaymentsTable,
             )
         }
         return file
@@ -128,6 +147,14 @@ object ExposedTestDb {
     fun cleanup(file: File) {
         transaction {
             SchemaUtils.drop(
+                InvoicePaymentsTable,
+                InvoiceLineItemsTable,
+                TimeEntriesTable,
+                InvoicesTable,
+                TasksTable,
+                ProjectsTable,
+                ClientsTable,
+                PayoutAccountsTable,
                 RefundsTable,
                 OrderProductsTable,
                 TicketTemplateElementsTable,
@@ -460,6 +487,68 @@ object ExposedTestDb {
                     this.exchangeRateAtPayment = exchangeRateAtPayment
                     this.exchangeRateCurrency = exchangeRateCurrency
                     this.fiatAmountAtPayment = fiatAmountAtPayment
+                }.id.value
+                .toString()
+        }
+
+    fun seedPayoutAccount(
+        type: String = "bank",
+        currencyId: String? = seedCurrency("USD"),
+        isDeleted: Boolean = false,
+    ): String =
+        transaction {
+            PayoutAccountEntity
+                .new(UUID.randomUUID()) {
+                    this.type = type
+                    this.currencyId = currencyId?.let { EntityID(UUID.fromString(it), CurrencyTable) }
+                    this.isDeleted = isDeleted
+                    this.createdAt = "2024-01-01T00:00:00"
+                }.id.value
+                .toString()
+        }
+
+    fun seedFreelanceClient(
+        name: String = "Client",
+        currencyId: String = seedCurrency("USD"),
+        hourlyRateCents: Int = 5000,
+        billingCycle: String = "monthly",
+        paymentMethod: String = "bank",
+        payoutAccountId: String? = null,
+        isDeleted: Boolean = false,
+    ): String =
+        transaction {
+            ClientEntity
+                .new(UUID.randomUUID()) {
+                    this.name = name
+                    this.currencyId = EntityID(UUID.fromString(currencyId), CurrencyTable)
+                    this.hourlyRateCents = hourlyRateCents
+                    this.billingCycle = billingCycle
+                    this.paymentMethod = paymentMethod
+                    this.payoutAccountId = payoutAccountId?.let { EntityID(UUID.fromString(it), PayoutAccountsTable) }
+                    this.isDeleted = isDeleted
+                    this.createdAt = "2024-01-01T00:00:00"
+                }.id.value
+                .toString()
+        }
+
+    fun seedFreelanceProject(
+        clientId: String = seedFreelanceClient(),
+        name: String = "Project",
+        status: String = "pending",
+        hourlyRateCents: Int? = null,
+        isBillable: Boolean = true,
+        isDeleted: Boolean = false,
+    ): String =
+        transaction {
+            ProjectEntity
+                .new(UUID.randomUUID()) {
+                    this.clientId = EntityID(UUID.fromString(clientId), ClientsTable)
+                    this.name = name
+                    this.status = status
+                    this.hourlyRateCents = hourlyRateCents
+                    this.isBillable = isBillable
+                    this.isDeleted = isDeleted
+                    this.createdAt = "2024-01-01T00:00:00"
                 }.id.value
                 .toString()
         }


### PR DESCRIPTION
  ## Summary

  Implements the freelance Clients and Projects backend foundation for issue #652, built on top of the freelance schema from #651.

  ## Changes

  - Adds API DTOs for freelance clients and projects.
  - Adds `ClientService` for listing, creating, updating, reading, and soft-deleting clients.
  - Adds `ProjectService` for listing projects by client, creating projects under clients, updating, reading, and soft-deleting projects.
  - Registers new API modules with `configureClients()` and `configureProjects()`.
  - Adds client routes:
    - `GET /clients`
    - `POST /clients`
    - `GET /clients/{id}`
    - `PUT /clients/{id}`
    - `DELETE /clients/{id}`
    - `GET /clients/{id}/projects`
    - `POST /clients/{id}/projects`
  - Adds project routes:
    - `GET /projects/{id}`
    - `PUT /projects/{id}`
    - `DELETE /projects/{id}`
  - Uses the freelance permissions added by #651.
  - Keeps delete behavior as soft delete only.

  ## Notes

  - Project `hourlyRateCents = null` is preserved as “inherit from client.”
  - The actual rate fallback resolution is intentionally left for the Time Entries workflow so the logic is implemented in one place.

  ## Testing

  - Added focused service tests for clients and projects.
  - Added route tests for client/project endpoints and permission guards.
  - Verified focused suites locally with:
    - `./gradlew :app:test --tests pos.ambrosia.utest.ClientServiceTest --tests pos.ambrosia.utest.ProjectServiceTest`
    - `./gradlew :app:test --tests pos.ambrosia.utest.FreelanceRoutesTest`