### PR TITLE
Chore/usepermission mock dedup

### DIFF
--- a/client/src/components/pages/Store/Products/Categories/__tests__/Categories.test.jsx
+++ b/client/src/components/pages/Store/Products/Categories/__tests__/Categories.test.jsx
@@ -9,10 +9,7 @@ jest.mock("@heroui/react", () => {
   return { ...actual, addToast: jest.fn() };
 });
 
-jest.mock("@/hooks/usePermission", () => ({
-  RequirePermission: ({ children }) => <>{children}</>,
-  usePermission: () => true,
-}));
+jest.mock("@/hooks/usePermission");
 
 jest.mock("@/components/shared/EditButton", () => ({
   EditButton: ({ onPress, children }) => <button onClick={onPress}>{children}</button>,

--- a/client/src/components/pages/Store/Products/Categories/__tests__/CategoriesCard.test.jsx
+++ b/client/src/components/pages/Store/Products/Categories/__tests__/CategoriesCard.test.jsx
@@ -7,9 +7,7 @@ jest.mock("@heroui/react", () => ({
   CardBody: ({ children, className }) => <div className={className}>{children}</div>,
 }));
 
-jest.mock("@/hooks/usePermission", () => ({
-  RequirePermission: ({ children }) => children,
-}));
+jest.mock("@/hooks/usePermission");
 
 jest.mock("@/components/shared/EditButton", () => ({
   EditButton: ({ onPress }) => <button data-testid="edit-button" onClick={onPress} />,

--- a/client/src/components/pages/Store/Products/Categories/__tests__/CategoriesTable.test.jsx
+++ b/client/src/components/pages/Store/Products/Categories/__tests__/CategoriesTable.test.jsx
@@ -15,9 +15,7 @@ jest.mock("@heroui/react", () => ({
   TableCell: ({ children, className }) => <td className={className}>{children}</td>,
 }));
 
-jest.mock("@/hooks/usePermission", () => ({
-  RequirePermission: ({ children }) => children,
-}));
+jest.mock("@/hooks/usePermission");
 
 jest.mock("@/components/shared/EditButton", () => ({
   EditButton: ({ onPress, children }) => <button onClick={onPress}>{children}</button>,

--- a/client/src/components/pages/Store/Products/ProductsList/__tests__/ProductsCard.test.jsx
+++ b/client/src/components/pages/Store/Products/ProductsList/__tests__/ProductsCard.test.jsx
@@ -33,9 +33,7 @@ jest.mock("@/components/hooks/useCurrency", () => ({
   useCurrency: () => ({ formatAmount: (cents) => `$${cents}` }),
 }));
 
-jest.mock("@/hooks/usePermission", () => ({
-  RequirePermission: ({ children }) => children,
-}));
+jest.mock("@/hooks/usePermission");
 
 const mockStoredAssetUrl = jest.fn((url) => (url ? `cdn${url}` : null));
 jest.mock("@/components/utils/storedAssetUrl", () => ({

--- a/client/src/components/pages/Store/Products/ProductsList/__tests__/ProductsList.test.jsx
+++ b/client/src/components/pages/Store/Products/ProductsList/__tests__/ProductsList.test.jsx
@@ -10,10 +10,7 @@ jest.mock("@/components/hooks/useCurrency", () => ({
   useCurrency: () => ({ formatAmount: (cents) => `$${cents}` }),
 }));
 
-jest.mock("@/hooks/usePermission", () => ({
-  usePermission: () => true,
-  RequirePermission: ({ children }) => children,
-}));
+jest.mock("@/hooks/usePermission");
 
 jest.mock("@/components/shared/EditButton", () => ({
   EditButton: ({ onPress, children }) => <button onClick={onPress}>{children}</button>,

--- a/client/src/components/pages/Store/Products/ProductsList/__tests__/ProductsTable.test.jsx
+++ b/client/src/components/pages/Store/Products/ProductsList/__tests__/ProductsTable.test.jsx
@@ -33,9 +33,7 @@ jest.mock("@/components/shared/VariantsButton", () => ({
   VariantsButton: ({ onPress, children }) => <button data-testid="variants-button" onClick={onPress}>{children}</button>,
 }));
 
-jest.mock("@/hooks/usePermission", () => ({
-  RequirePermission: ({ children }) => children,
-}));
+jest.mock("@/hooks/usePermission");
 
 const mockStoredAssetUrl = jest.fn((url) => (url ? `cdn${url}` : null));
 jest.mock("@/components/utils/storedAssetUrl", () => ({

--- a/client/src/components/pages/Store/Products/__tests__/Products.test.jsx
+++ b/client/src/components/pages/Store/Products/__tests__/Products.test.jsx
@@ -22,10 +22,7 @@ jest.mock("@/components/utils/storedAssetUrl", () => ({
   storedAssetUrl: (url) => url,
 }));
 
-jest.mock("@/hooks/usePermission", () => ({
-  usePermission: () => true,
-  RequirePermission: ({ children }) => children,
-}));
+jest.mock("@/hooks/usePermission");
 
 jest.mock("../AddProductsModal", () => ({
   AddProductsModal: ({ addProductsShowModal, productForm, onChange, onProductCreated, addProduct, onClose }) => (

--- a/client/src/components/pages/Store/Settings/NwcConnection/__tests__/NwcConnectionCard.test.jsx
+++ b/client/src/components/pages/Store/Settings/NwcConnection/__tests__/NwcConnectionCard.test.jsx
@@ -2,9 +2,7 @@ import { render, screen, fireEvent } from "@testing-library/react";
 
 import { NwcConnectionCard } from "../NwcConnectionCard";
 
-jest.mock("@/hooks/usePermission", () => ({
-  RequirePermission: ({ children }) => children,
-}));
+jest.mock("@/hooks/usePermission");
 
 jest.mock("@heroui/react", () => ({
   addToast: jest.fn(),

--- a/client/src/components/pages/Store/Settings/NwcConnection/__tests__/NwcConnectionCardUnlocked.test.jsx
+++ b/client/src/components/pages/Store/Settings/NwcConnection/__tests__/NwcConnectionCardUnlocked.test.jsx
@@ -4,9 +4,7 @@ import * as walletService from "@/services/walletService";
 
 import { NwcConnectionCardUnlocked } from "../NwcConnectionCardUnlocked";
 
-jest.mock("@/hooks/usePermission", () => ({
-  RequirePermission: ({ children }) => children,
-}));
+jest.mock("@/hooks/usePermission");
 
 jest.mock("@heroui/react", () => ({
   addToast: jest.fn(),

--- a/client/src/components/pages/Store/Settings/Printers/__tests__/PrinterConfigRow.test.jsx
+++ b/client/src/components/pages/Store/Settings/Printers/__tests__/PrinterConfigRow.test.jsx
@@ -6,9 +6,7 @@ jest.mock("next-intl", () => ({
   useTranslations: () => (key) => key,
 }));
 
-jest.mock("@/hooks/usePermission", () => ({
-  RequirePermission: ({ children }) => children,
-}));
+jest.mock("@/hooks/usePermission");
 
 jest.mock("@components/shared/DeleteButton", () => ({
   DeleteButton: ({ onPress }) => (

--- a/client/src/components/pages/Store/Settings/Printers/__tests__/PrintersCard.test.jsx
+++ b/client/src/components/pages/Store/Settings/Printers/__tests__/PrintersCard.test.jsx
@@ -6,9 +6,7 @@ jest.mock("next-intl", () => ({
   useTranslations: () => (key) => key,
 }));
 
-jest.mock("@/hooks/usePermission", () => ({
-  RequirePermission: ({ children }) => children,
-}));
+jest.mock("@/hooks/usePermission");
 
 jest.mock("@heroui/react", () => ({
   Button: ({ onPress, children, ...props }) => (

--- a/client/src/components/pages/Store/Settings/StoreInfo/__tests__/StoreInfo.test.jsx
+++ b/client/src/components/pages/Store/Settings/StoreInfo/__tests__/StoreInfo.test.jsx
@@ -7,9 +7,7 @@ import * as configurationsProvider from "@providers/configurations/configuration
 
 import { StoreInfo } from "../StoreInfo";
 
-jest.mock("@/hooks/usePermission", () => ({
-  RequirePermission: ({ children }) => children,
-}));
+jest.mock("@/hooks/usePermission");
 
 const mockUpdateConfig = jest.fn();
 const mockUpload = jest.fn();

--- a/client/src/components/pages/Store/Settings/StoreInfo/__tests__/StoreInfoCard.test.jsx
+++ b/client/src/components/pages/Store/Settings/StoreInfo/__tests__/StoreInfoCard.test.jsx
@@ -5,9 +5,7 @@ import { I18nProvider } from "@i18n/I18nProvider";
 
 import { StoreInfoCard } from "../StoreInfoCard";
 
-jest.mock("@/hooks/usePermission", () => ({
-  RequirePermission: ({ children }) => children,
-}));
+jest.mock("@/hooks/usePermission");
 
 const mockData = {
   businessName: "Mi Tienda Test",

--- a/client/src/components/pages/Store/Settings/TicketTemplates/__tests__/List.test.jsx
+++ b/client/src/components/pages/Store/Settings/TicketTemplates/__tests__/List.test.jsx
@@ -2,9 +2,7 @@ import { fireEvent, render, screen } from "@testing-library/react";
 
 import { TemplateList } from "../List";
 
-jest.mock("@/hooks/usePermission", () => ({
-  RequirePermission: ({ children }) => children,
-}));
+jest.mock("@/hooks/usePermission");
 
 jest.mock("@heroui/react", () => ({
   Button: ({ onPress, children, ...props }) => (

--- a/client/src/components/pages/Store/Settings/TicketTemplates/__tests__/TicketTemplatesModal.test.jsx
+++ b/client/src/components/pages/Store/Settings/TicketTemplates/__tests__/TicketTemplatesModal.test.jsx
@@ -6,9 +6,7 @@ import { useTemplates } from "@components/pages/Store/hooks/useTemplates";
 
 import { TicketTemplatesModal } from "../Modal";
 
-jest.mock("@/hooks/usePermission", () => ({
-  RequirePermission: ({ children }) => children,
-}));
+jest.mock("@/hooks/usePermission");
 
 jest.mock("@heroui/react", () => ({
   addToast: jest.fn(),

--- a/client/src/components/pages/Store/Users/Roles/RolesList/__tests__/RolesCard.test.jsx
+++ b/client/src/components/pages/Store/Users/Roles/RolesList/__tests__/RolesCard.test.jsx
@@ -6,9 +6,7 @@ jest.mock("next-intl", () => ({
   useTranslations: () => (key) => key,
 }));
 
-jest.mock("@/hooks/usePermission", () => ({
-  RequirePermission: ({ children }) => <>{children}</>,
-}));
+jest.mock("@/hooks/usePermission");
 
 jest.mock("@/components/shared/EditButton", () => ({
   EditButton: ({ onPress, "aria-label": ariaLabel }) => (

--- a/client/src/components/pages/Store/Users/Roles/RolesList/__tests__/RolesTable.test.jsx
+++ b/client/src/components/pages/Store/Users/Roles/RolesList/__tests__/RolesTable.test.jsx
@@ -4,9 +4,7 @@ import { I18nProvider } from "@/i18n/I18nProvider";
 
 import { RolesTable } from "../RolesTable";
 
-jest.mock("@/hooks/usePermission", () => ({
-  RequirePermission: ({ children }) => <>{children}</>,
-}));
+jest.mock("@/hooks/usePermission");
 
 jest.mock("@/components/shared/EditButton", () => ({
   EditButton: ({ onPress, children }) => (

--- a/client/src/components/pages/Store/Users/Roles/__tests__/Roles.test.jsx
+++ b/client/src/components/pages/Store/Users/Roles/__tests__/Roles.test.jsx
@@ -14,9 +14,7 @@ jest.mock("next-intl", () => {
   return { useTranslations: () => roleTranslations };
 });
 
-jest.mock("@/hooks/usePermission", () => ({
-  RequirePermission: ({ children }) => children,
-}));
+jest.mock("@/hooks/usePermission");
 
 jest.mock("@/hooks/useNavigation", () => ({
   useNavigation: () => ({ isAdmin: mockIsAdmin }),

--- a/client/src/components/pages/Store/Users/UsersList/__tests__/UsersCard.test.jsx
+++ b/client/src/components/pages/Store/Users/UsersList/__tests__/UsersCard.test.jsx
@@ -6,9 +6,7 @@ jest.mock("next-intl", () => ({
   useTranslations: () => (key) => key,
 }));
 
-jest.mock("@/hooks/usePermission", () => ({
-  RequirePermission: ({ children }) => <>{children}</>,
-}));
+jest.mock("@/hooks/usePermission");
 
 jest.mock("@/components/shared/EditButton", () => ({
   EditButton: ({ onPress }) => <button aria-label="Edit User" onClick={onPress}>edit</button>,

--- a/client/src/components/pages/Store/Users/UsersList/__tests__/UsersTable.test.jsx
+++ b/client/src/components/pages/Store/Users/UsersList/__tests__/UsersTable.test.jsx
@@ -6,10 +6,7 @@ jest.mock("next-intl", () => ({
   useTranslations: () => (key) => key,
 }));
 
-jest.mock("@/hooks/usePermission", () => ({
-  usePermission: () => true,
-  RequirePermission: ({ children }) => children,
-}));
+jest.mock("@/hooks/usePermission");
 
 jest.mock("@/components/shared/EditButton", () => ({
   EditButton: ({ onPress }) => <button aria-label="Edit User" onClick={onPress}>edit</button>,

--- a/client/src/components/pages/Store/Users/__tests__/Users.test.jsx
+++ b/client/src/components/pages/Store/Users/__tests__/Users.test.jsx
@@ -38,10 +38,7 @@ jest.mock("../UsersList", () => ({
   ),
 }));
 
-jest.mock("@/hooks/usePermission", () => ({
-  usePermission: () => true,
-  RequirePermission: ({ children }) => children,
-}));
+jest.mock("@/hooks/usePermission");
 
 jest.mock("../AddUsersModal", () => ({
   AddUsersModal: ({ addUsersShowModal, data, onChange, addUser }) => (

--- a/client/src/hooks/__mocks__/usePermission.jsx
+++ b/client/src/hooks/__mocks__/usePermission.jsx
@@ -1,0 +1,2 @@
+export const usePermission = () => true;
+export const RequirePermission = ({ children }) => children;


### PR DESCRIPTION
## Changes:

- Deduplicated the `@/hooks/usePermission` test mock: added a colocated `src/hooks/__mocks__/usePermission.jsx` and switched 21 test files from a duplicated inline factory to `jest.mock("@/hooks/usePermission")`; the 3 files that test real permission allow/deny behavior (`Settings.test.jsx`, `StoreWallet.test.jsx`, `Cart.test.jsx`) are untouched