### PR TITLE
feat(client): add Qr to open in another device on store settings

### DIFF
--- a/client/src/components/pages/Store/Settings/QRUrl/QRUrl.jsx
+++ b/client/src/components/pages/Store/Settings/QRUrl/QRUrl.jsx
@@ -1,0 +1,5 @@
+import { QRUrlCard } from "./QRUrlCard";
+
+export function QRUrl() {
+  return <QRUrlCard />;
+}

--- a/client/src/components/pages/Store/Settings/QRUrl/QRUrlCard.jsx
+++ b/client/src/components/pages/Store/Settings/QRUrl/QRUrlCard.jsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { Card, CardBody, CardHeader } from "@heroui/react";
+import { useTranslations } from "next-intl";
+import QRCode from "react-qr-code";
+
+export function QRUrlCard() {
+  const [urlBase, setUrlBase] = useState("");
+  const settingsTranslations = useTranslations("settings");
+
+  useEffect(() => {
+    const animationFrame = window.requestAnimationFrame(() => {
+      setUrlBase(window.location.origin);
+    });
+
+    return () => window.cancelAnimationFrame(animationFrame);
+  }, []);
+
+  if (!urlBase) return null;
+
+  return (
+    <Card shadow="none" className="rounded-lg p-6 shadow-lg">
+      <CardHeader className="flex items-start gap-3 pb-2">
+        <div className="flex flex-col">
+          <h2 className="text-lg font-semibold text-green-900 sm:text-xl xl:text-2xl">
+            {settingsTranslations("cardQRUrl.title")}
+          </h2>
+          <p className="mt-1 text-sm text-gray-500">
+            {settingsTranslations("cardQRUrl.subtitle")}
+          </p>
+        </div>
+      </CardHeader>
+
+      <CardBody className="items-center gap-4 pt-4">
+        <div className="w-full max-w-64 rounded-xl border border-gray-200 bg-white p-4 sm:max-w-72">
+          <QRCode
+            aria-label={settingsTranslations("cardQRUrl.qrLabel")}
+            bgColor="#FFFFFF"
+            fgColor="#14532D"
+            level="M"
+            size={256}
+            style={{ height: "auto", maxWidth: "100%", width: "100%" }}
+            value={urlBase}
+          />
+        </div>
+        <p className="text-center text-xs text-gray-500">
+          {settingsTranslations("cardQRUrl.helper")}
+        </p>
+      </CardBody>
+    </Card>
+  );
+}

--- a/client/src/components/pages/Store/Settings/QRUrl/__tests__/QRUrlCard.test.jsx
+++ b/client/src/components/pages/Store/Settings/QRUrl/__tests__/QRUrlCard.test.jsx
@@ -1,0 +1,24 @@
+import { render, screen } from "@testing-library/react";
+
+import { QRUrlCard } from "../QRUrlCard";
+
+jest.mock("next-intl", () => ({
+  useTranslations: () => (key) => key,
+}));
+
+jest.mock("react-qr-code", () => ({
+  __esModule: true,
+  default: ({ "aria-label": ariaLabel, value }) => (
+    <svg aria-label={ariaLabel} data-testid="qr-code" data-value={value} />
+  ),
+}));
+
+describe("QRUrlCard", () => {
+  it("renders a QR code for the current origin", async () => {
+    render(<QRUrlCard />);
+
+    const qrCode = await screen.findByTestId("qr-code");
+    expect(qrCode).toHaveAttribute("data-value", window.location.origin);
+    expect(qrCode).toHaveAttribute("aria-label", "cardQRUrl.qrLabel");
+  });
+});

--- a/client/src/components/pages/Store/Settings/QRUrl/index.js
+++ b/client/src/components/pages/Store/Settings/QRUrl/index.js
@@ -1,0 +1,2 @@
+export * from "./QRUrl";
+

--- a/client/src/components/pages/Store/Settings/QRUrl/index.js
+++ b/client/src/components/pages/Store/Settings/QRUrl/index.js
@@ -1,2 +1,1 @@
 export * from "./QRUrl";
-

--- a/client/src/components/pages/Store/Settings/Settings.jsx
+++ b/client/src/components/pages/Store/Settings/Settings.jsx
@@ -14,6 +14,7 @@ import { LightningCard } from "./Lightning/LightningCard";
 import { NotificationPreferencesCard } from "./Notifications";
 import { NwcConnectionCard } from "./NwcConnection/NwcConnectionCard";
 import { Printers } from "./Printers";
+import { QRUrl } from "./QRUrl";
 import { Seed } from "./Seed";
 import { StoreInfo } from "./StoreInfo";
 import { TicketTemplates } from "./TicketTemplates";
@@ -43,6 +44,7 @@ export function Settings() {
         </div>
 
         <div className="flex flex-col gap-6">
+          <QRUrl />
           <Printers />
           <TicketTemplates />
           {isAdmin && <NotificationPreferencesCard />}

--- a/client/src/components/pages/Store/Settings/locales/en.js
+++ b/client/src/components/pages/Store/Settings/locales/en.js
@@ -18,6 +18,12 @@ const settingsEn = {
       errorTitle: "Currency update failed",
       errorDescription: "Could not update the store currency.",
     },
+    cardQRUrl: {
+      title: "Open on another device",
+      subtitle: "Scan this QR code to open Ambrosia.",
+      helper: "Use your phone or another device's camera to scan it.",
+      qrLabel: "QR code to open Ambrosia on another device",
+    },
     cardLanguage: {
       title: "Language",
     },

--- a/client/src/components/pages/Store/Settings/locales/es.js
+++ b/client/src/components/pages/Store/Settings/locales/es.js
@@ -18,6 +18,12 @@ const settingsEs = {
       errorTitle: "Error al actualizar moneda",
       errorDescription: "No se pudo actualizar la moneda de la tienda.",
     },
+    cardQRUrl: {
+      title: "Abrir en otro dispositivo",
+      subtitle: "Escanea este código QR para abrir Ambrosia.",
+      helper: "Usa la cámara de tu teléfono u otro dispositivo para escanearlo.",
+      qrLabel: "Código QR para abrir Ambrosia en otro dispositivo",
+    },
     cardLanguage: {
       title: "Idioma",
     },


### PR DESCRIPTION
## Changes
- Add QR on Settings to open Ambrosia in another device 
- Add Test for new QR files
- Match design with ambrosia settings content

## Screenshots
<img width="565" height="498" alt="image" src="https://github.com/user-attachments/assets/a1fa8e16-9bc8-4b9a-8127-7c6fe607f28f" />
