### PR TITLE
chore(server): route coverage

### DIFF
--- a/server/app/build.gradle.kts
+++ b/server/app/build.gradle.kts
@@ -107,20 +107,20 @@ ktlint {
 }
 
 // Coverage ratchet. Bounds sit just below the measured baseline
-// (62.5% line / 26.9% branch) so a regression fails `koverVerify`
+// (74.2% line / 37.4% branch) so a regression fails `koverVerify`
 // without normal churn tripping it. Raise them as coverage improves.
 kover {
     reports {
         verify {
             rule {
                 bound {
-                    minValue = 58
+                    minValue = 70
                     coverageUnits = CoverageUnit.LINE
                 }
             }
             rule {
                 bound {
-                    minValue = 23
+                    minValue = 33
                     coverageUnits = CoverageUnit.BRANCH
                 }
             }

--- a/server/app/src/main/kotlin/pos/ambrosia/api/Authorize.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/api/Authorize.kt
@@ -26,7 +26,7 @@ import pos.ambrosia.services.TokenService
 import pos.ambrosia.utils.InvalidTokenException
 import java.util.concurrent.ConcurrentHashMap
 
-private object LoginRateLimiter {
+internal object LoginRateLimiter {
     private data class IpState(
         val failureCount: Int,
         val blockUntil: Long,
@@ -90,6 +90,10 @@ private object LoginRateLimiter {
 
     fun reset(ip: String) {
         state.remove(ip)
+    }
+
+    internal fun resetAll() {
+        state.clear()
     }
 }
 

--- a/server/app/src/main/kotlin/pos/ambrosia/api/Orders.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/api/Orders.kt
@@ -16,6 +16,7 @@ import pos.ambrosia.models.AddOrderDishRequest
 import pos.ambrosia.models.CompleteOrder
 import pos.ambrosia.models.Order
 import pos.ambrosia.models.OrderDish
+import pos.ambrosia.models.OrderTotalResponse
 import pos.ambrosia.models.OrderWithDishesRequest
 import pos.ambrosia.services.OrderService
 import pos.ambrosia.utils.DatabaseException
@@ -297,7 +298,7 @@ fun Route.orders(orderService: OrderService) {
             }
             call.respond(
                 HttpStatusCode.OK,
-                mapOf("message" to "Order total updated successfully", "total" to newTotal),
+                OrderTotalResponse("Order total updated successfully", newTotal),
             )
         }
     }

--- a/server/app/src/main/kotlin/pos/ambrosia/api/Uploads.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/api/Uploads.kt
@@ -12,6 +12,7 @@ import io.ktor.server.http.content.staticFiles
 import io.ktor.server.plugins.origin
 import io.ktor.server.request.receiveMultipart
 import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
 import io.ktor.server.routing.post
 import io.ktor.server.routing.routing
 import pos.ambrosia.datadir
@@ -27,42 +28,49 @@ fun Application.configureUploads() {
 
     routing {
         staticFiles("/uploads", uploadRoot.toFile())
-        authenticate("auth-jwt", optional = true) {
-            post("/uploads") {
-                val configExists = configService.getConfig() != null
-                if (configExists && call.principal<JWTPrincipal>() == null) {
-                    call.respond(HttpStatusCode.Unauthorized, mapOf("message" to "Unauthorized"))
-                    return@post
-                }
+        uploads(uploadService, configService)
+    }
+}
 
-                val multipart = call.receiveMultipart()
-                val uploads = mutableListOf<Map<String, String>>()
-
-                multipart.forEachPart { part ->
-                    when (part) {
-                        is PartData.FileItem -> {
-                            val savedUpload = uploadService.saveFile(part.originalFileName, part.provider)
-                            val absoluteUrl = buildAbsoluteUrl(call, savedUpload.relativePath)
-                            uploads.add(
-                                mapOf(
-                                    "path" to savedUpload.relativePath,
-                                    "url" to absoluteUrl,
-                                ),
-                            )
-                        }
-
-                        else -> {}
-                    }
-                    part.release()
-                }
-
-                if (uploads.isEmpty()) {
-                    call.respond(HttpStatusCode.BadRequest, mapOf("message" to "No files uploaded"))
-                    return@post
-                }
-
-                call.respond(HttpStatusCode.Created, mapOf("uploads" to uploads))
+fun Route.uploads(
+    uploadService: UploadService,
+    configService: ConfigService,
+) {
+    authenticate("auth-jwt", optional = true) {
+        post("/uploads") {
+            val configExists = configService.getConfig() != null
+            if (configExists && call.principal<JWTPrincipal>() == null) {
+                call.respond(HttpStatusCode.Unauthorized, mapOf("message" to "Unauthorized"))
+                return@post
             }
+
+            val multipart = call.receiveMultipart()
+            val uploads = mutableListOf<Map<String, String>>()
+
+            multipart.forEachPart { part ->
+                when (part) {
+                    is PartData.FileItem -> {
+                        val savedUpload = uploadService.saveFile(part.originalFileName, part.provider)
+                        val absoluteUrl = buildAbsoluteUrl(call, savedUpload.relativePath)
+                        uploads.add(
+                            mapOf(
+                                "path" to savedUpload.relativePath,
+                                "url" to absoluteUrl,
+                            ),
+                        )
+                    }
+
+                    else -> {}
+                }
+                part.release()
+            }
+
+            if (uploads.isEmpty()) {
+                call.respond(HttpStatusCode.BadRequest, mapOf("message" to "No files uploaded"))
+                return@post
+            }
+
+            call.respond(HttpStatusCode.Created, mapOf("uploads" to uploads))
         }
     }
 }

--- a/server/app/src/main/kotlin/pos/ambrosia/models/AppModels.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/models/AppModels.kt
@@ -234,11 +234,19 @@ data class AddOrderDishRequest(
     val notes: String? = null,
 )
 
+@Serializable
 data class CompleteOrder(
     val order: Order,
     val dishes: List<OrderDish>,
 )
 
+@Serializable
+data class OrderTotalResponse(
+    val message: String,
+    val total: Double,
+)
+
+@Serializable
 data class OrderWithDishesRequest(
     val order: Order,
     val dishes: List<OrderDish>,

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/AuthUtilsTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/AuthUtilsTest.kt
@@ -1,0 +1,143 @@
+package pos.ambrosia.utest
+
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.response.respond
+import io.ktor.server.routing.get
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.ApplicationTestBuilder
+import pos.ambrosia.utils.AuthCookies
+import pos.ambrosia.utils.authenticateAdmin
+import pos.ambrosia.utils.authorizeAdminPermission
+import pos.ambrosia.utils.authorizePermission
+import pos.ambrosia.utils.getCurrentUser
+import pos.ambrosia.utils.grantPermissions
+import pos.ambrosia.utils.installAdminAuth
+import pos.ambrosia.utils.installNonAdminAuth
+import pos.ambrosia.utils.installRoutes
+import pos.ambrosia.utils.routeTest
+import pos.ambrosia.utils.withAuthCookies
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class AuthUtilsTest {
+    @Test
+    fun `authorizePermission denies a role without the named permission`() =
+        decoratorTest({ installNonAdminAuth() }) { auth ->
+            val response = client.get("/guarded") { withAuthCookies(auth) }
+
+            assertEquals(HttpStatusCode.Forbidden, response.status)
+        }
+
+    @Test
+    fun `authorizePermission allows a role holding the named permission`() =
+        decoratorTest({ installNonAdminAuth() }) { auth ->
+            grantPermissions("non-admin-test-role", "things_read")
+
+            val response = client.get("/guarded") { withAuthCookies(auth) }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+        }
+
+    @Test
+    fun `authorizePermission denies a permission that is not the one required`() =
+        decoratorTest({ installNonAdminAuth() }) { auth ->
+            grantPermissions("non-admin-test-role", "things_write")
+
+            val response = client.get("/guarded") { withAuthCookies(auth) }
+
+            assertEquals(HttpStatusCode.Forbidden, response.status)
+        }
+
+    @Test
+    fun `authorizePermission rejects a request with no access token`() =
+        decoratorTest({ installNonAdminAuth() }) {
+            val response = client.get("/guarded")
+
+            assertEquals(HttpStatusCode.Unauthorized, response.status)
+        }
+
+    @Test
+    fun `authenticateAdmin rejects a non-admin role`() =
+        decoratorTest({ installNonAdminAuth() }) { auth ->
+            val response = client.get("/admin-only") { withAuthCookies(auth) }
+
+            assertEquals(HttpStatusCode.Forbidden, response.status)
+        }
+
+    @Test
+    fun `authenticateAdmin allows an admin role`() =
+        decoratorTest({ installAdminAuth() }) { auth ->
+            val response = client.get("/admin-only") { withAuthCookies(auth) }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+        }
+
+    @Test
+    fun `authenticateAdmin depends on the refreshToken cookie`() =
+        decoratorTest({ installAdminAuth() }) { auth ->
+            val response =
+                client.get("/admin-only") {
+                    headers.append(HttpHeaders.Cookie, "accessToken=${auth.accessToken}")
+                }
+
+            assertEquals(HttpStatusCode.Forbidden, response.status)
+        }
+
+    @Test
+    fun `authorizeAdminPermission requires both the permission and the admin flag`() =
+        decoratorTest({ installNonAdminAuth() }) { auth ->
+            grantPermissions("non-admin-test-role", "things_read")
+
+            val response = client.get("/admin-guarded") { withAuthCookies(auth) }
+
+            assertEquals(HttpStatusCode.Forbidden, response.status)
+        }
+
+    @Test
+    fun `authorizeAdminPermission allows an admin holding the permission`() =
+        decoratorTest({ installAdminAuth() }) { auth ->
+            grantPermissions("admin-test-role", "things_read")
+
+            val response = client.get("/admin-guarded") { withAuthCookies(auth) }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+        }
+
+    @Test
+    fun `getCurrentUser reads the identity claims off the token`() =
+        decoratorTest({ installAdminAuth() }) { auth ->
+            val response = client.get("/whoami") { withAuthCookies(auth) }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            val body = response.bodyAsText()
+            assertTrue(body.contains(auth.userId), "expected the userId claim")
+            assertTrue(body.contains("admin-test-role"), "expected the role claim")
+            assertTrue(body.contains("isAdmin=true"), "expected the isAdmin claim")
+        }
+
+    private fun decoratorTest(
+        installAuth: ApplicationTestBuilder.() -> AuthCookies,
+        block: suspend ApplicationTestBuilder.(AuthCookies) -> Unit,
+    ) = routeTest {
+        val auth = installAuth()
+        installRoutes {
+            routing {
+                authorizePermission("things_read") {
+                    get("/guarded") { call.respond(HttpStatusCode.OK, "ok") }
+                }
+                authenticateAdmin {
+                    get("/admin-only") { call.respond(HttpStatusCode.OK, "ok") }
+                    get("/whoami") { call.respond(HttpStatusCode.OK, call.getCurrentUser().toString()) }
+                }
+                authorizeAdminPermission("things_read") {
+                    get("/admin-guarded") { call.respond(HttpStatusCode.OK, "ok") }
+                }
+            }
+        }
+        block(auth)
+    }
+}

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/AuthorizeRoutesTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/AuthorizeRoutesTest.kt
@@ -1,0 +1,274 @@
+package pos.ambrosia.utest
+
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.routing.route
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.ApplicationTestBuilder
+import org.junit.Before
+import pos.ambrosia.api.LoginRateLimiter
+import pos.ambrosia.api.auth
+import pos.ambrosia.services.AuthService
+import pos.ambrosia.services.PermissionsService
+import pos.ambrosia.utils.ExposedTestDb
+import pos.ambrosia.utils.grantPermissions
+import pos.ambrosia.utils.installAuthenticationWithoutUser
+import pos.ambrosia.utils.installRoutes
+import pos.ambrosia.utils.jsonBody
+import pos.ambrosia.utils.routeTest
+import pos.ambrosia.utils.setUserPin
+import pos.ambrosia.utils.testEnvironment
+import pos.ambrosia.utils.tokenService
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+private const val ROLE_NAME = "cashier"
+private const val USER_NAME = "cooluser1"
+private const val USER_PIN = "123456"
+
+class AuthorizeRoutesTest {
+    @Before
+    fun resetRateLimiter() {
+        LoginRateLimiter.resetAll()
+    }
+
+    @Test
+    fun `login with valid credentials issues both httpOnly cookies`() =
+        authTest {
+            seedCredentials()
+
+            val loginResponse =
+                client.post("/auth/login") {
+                    jsonBody("""{"name":"$USER_NAME","pin":"$USER_PIN"}""")
+                }
+
+            assertEquals(HttpStatusCode.OK, loginResponse.status)
+            val setCookies =
+                loginResponse.headers
+                    .getAll(HttpHeaders.SetCookie)
+                    .orEmpty()
+                    .joinToString(" ")
+            assertTrue(setCookies.contains("accessToken="), "expected an accessToken cookie")
+            assertTrue(setCookies.contains("refreshToken="), "expected a refreshToken cookie")
+            assertTrue(setCookies.contains("HttpOnly", ignoreCase = true), "login cookies must be HttpOnly")
+        }
+
+    @Test
+    fun `login response carries the role permissions`() =
+        authTest {
+            seedCredentials()
+
+            val loginResponse =
+                client.post("/auth/login") {
+                    jsonBody("""{"name":"$USER_NAME","pin":"$USER_PIN"}""")
+                }
+
+            assertTrue(loginResponse.bodyAsText().contains("orders_read"))
+        }
+
+    @Test
+    fun `login accepts a legacy four digit pin`() =
+        authTest {
+            seedCredentials(pin = "0000")
+
+            val loginResponse =
+                client.post("/auth/login") {
+                    jsonBody("""{"name":"$USER_NAME","pin":"0000"}""")
+                }
+
+            assertEquals(HttpStatusCode.OK, loginResponse.status)
+        }
+
+    @Test
+    fun `login with a wrong pin is rejected without issuing cookies`() =
+        authTest {
+            seedCredentials()
+
+            val loginResponse =
+                client.post("/auth/login") {
+                    jsonBody("""{"name":"$USER_NAME","pin":"999999"}""")
+                }
+
+            assertEquals(HttpStatusCode.Unauthorized, loginResponse.status)
+            assertNull(loginResponse.headers[HttpHeaders.SetCookie])
+        }
+
+    @Test
+    fun `login with an unknown user is rejected`() =
+        authTest {
+            seedCredentials()
+
+            val loginResponse =
+                client.post("/auth/login") {
+                    jsonBody("""{"name":"nobody","pin":"$USER_PIN"}""")
+                }
+
+            assertEquals(HttpStatusCode.Unauthorized, loginResponse.status)
+        }
+
+    @Test
+    fun `login is forbidden when the role has no permissions`() =
+        authTest {
+            val roleId = ExposedTestDb.seedRole(ROLE_NAME)
+            val userId = ExposedTestDb.seedUser(USER_NAME, roleId)
+            setUserPin(userId, USER_PIN)
+
+            val loginResponse =
+                client.post("/auth/login") {
+                    jsonBody("""{"name":"$USER_NAME","pin":"$USER_PIN"}""")
+                }
+
+            assertEquals(HttpStatusCode.Forbidden, loginResponse.status)
+        }
+
+    @Test
+    fun `the rate limiter blocks further attempts after five failures`() =
+        authTest {
+            seedCredentials()
+
+            val responses =
+                (1..6).map {
+                    client.post("/auth/login") {
+                        jsonBody("""{"name":"$USER_NAME","pin":"999999"}""")
+                    }
+                }
+
+            responses.take(5).forEach { assertEquals(HttpStatusCode.Unauthorized, it.status) }
+            val blocked = responses.last()
+            assertEquals(HttpStatusCode.TooManyRequests, blocked.status)
+            assertNotNull(blocked.headers["Retry-After"], "a blocked login must say when to retry")
+        }
+
+    @Test
+    fun `a blocked ip cannot log in even with the correct pin`() =
+        authTest {
+            seedCredentials()
+            repeat(6) {
+                client.post("/auth/login") { jsonBody("""{"name":"$USER_NAME","pin":"999999"}""") }
+            }
+
+            val loginResponse =
+                client.post("/auth/login") {
+                    jsonBody("""{"name":"$USER_NAME","pin":"$USER_PIN"}""")
+                }
+
+            assertEquals(HttpStatusCode.TooManyRequests, loginResponse.status)
+        }
+
+    @Test
+    fun `a successful login clears the failure count`() =
+        authTest {
+            seedCredentials()
+            repeat(4) {
+                client.post("/auth/login") { jsonBody("""{"name":"$USER_NAME","pin":"999999"}""") }
+            }
+            client.post("/auth/login") { jsonBody("""{"name":"$USER_NAME","pin":"$USER_PIN"}""") }
+
+            val afterReset =
+                (1..5).map {
+                    client.post("/auth/login") { jsonBody("""{"name":"$USER_NAME","pin":"999999"}""") }
+                }
+
+            afterReset.forEach { assertEquals(HttpStatusCode.Unauthorized, it.status) }
+        }
+
+    @Test
+    fun `refresh mints a new access token for a stored refresh token`() =
+        authTest {
+            val userId = seedCredentials()
+            val refreshToken = tokenService().generateRefreshToken(authResponseFor(userId))
+
+            val refreshResponse =
+                client.post("/auth/refresh") {
+                    header(HttpHeaders.Cookie, "refreshToken=$refreshToken")
+                }
+
+            assertEquals(HttpStatusCode.OK, refreshResponse.status)
+            assertTrue(refreshResponse.bodyAsText().contains("accessToken"))
+        }
+
+    @Test
+    fun `refresh without a cookie is rejected`() =
+        authTest {
+            seedCredentials()
+
+            val refreshResponse = client.post("/auth/refresh")
+
+            assertEquals(HttpStatusCode.Unauthorized, refreshResponse.status)
+        }
+
+    @Test
+    fun `refresh with a garbage token is rejected`() =
+        authTest {
+            seedCredentials()
+
+            val refreshResponse =
+                client.post("/auth/refresh") {
+                    header(HttpHeaders.Cookie, "refreshToken=not-a-jwt")
+                }
+
+            assertEquals(HttpStatusCode.Unauthorized, refreshResponse.status)
+        }
+
+    @Test
+    fun `refresh with a revoked token is rejected despite a valid signature`() =
+        authTest {
+            val userId = seedCredentials()
+            val refreshToken = tokenService().generateRefreshToken(authResponseFor(userId))
+            tokenService().revokeRefreshToken(userId)
+
+            val refreshResponse =
+                client.post("/auth/refresh") {
+                    header(HttpHeaders.Cookie, "refreshToken=$refreshToken")
+                }
+
+            assertEquals(HttpStatusCode.Unauthorized, refreshResponse.status)
+        }
+
+    @Test
+    fun `logout requires an access token`() =
+        authTest {
+            seedCredentials()
+
+            val logoutResponse = client.post("/auth/logout")
+
+            assertEquals(HttpStatusCode.Unauthorized, logoutResponse.status)
+        }
+
+    private fun seedCredentials(pin: String = USER_PIN): String {
+        val roleId = ExposedTestDb.seedRole(ROLE_NAME)
+        val userId = ExposedTestDb.seedUser(USER_NAME, roleId)
+        setUserPin(userId, pin)
+        grantPermissions(ROLE_NAME, "orders_read", "orders_create")
+        return userId
+    }
+
+    private fun authResponseFor(userId: String) =
+        pos.ambrosia.models.AuthResponse(
+            id = userId,
+            name = USER_NAME,
+            role = ROLE_NAME,
+            roleId = ExposedTestDb.seedRole(ROLE_NAME),
+            isAdmin = false,
+        )
+
+    private fun authTest(block: suspend ApplicationTestBuilder.() -> Unit) =
+        routeTest {
+            val environment = testEnvironment()
+            installAuthenticationWithoutUser()
+            installRoutes {
+                routing {
+                    route("/auth") {
+                        auth(tokenService(), AuthService(environment), PermissionsService())
+                    }
+                }
+            }
+            block()
+        }
+}

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/CheckoutRoutesTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/CheckoutRoutesTest.kt
@@ -1,0 +1,309 @@
+package pos.ambrosia.utest
+
+import io.ktor.client.request.delete
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.routing.route
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.ApplicationTestBuilder
+import org.junit.After
+import pos.ambrosia.api.checkout
+import pos.ambrosia.api.storeOrders
+import pos.ambrosia.services.ActiveLightningBackend
+import pos.ambrosia.services.CheckoutService
+import pos.ambrosia.services.RefundService
+import pos.ambrosia.utils.AuthCookies
+import pos.ambrosia.utils.ExposedTestDb
+import pos.ambrosia.utils.FakeLightningBackend
+import pos.ambrosia.utils.grantPermissions
+import pos.ambrosia.utils.installAdminAuth
+import pos.ambrosia.utils.installRoutes
+import pos.ambrosia.utils.jsonBody
+import pos.ambrosia.utils.routeTest
+import pos.ambrosia.utils.withAuthCookies
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+private const val ROLE_NAME = "admin-test-role"
+
+private val allCheckoutPermissions =
+    arrayOf("orders_create", "orders_delete", "orders_refund", "orders_discount")
+
+class CheckoutRoutesTest {
+    private val backend = FakeLightningBackend()
+
+    @After
+    fun tearDown() {
+        ActiveLightningBackend.closeActive()
+    }
+
+    @Test
+    fun `a checkout with no items is rejected`() =
+        checkoutTest { auth ->
+            val response =
+                client.post("/store/orders/checkout") {
+                    withAuthCookies(auth)
+                    jsonBody(checkoutBody(items = "[]"))
+                }
+
+            assertEquals(HttpStatusCode.BadRequest, response.status)
+            assertTrue(response.bodyAsText().contains("checkout_empty"))
+        }
+
+    @Test
+    fun `a checkout with a non-positive quantity is rejected`() =
+        checkoutTest { auth ->
+            val productId = ExposedTestDb.seedProduct("Espresso", quantity = 10)
+
+            val response =
+                client.post("/store/orders/checkout") {
+                    withAuthCookies(auth)
+                    jsonBody(
+                        checkoutBody(items = """[{"productId":"$productId","quantity":0,"priceAtOrder":200}]"""),
+                    )
+                }
+
+            assertEquals(HttpStatusCode.BadRequest, response.status)
+            assertTrue(response.bodyAsText().contains("checkout_invalid_quantity"))
+        }
+
+    @Test
+    fun `a cash checkout creates the order ticket and payment`() =
+        checkoutTest { auth ->
+            val productId = ExposedTestDb.seedProduct("Espresso", quantity = 10)
+
+            val response =
+                client.post("/store/orders/checkout") {
+                    withAuthCookies(auth)
+                    jsonBody(
+                        checkoutBody(items = """[{"productId":"$productId","quantity":1,"priceAtOrder":200}]"""),
+                    )
+                }
+
+            assertEquals(HttpStatusCode.Created, response.status)
+            val body = response.bodyAsText()
+            assertTrue(body.contains("orderId"))
+            assertTrue(body.contains("ticketId"))
+            assertTrue(body.contains("paymentId"))
+        }
+
+    @Test
+    fun `a lightning checkout for an unpaid invoice is left pending`() =
+        checkoutTest { auth ->
+            val productId = ExposedTestDb.seedProduct("Espresso", quantity = 10)
+            backend.incomingPaymentIsPaid = false
+
+            val response =
+                client.post("/store/orders/checkout") {
+                    withAuthCookies(auth)
+                    jsonBody(
+                        checkoutBody(
+                            items = """[{"productId":"$productId","quantity":1,"priceAtOrder":200}]""",
+                            extra = ""","paymentHash":"hash-unpaid"""",
+                        ),
+                    )
+                }
+
+            assertEquals(HttpStatusCode.Accepted, response.status)
+            assertTrue(response.bodyAsText().contains("pending"))
+        }
+
+    @Test
+    fun `replaying a payment hash returns the existing checkout`() =
+        checkoutTest { auth ->
+            val productId = ExposedTestDb.seedProduct("Espresso", quantity = 10)
+            val body =
+                checkoutBody(
+                    items = """[{"productId":"$productId","quantity":1,"priceAtOrder":200}]""",
+                    extra = ""","paymentHash":"hash-paid"""",
+                )
+
+            val first =
+                client.post("/store/orders/checkout") {
+                    withAuthCookies(auth)
+                    jsonBody(body)
+                }
+            val replay =
+                client.post("/store/orders/checkout") {
+                    withAuthCookies(auth)
+                    jsonBody(body)
+                }
+
+            assertEquals(HttpStatusCode.Created, first.status)
+            assertEquals(HttpStatusCode.OK, replay.status)
+            assertEquals(orderIdOf(first), orderIdOf(replay))
+        }
+
+    @Test
+    fun `a discounted checkout needs the orders_discount permission`() =
+        routeTest {
+            val auth = installAdminAuth()
+            grantPermissions(ROLE_NAME, "orders_create")
+            mountCheckout()
+            val productId = ExposedTestDb.seedProduct("Espresso", quantity = 10)
+
+            val response =
+                client.post("/store/orders/checkout") {
+                    withAuthCookies(auth)
+                    jsonBody(
+                        checkoutBody(
+                            items = """[{"productId":"$productId","quantity":1,"priceAtOrder":200}]""",
+                            extra = ""","discountAmount":1.5""",
+                        ),
+                    )
+                }
+
+            assertEquals(HttpStatusCode.Forbidden, response.status)
+        }
+
+    @Test
+    fun `a discounted checkout succeeds with the orders_discount permission`() =
+        checkoutTest { auth ->
+            val productId = ExposedTestDb.seedProduct("Espresso", quantity = 10)
+
+            val response =
+                client.post("/store/orders/checkout") {
+                    withAuthCookies(auth)
+                    jsonBody(
+                        checkoutBody(
+                            items = """[{"productId":"$productId","quantity":1,"priceAtOrder":200}]""",
+                            extra = ""","discountAmount":1.5""",
+                        ),
+                    )
+                }
+
+            assertEquals(HttpStatusCode.Created, response.status)
+        }
+
+    @Test
+    fun `payment status reports pending for an unknown hash`() =
+        checkoutTest { auth ->
+            backend.incomingPaymentIsPaid = false
+
+            val response = client.get("/store/orders/payment-status/unknown-hash") { withAuthCookies(auth) }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertTrue(response.bodyAsText().contains("pending"))
+        }
+
+    @Test
+    fun `payment status reports paid once the backend settles the invoice`() =
+        checkoutTest { auth ->
+            val response = client.get("/store/orders/payment-status/settled-hash") { withAuthCookies(auth) }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertTrue(response.bodyAsText().contains("paid"))
+        }
+
+    @Test
+    fun `cancelling an unknown store order is a not found`() =
+        checkoutTest { auth ->
+            val response =
+                client.delete("/store/orders/00000000-0000-0000-0000-000000000000") { withAuthCookies(auth) }
+
+            assertEquals(HttpStatusCode.NotFound, response.status)
+        }
+
+    @Test
+    fun `cancelling an open store order succeeds`() =
+        checkoutTest { auth ->
+            val userId = ExposedTestDb.seedUser("cashier")
+            val orderId = ExposedTestDb.seedOrder(userId, status = "open")
+
+            val response = client.delete("/store/orders/$orderId") { withAuthCookies(auth) }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+        }
+
+    @Test
+    fun `a completed checkout can no longer be cancelled`() =
+        checkoutTest { auth ->
+            val productId = ExposedTestDb.seedProduct("Espresso", quantity = 10)
+            val checkoutResponse =
+                client.post("/store/orders/checkout") {
+                    withAuthCookies(auth)
+                    jsonBody(
+                        checkoutBody(items = """[{"productId":"$productId","quantity":1,"priceAtOrder":200}]"""),
+                    )
+                }
+
+            val response =
+                client.delete("/store/orders/${orderIdOf(checkoutResponse)}") { withAuthCookies(auth) }
+
+            assertEquals(HttpStatusCode.NotFound, response.status)
+        }
+
+    @Test
+    fun `an order attached to a table is not a store order`() =
+        checkoutTest { auth ->
+            val userId = ExposedTestDb.seedUser("cashier")
+            val tableId = ExposedTestDb.seedDiningTable()
+            val orderId = ExposedTestDb.seedOrder(userId, status = "open", tableId = tableId)
+
+            val response = client.delete("/store/orders/$orderId") { withAuthCookies(auth) }
+
+            assertEquals(HttpStatusCode.NotFound, response.status)
+        }
+
+    @Test
+    fun `cancelling with a malformed order id is a not found`() =
+        checkoutTest { auth ->
+            val response = client.delete("/store/orders/not-a-uuid") { withAuthCookies(auth) }
+
+            assertEquals(HttpStatusCode.NotFound, response.status)
+        }
+
+    @Test
+    fun `checkout is unreachable without an access token`() =
+        checkoutTest {
+            val response = client.post("/store/orders/checkout") { jsonBody(checkoutBody(items = "[]")) }
+
+            assertEquals(HttpStatusCode.Unauthorized, response.status)
+        }
+
+    private suspend fun orderIdOf(response: io.ktor.client.statement.HttpResponse): String =
+        Regex("\"orderId\":\"([^\"]+)\"")
+            .find(response.bodyAsText())
+            ?.groupValues
+            ?.get(1)
+            .orEmpty()
+
+    private fun checkoutBody(
+        items: String,
+        extra: String = "",
+    ): String {
+        val userId = ExposedTestDb.seedUser("cashier")
+        val methodId = ExposedTestDb.seedPaymentMethod()
+        val currencyId = ExposedTestDb.seedCurrency("USD")
+        return """{
+            "userId":"$userId",
+            "items":$items,
+            "paymentMethodId":"$methodId",
+            "currencyId":"$currencyId",
+            "amount":2.0$extra
+        }"""
+    }
+
+    private fun ApplicationTestBuilder.mountCheckout() {
+        installRoutes {
+            routing {
+                route("/store/orders") {
+                    checkout(CheckoutService(ActiveLightningBackend))
+                    storeOrders(CheckoutService(), RefundService(ActiveLightningBackend))
+                }
+            }
+        }
+    }
+
+    private fun checkoutTest(block: suspend ApplicationTestBuilder.(AuthCookies) -> Unit) =
+        routeTest {
+            ActiveLightningBackend.set(backend)
+            val auth = installAdminAuth()
+            grantPermissions(ROLE_NAME, *allCheckoutPermissions)
+            mountCheckout()
+            block(auth)
+        }
+}

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/OrdersRoutesTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/OrdersRoutesTest.kt
@@ -1,0 +1,389 @@
+package pos.ambrosia.utest
+
+import io.ktor.client.request.delete
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.request.put
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.routing.route
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.ApplicationTestBuilder
+import pos.ambrosia.api.orders
+import pos.ambrosia.services.OrderService
+import pos.ambrosia.utils.AuthCookies
+import pos.ambrosia.utils.ExposedTestDb
+import pos.ambrosia.utils.grantPermissions
+import pos.ambrosia.utils.installAdminAuth
+import pos.ambrosia.utils.installRoutes
+import pos.ambrosia.utils.jsonBody
+import pos.ambrosia.utils.routeTest
+import pos.ambrosia.utils.withAuthCookies
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+private const val ROLE_NAME = "admin-test-role"
+
+class OrdersRoutesTest {
+    @Test
+    fun `listing orders returns the seeded orders`() =
+        ordersTest { auth ->
+            val userId = ExposedTestDb.seedUser("waiter")
+            ExposedTestDb.seedOrder(userId, status = "open")
+
+            val response = client.get("/orders") { withAuthCookies(auth) }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertTrue(response.bodyAsText().contains("open"))
+        }
+
+    @Test
+    fun `getting an order by id returns it`() =
+        ordersTest { auth ->
+            val userId = ExposedTestDb.seedUser("waiter")
+            val orderId = ExposedTestDb.seedOrder(userId, total = 12.5)
+
+            val response = client.get("/orders/$orderId") { withAuthCookies(auth) }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertTrue(response.bodyAsText().contains("12.5"))
+        }
+
+    @Test
+    fun `getting an unknown order is a not found`() =
+        ordersTest { auth ->
+            val response =
+                client.get("/orders/00000000-0000-0000-0000-000000000000") { withAuthCookies(auth) }
+
+            assertEquals(HttpStatusCode.NotFound, response.status)
+        }
+
+    @Test
+    fun `the complete order view includes its dishes`() =
+        ordersTest { auth ->
+            val userId = ExposedTestDb.seedUser("waiter")
+            val orderId = ExposedTestDb.seedOrder(userId)
+
+            val response = client.get("/orders/$orderId/complete") { withAuthCookies(auth) }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertTrue(response.bodyAsText().contains("dishes"))
+        }
+
+    @Test
+    fun `filtering by status returns matching orders`() =
+        ordersTest { auth ->
+            val userId = ExposedTestDb.seedUser("waiter")
+            ExposedTestDb.seedOrder(userId, status = "closed", total = 99.0)
+
+            val response = client.get("/orders/status/closed") { withAuthCookies(auth) }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertTrue(response.bodyAsText().contains("99"))
+        }
+
+    @Test
+    fun `filtering by user returns that user's orders`() =
+        ordersTest { auth ->
+            val userId = ExposedTestDb.seedUser("waiter")
+            ExposedTestDb.seedOrder(userId, total = 77.0)
+
+            val response = client.get("/orders/user/$userId") { withAuthCookies(auth) }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertTrue(response.bodyAsText().contains("77"))
+        }
+
+    @Test
+    fun `a date range needs both query parameters`() =
+        ordersTest { auth ->
+            val response = client.get("/orders/date-range?start_date=2024-01-01") { withAuthCookies(auth) }
+
+            assertEquals(HttpStatusCode.BadRequest, response.status)
+        }
+
+    @Test
+    fun `a date range returns the orders inside it`() =
+        ordersTest { auth ->
+            val userId = ExposedTestDb.seedUser("waiter")
+            ExposedTestDb.seedOrder(userId, createdAt = "2024-06-15T10:00:00", total = 55.0)
+
+            val response =
+                client.get("/orders/date-range?start_date=2024-06-01&end_date=2024-06-30") {
+                    withAuthCookies(auth)
+                }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertTrue(response.bodyAsText().contains("55"))
+        }
+
+    @Test
+    fun `creating an order returns its new id`() =
+        ordersTest { auth ->
+            val userId = ExposedTestDb.seedUser("waiter")
+
+            val response =
+                client.post("/orders") {
+                    withAuthCookies(auth)
+                    jsonBody(
+                        """{"userId":"$userId","status":"open","total":10.0,"createdAt":"2024-01-01T00:00:00"}""",
+                    )
+                }
+
+            assertEquals(HttpStatusCode.Created, response.status)
+            assertTrue(response.bodyAsText().contains("id"))
+        }
+
+    @Test
+    fun `creating an order with dishes succeeds`() =
+        ordersTest { auth ->
+            val userId = ExposedTestDb.seedUser("waiter")
+
+            val response =
+                client.post("/orders/with-dishes") {
+                    withAuthCookies(auth)
+                    jsonBody(
+                        """{
+                            "order":{"userId":"$userId","status":"open","total":0.0,"createdAt":"2024-01-01T00:00:00"},
+                            "dishes":[]
+                        }""",
+                    )
+                }
+
+            assertEquals(HttpStatusCode.Created, response.status)
+        }
+
+    @Test
+    fun `updating an order succeeds`() =
+        ordersTest { auth ->
+            val userId = ExposedTestDb.seedUser("waiter")
+            val orderId = ExposedTestDb.seedOrder(userId)
+
+            val response =
+                client.put("/orders/$orderId") {
+                    withAuthCookies(auth)
+                    jsonBody(
+                        """{"userId":"$userId","status":"closed","total":42.0,"createdAt":"2024-01-01T00:00:00"}""",
+                    )
+                }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+        }
+
+    @Test
+    fun `updating an unknown order is a not found`() =
+        ordersTest { auth ->
+            val userId = ExposedTestDb.seedUser("waiter")
+
+            val response =
+                client.put("/orders/00000000-0000-0000-0000-000000000000") {
+                    withAuthCookies(auth)
+                    jsonBody(
+                        """{"userId":"$userId","status":"closed","total":42.0,"createdAt":"2024-01-01T00:00:00"}""",
+                    )
+                }
+
+            assertEquals(HttpStatusCode.NotFound, response.status)
+        }
+
+    @Test
+    fun `deleting an order succeeds and then reports not found`() =
+        ordersTest { auth ->
+            val userId = ExposedTestDb.seedUser("waiter")
+            val orderId = ExposedTestDb.seedOrder(userId)
+
+            val deleteResponse = client.delete("/orders/$orderId") { withAuthCookies(auth) }
+            val getResponse = client.get("/orders/$orderId") { withAuthCookies(auth) }
+
+            assertEquals(HttpStatusCode.NoContent, deleteResponse.status)
+            assertEquals(HttpStatusCode.NotFound, getResponse.status)
+        }
+
+    @Test
+    fun `deleting an unknown order is a not found`() =
+        ordersTest { auth ->
+            val response =
+                client.delete("/orders/00000000-0000-0000-0000-000000000000") { withAuthCookies(auth) }
+
+            assertEquals(HttpStatusCode.NotFound, response.status)
+        }
+
+    @Test
+    fun `dishes can be added to an order and then listed`() =
+        ordersTest { auth ->
+            val userId = ExposedTestDb.seedUser("waiter")
+            val orderId = ExposedTestDb.seedOrder(userId)
+            val dishId = ExposedTestDb.seedDish("Paella", price = 18.0)
+
+            val addResponse =
+                client.post("/orders/$orderId/dishes") {
+                    withAuthCookies(auth)
+                    jsonBody("""[{"dishId":"$dishId","priceAtOrder":18.0,"notes":"no salt"}]""")
+                }
+            val listResponse = client.get("/orders/$orderId/dishes") { withAuthCookies(auth) }
+
+            assertEquals(HttpStatusCode.Created, addResponse.status)
+            assertEquals(HttpStatusCode.OK, listResponse.status)
+            assertTrue(listResponse.bodyAsText().contains("no salt"))
+        }
+
+    @Test
+    fun `adding an empty dish list is a bad request`() =
+        ordersTest { auth ->
+            val userId = ExposedTestDb.seedUser("waiter")
+            val orderId = ExposedTestDb.seedOrder(userId)
+
+            val response =
+                client.post("/orders/$orderId/dishes") {
+                    withAuthCookies(auth)
+                    jsonBody("[]")
+                }
+
+            assertEquals(HttpStatusCode.BadRequest, response.status)
+        }
+
+    @Test
+    fun `an order dish can be updated`() =
+        ordersTest { auth ->
+            val userId = ExposedTestDb.seedUser("waiter")
+            val orderId = ExposedTestDb.seedOrder(userId)
+            val dishId = ExposedTestDb.seedDish("Paella")
+            val orderDishId = ExposedTestDb.seedOrderDish(orderId, dishId)
+
+            val response =
+                client.put("/orders/$orderId/dishes/$orderDishId") {
+                    withAuthCookies(auth)
+                    jsonBody(
+                        """{
+                            "orderId":"$orderId","dishId":"$dishId","priceAtOrder":22.0,
+                            "status":"served","shouldPrepare":false
+                        }""",
+                    )
+                }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+        }
+
+    @Test
+    fun `updating an unknown order dish is a not found`() =
+        ordersTest { auth ->
+            val userId = ExposedTestDb.seedUser("waiter")
+            val orderId = ExposedTestDb.seedOrder(userId)
+            val dishId = ExposedTestDb.seedDish("Paella")
+
+            val response =
+                client.put("/orders/$orderId/dishes/00000000-0000-0000-0000-000000000000") {
+                    withAuthCookies(auth)
+                    jsonBody(
+                        """{
+                            "orderId":"$orderId","dishId":"$dishId","priceAtOrder":22.0,
+                            "status":"served","shouldPrepare":false
+                        }""",
+                    )
+                }
+
+            assertEquals(HttpStatusCode.NotFound, response.status)
+        }
+
+    @Test
+    fun `a single order dish can be removed`() =
+        ordersTest { auth ->
+            val userId = ExposedTestDb.seedUser("waiter")
+            val orderId = ExposedTestDb.seedOrder(userId)
+            val dishId = ExposedTestDb.seedDish("Paella")
+            val orderDishId = ExposedTestDb.seedOrderDish(orderId, dishId)
+
+            val response =
+                client.delete("/orders/$orderId/dishes/$orderDishId") { withAuthCookies(auth) }
+
+            assertEquals(HttpStatusCode.NoContent, response.status)
+        }
+
+    @Test
+    fun `all dishes can be removed from an order`() =
+        ordersTest { auth ->
+            val userId = ExposedTestDb.seedUser("waiter")
+            val orderId = ExposedTestDb.seedOrder(userId)
+            val dishId = ExposedTestDb.seedDish("Paella")
+            ExposedTestDb.seedOrderDish(orderId, dishId)
+
+            val response = client.delete("/orders/$orderId/dishes") { withAuthCookies(auth) }
+
+            assertEquals(HttpStatusCode.NoContent, response.status)
+        }
+
+    @Test
+    fun `recalculating the total sums the order dishes`() =
+        ordersTest { auth ->
+            val userId = ExposedTestDb.seedUser("waiter")
+            val orderId = ExposedTestDb.seedOrder(userId, total = 0.0)
+            val dishId = ExposedTestDb.seedDish("Paella")
+            ExposedTestDb.seedOrderDish(orderId, dishId, priceAtOrder = 12.0)
+            ExposedTestDb.seedOrderDish(orderId, dishId, priceAtOrder = 8.0)
+
+            val response = client.put("/orders/$orderId/calculate-total") { withAuthCookies(auth) }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertTrue(response.bodyAsText().contains("20"))
+        }
+
+    @Test
+    fun `filtering by table returns that table's orders`() =
+        ordersTest { auth ->
+            val userId = ExposedTestDb.seedUser("waiter")
+            val tableId = ExposedTestDb.seedDiningTable()
+            ExposedTestDb.seedOrder(userId, tableId = tableId, total = 31.0)
+
+            val response = client.get("/orders/table/$tableId") { withAuthCookies(auth) }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertTrue(response.bodyAsText().contains("31"))
+        }
+
+    @Test
+    fun `each verb needs its own orders permission`() =
+        routeTest {
+            val auth = installAdminAuth()
+            grantPermissions(ROLE_NAME, "orders_read")
+            mountOrders()
+            val userId = ExposedTestDb.seedUser("waiter")
+            val orderId = ExposedTestDb.seedOrder(userId)
+
+            val readResponse = client.get("/orders/$orderId") { withAuthCookies(auth) }
+            val createResponse =
+                client.post("/orders") {
+                    withAuthCookies(auth)
+                    jsonBody(
+                        """{"userId":"$userId","status":"open","total":10.0,"createdAt":"2024-01-01T00:00:00"}""",
+                    )
+                }
+            val deleteResponse = client.delete("/orders/$orderId") { withAuthCookies(auth) }
+
+            assertEquals(HttpStatusCode.OK, readResponse.status)
+            assertEquals(HttpStatusCode.Forbidden, createResponse.status)
+            assertEquals(HttpStatusCode.Forbidden, deleteResponse.status)
+        }
+
+    @Test
+    fun `orders are unreachable without an access token`() =
+        ordersTest {
+            val response = client.get("/orders")
+
+            assertEquals(HttpStatusCode.Unauthorized, response.status)
+        }
+
+    private fun ApplicationTestBuilder.mountOrders() {
+        installRoutes {
+            routing { route("/orders") { orders(OrderService()) } }
+        }
+    }
+
+    private fun ordersTest(block: suspend ApplicationTestBuilder.(AuthCookies) -> Unit) =
+        routeTest {
+            val auth = installAdminAuth()
+            grantPermissions(ROLE_NAME, "orders_read", "orders_create", "orders_update", "orders_delete")
+            mountOrders()
+            block(auth)
+        }
+}

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/PaymentsRoutesTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/PaymentsRoutesTest.kt
@@ -1,0 +1,260 @@
+package pos.ambrosia.utest
+
+import io.ktor.client.request.delete
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.request.put
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.routing.route
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.ApplicationTestBuilder
+import pos.ambrosia.api.payments
+import pos.ambrosia.services.PaymentService
+import pos.ambrosia.services.TicketPaymentService
+import pos.ambrosia.utils.AuthCookies
+import pos.ambrosia.utils.ExposedTestDb
+import pos.ambrosia.utils.grantPermissions
+import pos.ambrosia.utils.installAdminAuth
+import pos.ambrosia.utils.installRoutes
+import pos.ambrosia.utils.jsonBody
+import pos.ambrosia.utils.routeTest
+import pos.ambrosia.utils.withAuthCookies
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+private const val ROLE_NAME = "admin-test-role"
+
+class PaymentsRoutesTest {
+    @Test
+    fun `listing payments returns the seeded payments`() =
+        paymentsTest { auth ->
+            ExposedTestDb.seedPayment(amount = 33.0)
+
+            val response = client.get("/payments") { withAuthCookies(auth) }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertTrue(response.bodyAsText().contains("33"))
+        }
+
+    @Test
+    fun `getting a payment by id returns it`() =
+        paymentsTest { auth ->
+            val paymentId = ExposedTestDb.seedPayment(amount = 21.0)
+
+            val response = client.get("/payments/$paymentId") { withAuthCookies(auth) }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertTrue(response.bodyAsText().contains("21"))
+        }
+
+    @Test
+    fun `getting an unknown payment is a not found`() =
+        paymentsTest { auth ->
+            val response =
+                client.get("/payments/00000000-0000-0000-0000-000000000000") { withAuthCookies(auth) }
+
+            assertEquals(HttpStatusCode.NotFound, response.status)
+        }
+
+    @Test
+    fun `listing payment methods returns the seeded methods`() =
+        paymentsTest { auth ->
+            ExposedTestDb.seedPaymentMethod("Lightning")
+
+            val response = client.get("/payments/methods") { withAuthCookies(auth) }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertTrue(response.bodyAsText().contains("Lightning"))
+        }
+
+    @Test
+    fun `getting an unknown payment method is a not found`() =
+        paymentsTest { auth ->
+            val response =
+                client.get("/payments/methods/00000000-0000-0000-0000-000000000000") { withAuthCookies(auth) }
+
+            assertEquals(HttpStatusCode.NotFound, response.status)
+        }
+
+    @Test
+    fun `listing currencies returns the seeded currencies`() =
+        paymentsTest { auth ->
+            ExposedTestDb.seedCurrency("EUR")
+
+            val response = client.get("/payments/currencies") { withAuthCookies(auth) }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertTrue(response.bodyAsText().contains("EUR"))
+        }
+
+    @Test
+    fun `getting a currency by id returns it`() =
+        paymentsTest { auth ->
+            val currencyId = ExposedTestDb.seedCurrency("GBP")
+
+            val response = client.get("/payments/currencies/$currencyId") { withAuthCookies(auth) }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertTrue(response.bodyAsText().contains("GBP"))
+        }
+
+    @Test
+    fun `creating a payment returns its new id`() =
+        paymentsTest { auth ->
+            val methodId = ExposedTestDb.seedPaymentMethod()
+            val currencyId = ExposedTestDb.seedCurrency("USD")
+
+            val response =
+                client.post("/payments") {
+                    withAuthCookies(auth)
+                    jsonBody(
+                        """{"methodId":"$methodId","currencyId":"$currencyId","transactionId":"txn-9","amount":15.0}""",
+                    )
+                }
+
+            assertEquals(HttpStatusCode.Created, response.status)
+            assertTrue(response.bodyAsText().contains("id"))
+        }
+
+    @Test
+    fun `updating a payment succeeds`() =
+        paymentsTest { auth ->
+            val methodId = ExposedTestDb.seedPaymentMethod()
+            val currencyId = ExposedTestDb.seedCurrency("USD")
+            val paymentId = ExposedTestDb.seedPayment(methodId, currencyId)
+
+            val response =
+                client.put("/payments/$paymentId") {
+                    withAuthCookies(auth)
+                    jsonBody(
+                        """{"methodId":"$methodId","currencyId":"$currencyId","transactionId":"txn-9","amount":50.0}""",
+                    )
+                }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+        }
+
+    @Test
+    fun `updating an unknown payment is a not found`() =
+        paymentsTest { auth ->
+            val methodId = ExposedTestDb.seedPaymentMethod()
+            val currencyId = ExposedTestDb.seedCurrency("USD")
+
+            val response =
+                client.put("/payments/00000000-0000-0000-0000-000000000000") {
+                    withAuthCookies(auth)
+                    jsonBody(
+                        """{"methodId":"$methodId","currencyId":"$currencyId","transactionId":"txn-9","amount":50.0}""",
+                    )
+                }
+
+            assertEquals(HttpStatusCode.NotFound, response.status)
+        }
+
+    @Test
+    fun `deleting a payment succeeds and then reports not found`() =
+        paymentsTest { auth ->
+            val paymentId = ExposedTestDb.seedPayment()
+
+            val deleteResponse = client.delete("/payments/$paymentId") { withAuthCookies(auth) }
+            val getResponse = client.get("/payments/$paymentId") { withAuthCookies(auth) }
+
+            assertEquals(HttpStatusCode.NoContent, deleteResponse.status)
+            assertEquals(HttpStatusCode.NotFound, getResponse.status)
+        }
+
+    @Test
+    fun `deleting a ticket payment link needs both query parameters`() =
+        paymentsTest { auth ->
+            val response = client.delete("/payments/ticket-payments?paymentId=abc") { withAuthCookies(auth) }
+
+            assertEquals(HttpStatusCode.BadRequest, response.status)
+        }
+
+    @Test
+    fun `ticket payments can be listed by ticket`() =
+        paymentsTest { auth ->
+            val userId = ExposedTestDb.seedUser("waiter")
+            val orderId = ExposedTestDb.seedOrder(userId)
+            val ticketId = ExposedTestDb.seedTicket(orderId, userId)
+            val paymentId = ExposedTestDb.seedPayment(amount = 12.0)
+            ExposedTestDb.seedTicketPayment(paymentId, ticketId)
+
+            val response =
+                client.get("/payments/ticket-payments/by-ticket/$ticketId") { withAuthCookies(auth) }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertTrue(response.bodyAsText().contains(paymentId))
+        }
+
+    @Test
+    fun `ticket payments can be listed by payment`() =
+        paymentsTest { auth ->
+            val userId = ExposedTestDb.seedUser("waiter")
+            val orderId = ExposedTestDb.seedOrder(userId)
+            val ticketId = ExposedTestDb.seedTicket(orderId, userId)
+            val paymentId = ExposedTestDb.seedPayment(amount = 12.0)
+            ExposedTestDb.seedTicketPayment(paymentId, ticketId)
+
+            val response =
+                client.get("/payments/ticket-payments/by-payment/$paymentId") { withAuthCookies(auth) }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertTrue(response.bodyAsText().contains(ticketId))
+        }
+
+    @Test
+    fun `payments_read does not grant write access`() =
+        routeTest {
+            val auth = installAdminAuth()
+            grantPermissions(ROLE_NAME, "payments_read")
+            mountPayments()
+            val methodId = ExposedTestDb.seedPaymentMethod()
+            val currencyId = ExposedTestDb.seedCurrency("USD")
+            val paymentId = ExposedTestDb.seedPayment(methodId, currencyId)
+
+            val readResponse = client.get("/payments/$paymentId") { withAuthCookies(auth) }
+            val createResponse =
+                client.post("/payments") {
+                    withAuthCookies(auth)
+                    jsonBody(
+                        """{"methodId":"$methodId","currencyId":"$currencyId","transactionId":"t","amount":1.0}""",
+                    )
+                }
+            val deleteResponse = client.delete("/payments/$paymentId") { withAuthCookies(auth) }
+
+            assertEquals(HttpStatusCode.OK, readResponse.status)
+            assertEquals(HttpStatusCode.Forbidden, createResponse.status)
+            assertEquals(HttpStatusCode.Forbidden, deleteResponse.status)
+        }
+
+    @Test
+    fun `payments are unreachable without an access token`() =
+        paymentsTest {
+            val response = client.get("/payments")
+
+            assertEquals(HttpStatusCode.Unauthorized, response.status)
+        }
+
+    private fun ApplicationTestBuilder.mountPayments() {
+        installRoutes {
+            routing { route("/payments") { payments(PaymentService(), TicketPaymentService()) } }
+        }
+    }
+
+    private fun paymentsTest(block: suspend ApplicationTestBuilder.(AuthCookies) -> Unit) =
+        routeTest {
+            val auth = installAdminAuth()
+            grantPermissions(
+                ROLE_NAME,
+                "payments_read",
+                "payments_create",
+                "payments_update",
+                "payments_delete",
+            )
+            mountPayments()
+            block(auth)
+        }
+}

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/ProductsRoutesTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/ProductsRoutesTest.kt
@@ -1,0 +1,288 @@
+package pos.ambrosia.utest
+
+import io.ktor.client.request.delete
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.request.put
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.routing.route
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.ApplicationTestBuilder
+import pos.ambrosia.api.productVariants
+import pos.ambrosia.api.products
+import pos.ambrosia.services.ProductService
+import pos.ambrosia.services.ProductVariantService
+import pos.ambrosia.utils.AuthCookies
+import pos.ambrosia.utils.ExposedTestDb
+import pos.ambrosia.utils.grantPermissions
+import pos.ambrosia.utils.installAdminAuth
+import pos.ambrosia.utils.installRoutes
+import pos.ambrosia.utils.jsonBody
+import pos.ambrosia.utils.routeTest
+import pos.ambrosia.utils.withAuthCookies
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+private const val ROLE_NAME = "admin-test-role"
+
+class ProductsRoutesTest {
+    @Test
+    fun `listing products returns the seeded products`() =
+        productsTest { auth ->
+            ExposedTestDb.seedProduct("Espresso")
+
+            val response = client.get("/products") { withAuthCookies(auth) }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertTrue(response.bodyAsText().contains("Espresso"))
+        }
+
+    @Test
+    fun `getting a product by id returns it`() =
+        productsTest { auth ->
+            val productId = ExposedTestDb.seedProduct("Latte")
+
+            val response = client.get("/products/$productId") { withAuthCookies(auth) }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertTrue(response.bodyAsText().contains("Latte"))
+        }
+
+    @Test
+    fun `getting an unknown product is a not found`() =
+        productsTest { auth ->
+            val response =
+                client.get("/products/00000000-0000-0000-0000-000000000000") { withAuthCookies(auth) }
+
+            assertEquals(HttpStatusCode.NotFound, response.status)
+        }
+
+    @Test
+    fun `creating a product returns its new id`() =
+        productsTest { auth ->
+            val response =
+                client.post("/products") {
+                    withAuthCookies(auth)
+                    jsonBody("""{"name":"Cortado","priceCents":250,"quantity":10}""")
+                }
+
+            assertEquals(HttpStatusCode.Created, response.status)
+            assertTrue(response.bodyAsText().contains("id"))
+        }
+
+    @Test
+    fun `updating a product succeeds`() =
+        productsTest { auth ->
+            val productId = ExposedTestDb.seedProduct("Mocha")
+
+            val response =
+                client.put("/products/$productId") {
+                    withAuthCookies(auth)
+                    jsonBody("""{"name":"Mocha Grande","priceCents":400,"quantity":5}""")
+                }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+        }
+
+    @Test
+    fun `updating an unknown product is a not found`() =
+        productsTest { auth ->
+            val response =
+                client.put("/products/00000000-0000-0000-0000-000000000000") {
+                    withAuthCookies(auth)
+                    jsonBody("""{"name":"Ghost","priceCents":100,"quantity":1}""")
+                }
+
+            assertEquals(HttpStatusCode.NotFound, response.status)
+        }
+
+    @Test
+    fun `deleting a product succeeds and then reports not found`() =
+        productsTest { auth ->
+            val productId = ExposedTestDb.seedProduct("Doomed")
+
+            val deleteResponse = client.delete("/products/$productId") { withAuthCookies(auth) }
+            val getResponse = client.get("/products/$productId") { withAuthCookies(auth) }
+
+            assertEquals(HttpStatusCode.NoContent, deleteResponse.status)
+            assertEquals(HttpStatusCode.NotFound, getResponse.status)
+        }
+
+    @Test
+    fun `an empty stock adjustment list is a bad request`() =
+        productsTest { auth ->
+            val response =
+                client.post("/products/stock") {
+                    withAuthCookies(auth)
+                    jsonBody("[]")
+                }
+
+            assertEquals(HttpStatusCode.BadRequest, response.status)
+        }
+
+    @Test
+    fun `a stock adjustment beyond the available quantity is rejected`() =
+        productsTest { auth ->
+            val productId = ExposedTestDb.seedProduct("Scarce", quantity = 2)
+
+            val response =
+                client.post("/products/stock") {
+                    withAuthCookies(auth)
+                    jsonBody("""[{"productId":"$productId","quantity":99}]""")
+                }
+
+            assertEquals(HttpStatusCode.BadRequest, response.status)
+        }
+
+    @Test
+    fun `a negative stock adjustment is rejected`() =
+        productsTest { auth ->
+            val productId = ExposedTestDb.seedProduct("Scarce", quantity = 5)
+
+            val response =
+                client.post("/products/stock") {
+                    withAuthCookies(auth)
+                    jsonBody("""[{"productId":"$productId","quantity":-1}]""")
+                }
+
+            assertEquals(HttpStatusCode.BadRequest, response.status)
+        }
+
+    @Test
+    fun `stock adjustment is guarded by orders_create rather than products_update`() =
+        routeTest {
+            val auth = installAdminAuth()
+            grantPermissions(ROLE_NAME, "products_read", "products_update")
+            mountProducts()
+            val productId = ExposedTestDb.seedProduct("Guarded", quantity = 10)
+
+            val withoutOrdersCreate =
+                client.post("/products/stock") {
+                    withAuthCookies(auth)
+                    jsonBody("""[{"productId":"$productId","quantity":1}]""")
+                }
+
+            assertEquals(HttpStatusCode.Forbidden, withoutOrdersCreate.status)
+        }
+
+    @Test
+    fun `stock adjustment succeeds with orders_create`() =
+        productsTest { auth ->
+            val productId = ExposedTestDb.seedProduct("Stocked", quantity = 10)
+
+            val response =
+                client.post("/products/stock") {
+                    withAuthCookies(auth)
+                    jsonBody("""[{"productId":"$productId","quantity":1}]""")
+                }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+        }
+
+    @Test
+    fun `listing variants of a product succeeds`() =
+        productsTest { auth ->
+            val productId = ExposedTestDb.seedProduct("Varied", hasVariants = true)
+
+            val response = client.get("/products/$productId/variants") { withAuthCookies(auth) }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+        }
+
+    @Test
+    fun `an option type can be created and then listed`() =
+        productsTest { auth ->
+            val productId = ExposedTestDb.seedProduct("Sized", hasVariants = true)
+
+            val createResponse =
+                client.post("/products/$productId/options") {
+                    withAuthCookies(auth)
+                    jsonBody("""{"name":"Size","values":[{"value":"Small"},{"value":"Large"}]}""")
+                }
+            val listResponse = client.get("/products/$productId/options") { withAuthCookies(auth) }
+
+            assertEquals(HttpStatusCode.Created, createResponse.status)
+            assertTrue(listResponse.bodyAsText().contains("Size"))
+        }
+
+    @Test
+    fun `deleting an unknown option type is a not found`() =
+        productsTest { auth ->
+            val productId = ExposedTestDb.seedProduct("Sized", hasVariants = true)
+
+            val response =
+                client.delete("/products/$productId/options/00000000-0000-0000-0000-000000000000") {
+                    withAuthCookies(auth)
+                }
+
+            assertEquals(HttpStatusCode.NotFound, response.status)
+        }
+
+    @Test
+    fun `a variant can be created and then updated`() =
+        productsTest { auth ->
+            val productId = ExposedTestDb.seedProduct("Varied", hasVariants = true)
+
+            val createResponse =
+                client.post("/products/$productId/variants") {
+                    withAuthCookies(auth)
+                    jsonBody("""{"priceCents":300,"quantity":4}""")
+                }
+            val variantId = Regex("\"id\":\"([^\"]+)\"").find(createResponse.bodyAsText())?.groupValues?.get(1)
+            val updateResponse =
+                client.put("/products/$productId/variants/$variantId") {
+                    withAuthCookies(auth)
+                    jsonBody("""{"priceCents":350,"quantity":6}""")
+                }
+
+            assertEquals(HttpStatusCode.Created, createResponse.status)
+            assertEquals(HttpStatusCode.OK, updateResponse.status)
+        }
+
+    @Test
+    fun `deleting an unknown variant is a not found`() =
+        productsTest { auth ->
+            val productId = ExposedTestDb.seedProduct("Varied", hasVariants = true)
+
+            val response =
+                client.delete("/products/$productId/variants/00000000-0000-0000-0000-000000000000") {
+                    withAuthCookies(auth)
+                }
+
+            assertEquals(HttpStatusCode.NotFound, response.status)
+        }
+
+    @Test
+    fun `products are unreachable without an access token`() =
+        productsTest {
+            val response = client.get("/products")
+
+            assertEquals(HttpStatusCode.Unauthorized, response.status)
+        }
+
+    private fun ApplicationTestBuilder.mountProducts() {
+        installRoutes {
+            routing {
+                route("/products") { products(ProductService(), ProductVariantService()) }
+                route("/products/{id}") { productVariants(ProductVariantService()) }
+            }
+        }
+    }
+
+    private fun productsTest(block: suspend ApplicationTestBuilder.(AuthCookies) -> Unit) =
+        routeTest {
+            val auth = installAdminAuth()
+            grantPermissions(
+                ROLE_NAME,
+                "products_read",
+                "products_create",
+                "products_update",
+                "products_delete",
+                "orders_create",
+            )
+            mountProducts()
+            block(auth)
+        }
+}

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/UploadsRoutesTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/UploadsRoutesTest.kt
@@ -1,0 +1,130 @@
+package pos.ambrosia.utest
+
+import io.ktor.client.request.forms.MultiPartFormDataContent
+import io.ktor.client.request.forms.formData
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.Headers
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.ApplicationTestBuilder
+import pos.ambrosia.api.uploads
+import pos.ambrosia.services.ConfigService
+import pos.ambrosia.services.UploadService
+import pos.ambrosia.utils.AuthCookies
+import pos.ambrosia.utils.ExposedTestDb
+import pos.ambrosia.utils.installAdminAuth
+import pos.ambrosia.utils.installRoutes
+import pos.ambrosia.utils.routeTest
+import pos.ambrosia.utils.withAuthCookies
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.createTempDirectory
+import kotlin.io.path.name
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class UploadsRoutesTest {
+    private lateinit var uploadRoot: Path
+
+    @Test
+    fun `upload without a token is allowed before the config row exists`() =
+        uploadTest {
+            val response = client.post("/uploads") { setBody(filePart("logo.png")) }
+
+            assertEquals(HttpStatusCode.Created, response.status)
+        }
+
+    @Test
+    fun `upload without a token is rejected once the config row exists`() =
+        uploadTest {
+            ExposedTestDb.seedConfig("UTC")
+
+            val response = client.post("/uploads") { setBody(filePart("logo.png")) }
+
+            assertEquals(HttpStatusCode.Unauthorized, response.status)
+            assertTrue(storedFiles().isEmpty(), "a rejected upload must not write a file")
+        }
+
+    @Test
+    fun `upload with a token is accepted once the config row exists`() =
+        uploadTest { auth ->
+            ExposedTestDb.seedConfig("UTC")
+
+            val response =
+                client.post("/uploads") {
+                    withAuthCookies(auth)
+                    setBody(filePart("logo.png"))
+                }
+
+            assertEquals(HttpStatusCode.Created, response.status)
+            assertEquals(1, storedFiles().size)
+        }
+
+    @Test
+    fun `a request with no file part is a bad request`() =
+        uploadTest {
+            val response =
+                client.post("/uploads") {
+                    setBody(MultiPartFormDataContent(formData { append("note", "no file here") }))
+                }
+
+            assertEquals(HttpStatusCode.BadRequest, response.status)
+        }
+
+    @Test
+    fun `a traversal filename cannot escape the upload root`() =
+        uploadTest {
+            val response = client.post("/uploads") { setBody(filePart("../../../evil.png")) }
+
+            assertEquals(HttpStatusCode.Created, response.status)
+            val stored = storedFiles()
+            assertEquals(1, stored.size)
+            assertFalse(stored.single().name.contains("evil"), "the client filename must not be reused")
+            assertTrue(stored.single().name.endsWith(".png"))
+            assertTrue(stored.single().startsWith(uploadRoot), "the file must stay under the upload root")
+        }
+
+    @Test
+    fun `the response points at the stored path under uploads`() =
+        uploadTest {
+            val response = client.post("/uploads") { setBody(filePart("logo.png")) }
+
+            assertTrue(response.bodyAsText().contains("\"path\":\"/uploads/"))
+        }
+
+    private fun filePart(fileName: String) =
+        MultiPartFormDataContent(
+            formData {
+                append(
+                    "file",
+                    byteArrayOf(1, 2, 3, 4),
+                    Headers.build {
+                        append(HttpHeaders.ContentType, ContentType.Image.PNG.toString())
+                        append(HttpHeaders.ContentDisposition, "filename=\"$fileName\"")
+                    },
+                )
+            },
+        )
+
+    private fun storedFiles(): List<Path> =
+        Files
+            .walk(uploadRoot)
+            .filter { Files.isRegularFile(it) }
+            .toList()
+
+    private fun uploadTest(block: suspend ApplicationTestBuilder.(AuthCookies) -> Unit) =
+        routeTest {
+            uploadRoot = createTempDirectory("ambrosia-uploads-test")
+            val auth = installAdminAuth()
+            installRoutes {
+                routing { uploads(UploadService(uploadRoot), ConfigService()) }
+            }
+            block(auth)
+        }
+}

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/WalletRoutesTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/WalletRoutesTest.kt
@@ -1,0 +1,435 @@
+package pos.ambrosia.utest
+
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.routing.route
+import io.ktor.server.routing.routing
+import org.junit.After
+import pos.ambrosia.api.wallet
+import pos.ambrosia.models.phoenix.IncomingPayment
+import pos.ambrosia.models.phoenix.OutgoingPayment
+import pos.ambrosia.services.ActiveLightningBackend
+import pos.ambrosia.services.AuthService
+import pos.ambrosia.services.PaymentService
+import pos.ambrosia.services.RefundService
+import pos.ambrosia.services.RolesService
+import pos.ambrosia.services.WalletAdminNotificationService
+import pos.ambrosia.services.WalletRateService
+import pos.ambrosia.utils.AuthCookies
+import pos.ambrosia.utils.ExposedTestDb
+import pos.ambrosia.utils.FakeLightningBackend
+import pos.ambrosia.utils.PhoenixConnectionException
+import pos.ambrosia.utils.installRoutes
+import pos.ambrosia.utils.installWalletAuth
+import pos.ambrosia.utils.jsonBody
+import pos.ambrosia.utils.routeTest
+import pos.ambrosia.utils.testEnvironment
+import pos.ambrosia.utils.tokenService
+import pos.ambrosia.utils.withAccessTokenOnly
+import pos.ambrosia.utils.withAuthCookies
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class WalletRoutesTest {
+    private val backend = FakeLightningBackend()
+
+    @After
+    fun tearDown() {
+        ActiveLightningBackend.closeActive()
+    }
+
+    @Test
+    fun `wallet endpoints reject an access token without a wallet token`() =
+        walletTest { auth ->
+            val balanceResponse = client.get("/wallet/getbalance") { withAccessTokenOnly(auth) }
+            val seedResponse = client.get("/wallet/seed") { withAccessTokenOnly(auth) }
+
+            assertEquals(HttpStatusCode.Unauthorized, balanceResponse.status)
+            assertEquals(HttpStatusCode.Unauthorized, seedResponse.status)
+        }
+
+    @Test
+    fun `wallet endpoints accept a valid wallet token`() =
+        walletTest { auth ->
+            backend.balanceSat = 4242
+
+            val balanceResponse = client.get("/wallet/getbalance") { withAuthCookies(auth) }
+
+            assertEquals(HttpStatusCode.OK, balanceResponse.status)
+            assertTrue(balanceResponse.bodyAsText().contains("4242"))
+        }
+
+    @Test
+    fun `invoice creation only needs the standard access token`() =
+        walletTest { auth ->
+            val invoiceResponse =
+                client.post("/wallet/invoice") {
+                    withAccessTokenOnly(auth)
+                    jsonBody("""{"description":"coffee","amountSat":1000}""")
+                }
+
+            assertEquals(HttpStatusCode.OK, invoiceResponse.status)
+            assertEquals(1, backend.createInvoiceRequests.size)
+            assertEquals(1000L, backend.createInvoiceRequests.single().amountSat)
+        }
+
+    @Test
+    fun `wallet auth issues a scoped strict cookie for the correct role password`() =
+        walletTest { auth ->
+            val walletAuthResponse =
+                client.post("/wallet/auth") {
+                    withAccessTokenOnly(auth)
+                    jsonBody("""{"password":"wallet-password"}""")
+                }
+
+            assertEquals(HttpStatusCode.OK, walletAuthResponse.status)
+            val setCookie = walletAuthResponse.headers[HttpHeaders.SetCookie] ?: ""
+            assertTrue(setCookie.contains("walletAccessToken="), "expected a walletAccessToken cookie")
+            assertTrue(setCookie.contains("HttpOnly", ignoreCase = true), "wallet cookie must be HttpOnly")
+            assertTrue(setCookie.contains("SameSite=Strict"), "wallet cookie must be SameSite=Strict")
+        }
+
+    @Test
+    fun `wallet auth rejects a wrong role password without issuing a cookie`() =
+        walletTest { auth ->
+            val walletAuthResponse =
+                client.post("/wallet/auth") {
+                    withAccessTokenOnly(auth)
+                    jsonBody("""{"password":"not-the-password"}""")
+                }
+
+            assertEquals(HttpStatusCode.Unauthorized, walletAuthResponse.status)
+            assertNull(walletAuthResponse.headers[HttpHeaders.SetCookie])
+        }
+
+    @Test
+    fun `wallet logout revokes the token in the database`() =
+        walletTest { auth ->
+            val beforeLogout = client.get("/wallet/getbalance") { withAuthCookies(auth) }
+            val logoutResponse = client.post("/wallet/logout") { withAccessTokenOnly(auth) }
+            val afterLogout = client.get("/wallet/getbalance") { withAuthCookies(auth) }
+
+            assertEquals(HttpStatusCode.OK, beforeLogout.status)
+            assertEquals(HttpStatusCode.OK, logoutResponse.status)
+            assertEquals(HttpStatusCode.Unauthorized, afterLogout.status)
+        }
+
+    @Test
+    fun `a token without the wallet access scope is rejected`() =
+        walletTest { auth ->
+            val accessTokenAsWalletCookie = auth.copy(walletAccessToken = auth.accessToken)
+
+            val balanceResponse = client.get("/wallet/getbalance") { withAuthCookies(accessTokenAsWalletCookie) }
+
+            assertEquals(HttpStatusCode.Unauthorized, balanceResponse.status)
+        }
+
+    @Test
+    fun `pay invoice delegates to the lightning backend and echoes the settled amount`() =
+        walletTest { auth ->
+            val payResponse =
+                client.post("/wallet/payinvoice") {
+                    withAuthCookies(auth)
+                    jsonBody("""{"invoice":"lnbc1test","amountSat":2500}""")
+                }
+
+            assertEquals(HttpStatusCode.OK, payResponse.status)
+            assertEquals(1, backend.payInvoiceRequests.size)
+            assertEquals("lnbc1test", backend.payInvoiceRequests.single().invoice)
+            assertTrue(payResponse.bodyAsText().contains("2500"))
+        }
+
+    @Test
+    fun `pay onchain delegates the address and amount to the lightning backend`() =
+        walletTest { auth ->
+            val payResponse =
+                client.post("/wallet/payonchain") {
+                    withAuthCookies(auth)
+                    jsonBody("""{"amountSat":30000,"address":"bc1qtest","feerateSatByte":5}""")
+                }
+
+            assertEquals(HttpStatusCode.OK, payResponse.status)
+            val request = backend.payOnchainRequests.single()
+            assertEquals("bc1qtest", request.address)
+            assertEquals(30000L, request.amountSat)
+        }
+
+    @Test
+    fun `a backend failure on pay invoice surfaces as service unavailable`() =
+        walletTest { auth ->
+            backend.failNextPayment = PhoenixConnectionException()
+
+            val payResponse =
+                client.post("/wallet/payinvoice") {
+                    withAuthCookies(auth)
+                    jsonBody("""{"invoice":"lnbc1test","amountSat":2500}""")
+                }
+
+            assertEquals(HttpStatusCode.ServiceUnavailable, payResponse.status)
+        }
+
+    @Test
+    fun `close channel delegates to the lightning backend`() =
+        walletTest { auth ->
+            val closeResponse =
+                client.post("/wallet/closechannel") {
+                    withAuthCookies(auth)
+                    jsonBody("""{"channelId":"chan-1","address":"bc1qtest","feerateSatByte":3}""")
+                }
+
+            assertEquals(HttpStatusCode.OK, closeResponse.status)
+            assertEquals("chan-1", backend.closeChannelRequests.single().channelId)
+        }
+
+    @Test
+    fun `node info and seed are served from the active backend`() =
+        walletTest { auth ->
+            val infoResponse = client.get("/wallet/getinfo") { withAuthCookies(auth) }
+            val seedResponse = client.get("/wallet/seed") { withAuthCookies(auth) }
+
+            assertEquals(HttpStatusCode.OK, infoResponse.status)
+            assertEquals(HttpStatusCode.OK, seedResponse.status)
+            assertTrue(infoResponse.bodyAsText().contains("fake-backend"))
+        }
+
+    @Test
+    fun `bumping onchain fees and exporting delegate to the backend`() =
+        walletTest { auth ->
+            val bumpResponse =
+                client.post("/wallet/bumpfee") {
+                    withAuthCookies(auth)
+                    jsonBody("5")
+                }
+            val exportResponse =
+                client.post("/wallet/export") {
+                    withAuthCookies(auth)
+                    jsonBody("""{"from":0,"to":0}""")
+                }
+
+            assertEquals(HttpStatusCode.OK, bumpResponse.status)
+            assertEquals(HttpStatusCode.OK, exportResponse.status)
+        }
+
+    @Test
+    fun `an undecodable invoice is a bad request`() =
+        walletTest { auth ->
+            val response =
+                client.post("/wallet/decodeinvoice") {
+                    withAuthCookies(auth)
+                    jsonBody("""{"invoice":"definitely-not-a-bolt11"}""")
+                }
+
+            assertEquals(HttpStatusCode.BadRequest, response.status)
+        }
+
+    @Test
+    fun `changing the wallet password requires both fields`() =
+        walletTest { auth ->
+            val response =
+                client.post("/wallet/password") {
+                    withAuthCookies(auth)
+                    jsonBody("""{"currentPassword":"","newPassword":"whatever"}""")
+                }
+
+            assertEquals(HttpStatusCode.BadRequest, response.status)
+        }
+
+    @Test
+    fun `changing the wallet password rejects a wrong current password`() =
+        walletTest { auth ->
+            val response =
+                client.post("/wallet/password") {
+                    withAuthCookies(auth)
+                    jsonBody("""{"currentPassword":"wrong","newPassword":"new-password"}""")
+                }
+
+            assertEquals(HttpStatusCode.Unauthorized, response.status)
+        }
+
+    @Test
+    fun `changing the wallet password succeeds and the new one authenticates`() =
+        walletTest { auth ->
+            val changeResponse =
+                client.post("/wallet/password") {
+                    withAuthCookies(auth)
+                    jsonBody("""{"currentPassword":"wallet-password","newPassword":"new-password"}""")
+                }
+            val reauthResponse =
+                client.post("/wallet/auth") {
+                    withAccessTokenOnly(auth)
+                    jsonBody("""{"password":"new-password"}""")
+                }
+
+            assertEquals(HttpStatusCode.OK, changeResponse.status)
+            assertEquals(HttpStatusCode.OK, reauthResponse.status)
+        }
+
+    @Test
+    fun `updating the nwc uri is refused when nwc is not the active backend`() =
+        walletTest { auth ->
+            val response =
+                client.post("/wallet/updatenwcuri") {
+                    withAuthCookies(auth)
+                    jsonBody("""{"nwcUri":"nostr+walletconnect://abc"}""")
+                }
+
+            assertEquals(HttpStatusCode.NotImplemented, response.status)
+            assertTrue(response.bodyAsText().contains("provider_switch_not_supported"))
+        }
+
+    @Test
+    fun `a blank nwc uri is a bad request`() =
+        walletTest { auth ->
+            val response =
+                client.post("/wallet/updatenwcuri") {
+                    withAuthCookies(auth)
+                    jsonBody("""{"nwcUri":"   "}""")
+                }
+
+            assertEquals(HttpStatusCode.BadRequest, response.status)
+        }
+
+    @Test
+    fun `incoming payments are listed and marked unrefunded by default`() =
+        walletTest { auth ->
+            backend.incomingPayments =
+                listOf(
+                    IncomingPayment(
+                        type = "incoming_payment",
+                        subType = "lightning",
+                        paymentHash = "hash-in-1",
+                        isPaid = true,
+                        receivedSat = 1500,
+                        fees = 0,
+                        createdAt = 0,
+                    ),
+                )
+
+            val response = client.get("/wallet/payments/incoming") { withAuthCookies(auth) }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            val body = response.bodyAsText()
+            assertTrue(body.contains("hash-in-1"))
+            assertTrue(body.contains("\"refunded\":false"))
+        }
+
+    @Test
+    fun `an incoming payment is enriched with the sale exchange rate`() =
+        walletTest { auth ->
+            ExposedTestDb.seedPayment(
+                paymentHash = "hash-in-2",
+                exchangeRateAtPayment = 65000.0,
+                exchangeRateCurrency = "USD",
+                fiatAmountAtPayment = 9.75,
+            )
+            backend.incomingPayments =
+                listOf(
+                    IncomingPayment(
+                        type = "incoming_payment",
+                        subType = "lightning",
+                        paymentHash = "hash-in-2",
+                        isPaid = true,
+                        receivedSat = 1500,
+                        fees = 0,
+                        createdAt = 0,
+                    ),
+                )
+
+            val response = client.get("/wallet/payments/incoming") { withAuthCookies(auth) }
+
+            val body = response.bodyAsText()
+            assertTrue(body.contains("65000"), "expected the sale exchange rate")
+            assertTrue(body.contains("USD"))
+        }
+
+    @Test
+    fun `outgoing payments are listed`() =
+        walletTest { auth ->
+            backend.outgoingPayments =
+                listOf(
+                    OutgoingPayment(
+                        type = "outgoing_payment",
+                        subType = "lightning",
+                        paymentId = "out-1",
+                        paymentHash = "hash-out-1",
+                        isPaid = true,
+                        sent = 800,
+                        fees = 1,
+                        createdAt = 0,
+                    ),
+                )
+
+            val response = client.get("/wallet/payments/outgoing") { withAuthCookies(auth) }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertTrue(response.bodyAsText().contains("hash-out-1"))
+        }
+
+    @Test
+    fun `a single payment can be fetched by hash and by id`() =
+        walletTest { auth ->
+            val incomingResponse = client.get("/wallet/payments/incoming/hash-1") { withAuthCookies(auth) }
+            val outgoingResponse = client.get("/wallet/payments/outgoing/out-1") { withAuthCookies(auth) }
+            val byHashResponse = client.get("/wallet/payments/outgoingbyhash/hash-1") { withAuthCookies(auth) }
+
+            assertEquals(HttpStatusCode.OK, incomingResponse.status)
+            assertEquals(HttpStatusCode.OK, outgoingResponse.status)
+            assertEquals(HttpStatusCode.OK, byHashResponse.status)
+        }
+
+    @Test
+    fun `payment listings are wallet-scoped`() =
+        walletTest { auth ->
+            val incomingResponse = client.get("/wallet/payments/incoming") { withAccessTokenOnly(auth) }
+            val outgoingResponse = client.get("/wallet/payments/outgoing") { withAccessTokenOnly(auth) }
+
+            assertEquals(HttpStatusCode.Unauthorized, incomingResponse.status)
+            assertEquals(HttpStatusCode.Unauthorized, outgoingResponse.status)
+        }
+
+    @Test
+    fun `unauthenticated requests never reach the wallet`() =
+        walletTest {
+            val balanceResponse = client.get("/wallet/getbalance")
+            val seedResponse = client.get("/wallet/seed")
+            val invoiceResponse =
+                client.post("/wallet/invoice") {
+                    header(HttpHeaders.ContentType, "application/json")
+                    jsonBody("""{"description":"coffee","amountSat":1000}""")
+                }
+
+            assertEquals(HttpStatusCode.Unauthorized, balanceResponse.status)
+            assertEquals(HttpStatusCode.Unauthorized, seedResponse.status)
+            assertEquals(HttpStatusCode.Unauthorized, invoiceResponse.status)
+            assertTrue(backend.createInvoiceRequests.isEmpty())
+        }
+
+    private fun walletTest(block: suspend io.ktor.server.testing.ApplicationTestBuilder.(AuthCookies) -> Unit) =
+        routeTest {
+            ActiveLightningBackend.set(backend)
+            val auth = installWalletAuth()
+            val environment = testEnvironment()
+            installRoutes {
+                routing {
+                    route("/wallet") {
+                        wallet(
+                            tokenService(),
+                            AuthService(environment),
+                            RolesService(environment),
+                            PaymentService(),
+                            WalletRateService(),
+                            RefundService(ActiveLightningBackend),
+                            WalletAdminNotificationService(),
+                        )
+                    }
+                }
+            }
+            block(auth)
+        }
+}

--- a/server/app/src/test/kotlin/pos/ambrosia/utils/AdminAuthTestFixture.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utils/AdminAuthTestFixture.kt
@@ -11,13 +11,16 @@ import pos.ambrosia.models.AuthResponse
 import pos.ambrosia.services.PermissionsService
 import pos.ambrosia.services.TokenService
 
-private const val TEST_SECRET = "admin-auth-test-fixture-secret"
-private const val TEST_ISSUER = "admin-auth-test-fixture-issuer"
-private const val TEST_AUDIENCE = "admin-auth-test-fixture-audience"
+internal const val TEST_SECRET = "admin-auth-test-fixture-secret"
+internal const val TEST_ISSUER = "admin-auth-test-fixture-issuer"
+internal const val TEST_AUDIENCE = "admin-auth-test-fixture-audience"
 
 data class AuthCookies(
     val accessToken: String,
     val refreshToken: String,
+    val walletAccessToken: String? = null,
+    val userId: String = "",
+    val roleId: String = "",
 )
 
 fun ApplicationTestBuilder.installAdminAuth(
@@ -29,6 +32,17 @@ fun ApplicationTestBuilder.installNonAdminAuth(
     roleName: String = "non-admin-test-role",
     userName: String = "non-admin-test-user",
 ): AuthCookies = installAuth(roleName, userName, isAdmin = false)
+
+fun ApplicationTestBuilder.installWalletAuth(
+    roleName: String = "wallet-test-role",
+    userName: String = "wallet-test-user",
+    rolePassword: String = "wallet-password",
+): AuthCookies {
+    val cookies = installAuth(roleName, userName, isAdmin = true)
+    setRolePassword(cookies.roleId, rolePassword)
+    val walletAccessToken = tokenService().generateWalletAccessToken(cookies.userId)
+    return cookies.copy(walletAccessToken = walletAccessToken)
+}
 
 private fun ApplicationTestBuilder.installAuth(
     roleName: String,
@@ -65,10 +79,22 @@ private fun ApplicationTestBuilder.installAuth(
     return AuthCookies(
         accessToken = tokenService.generateAccessToken(seededUser),
         refreshToken = tokenService.generateRefreshToken(seededUser),
+        userId = userId,
+        roleId = roleId,
     )
 }
 
+internal fun tokenService(): TokenService = TokenService(testEnvironment())
+
 fun HttpRequestBuilder.withAuthCookies(cookies: AuthCookies) {
+    val walletCookie = cookies.walletAccessToken?.let { "; walletAccessToken=$it" } ?: ""
+    header(
+        HttpHeaders.Cookie,
+        "accessToken=${cookies.accessToken}; refreshToken=${cookies.refreshToken}$walletCookie",
+    )
+}
+
+fun HttpRequestBuilder.withAccessTokenOnly(cookies: AuthCookies) {
     header(
         HttpHeaders.Cookie,
         "accessToken=${cookies.accessToken}; refreshToken=${cookies.refreshToken}",

--- a/server/app/src/test/kotlin/pos/ambrosia/utils/FakeLightningBackend.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utils/FakeLightningBackend.kt
@@ -17,28 +17,62 @@ import pos.ambrosia.models.phoenix.PhoenixBalance
 import pos.ambrosia.services.LightningBackend
 
 class FakeLightningBackend(
-    private val label: String,
+    private val label: String = "fake-backend",
 ) : LightningBackend {
     var closed = false
         private set
 
+    var balanceSat: Long = 0
+    var failNextPayment: Exception? = null
+    var incomingPaymentIsPaid: Boolean = true
+
+    var incomingPayments: List<IncomingPayment> = emptyList()
+    var outgoingPayments: List<OutgoingPayment> = emptyList()
+
+    val createInvoiceRequests = mutableListOf<CreateInvoiceRequest>()
+    val payInvoiceRequests = mutableListOf<PayInvoiceRequest>()
+    val payOnchainRequests = mutableListOf<PayOnchainRequest>()
+    val closeChannelRequests = mutableListOf<CloseChannelRequest>()
+
     override suspend fun getNodeInfo(): NodeInfo =
         NodeInfo(nodeId = label, channels = emptyList(), chain = "test", blockHeight = 0, version = label)
 
-    override suspend fun getBalance(): PhoenixBalance = PhoenixBalance(balanceSat = 0, feeCreditSat = 0)
+    override suspend fun getBalance(): PhoenixBalance = PhoenixBalance(balanceSat = balanceSat, feeCreditSat = 0)
 
     override suspend fun getSeed(): String = label
 
-    override suspend fun createInvoice(request: CreateInvoiceRequest): CreateInvoiceResponse =
-        CreateInvoiceResponse(amountSat = request.amountSat, paymentHash = label, serialized = label)
+    override suspend fun createInvoice(request: CreateInvoiceRequest): CreateInvoiceResponse {
+        createInvoiceRequests.add(request)
+        return CreateInvoiceResponse(amountSat = request.amountSat, paymentHash = label, serialized = label)
+    }
 
     override suspend fun createOffer(request: CreateOffer): String = label
 
-    override suspend fun payInvoice(request: PayInvoiceRequest): PaymentResponse = fakePaymentResponse()
+    override suspend fun payInvoice(request: PayInvoiceRequest): PaymentResponse {
+        payInvoiceRequests.add(request)
+        failNextPayment?.let { failure ->
+            failNextPayment = null
+            throw failure
+        }
+        return fakePaymentResponse(request.amountSat ?: 0)
+    }
 
-    override suspend fun payOffer(request: PayOfferRequest): PaymentResponse = fakePaymentResponse()
+    override suspend fun payOffer(request: PayOfferRequest): PaymentResponse {
+        failNextPayment?.let { failure ->
+            failNextPayment = null
+            throw failure
+        }
+        return fakePaymentResponse()
+    }
 
-    override suspend fun payOnchain(request: PayOnchainRequest): PaymentResponse = fakePaymentResponse()
+    override suspend fun payOnchain(request: PayOnchainRequest): PaymentResponse {
+        payOnchainRequests.add(request)
+        failNextPayment?.let { failure ->
+            failNextPayment = null
+            throw failure
+        }
+        return fakePaymentResponse(request.amountSat)
+    }
 
     override suspend fun bumpOnchainFees(feerateSatByte: Int): String = label
 
@@ -49,14 +83,14 @@ class FakeLightningBackend(
         offset: Int,
         all: Boolean,
         externalId: String?,
-    ): List<IncomingPayment> = emptyList()
+    ): List<IncomingPayment> = incomingPayments
 
     override suspend fun getIncomingPayment(paymentHash: String): IncomingPayment =
         IncomingPayment(
             type = "incoming_payment",
             subType = "lightning",
             paymentHash = label,
-            isPaid = true,
+            isPaid = incomingPaymentIsPaid,
             receivedSat = 0,
             fees = 0,
             createdAt = 0,
@@ -68,7 +102,7 @@ class FakeLightningBackend(
         limit: Int,
         offset: Int,
         all: Boolean,
-    ): List<OutgoingPayment> = emptyList()
+    ): List<OutgoingPayment> = outgoingPayments
 
     override suspend fun getOutgoingPayment(paymentId: String): OutgoingPayment = fakeOutgoingPayment()
 
@@ -76,15 +110,18 @@ class FakeLightningBackend(
 
     override suspend fun csvExport(request: CsvExport): String = label
 
-    override suspend fun closeChannel(request: CloseChannelRequest): CloseChannelResponse = CloseChannelResponse(txId = label)
+    override suspend fun closeChannel(request: CloseChannelRequest): CloseChannelResponse {
+        closeChannelRequests.add(request)
+        return CloseChannelResponse(txId = label)
+    }
 
     override fun close() {
         closed = true
     }
 
-    private fun fakePaymentResponse() =
+    private fun fakePaymentResponse(recipientAmountSat: Long = 0) =
         PaymentResponse(
-            recipientAmountSat = 0,
+            recipientAmountSat = recipientAmountSat,
             routingFeeSat = 0,
             paymentId = label,
             paymentHash = label,

--- a/server/app/src/test/kotlin/pos/ambrosia/utils/RouteTestSupport.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utils/RouteTestSupport.kt
@@ -1,0 +1,110 @@
+package pos.ambrosia.utils
+
+import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.client.request.header
+import io.ktor.client.request.setBody
+import io.ktor.http.HttpHeaders
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.Application
+import io.ktor.server.application.install
+import io.ktor.server.config.MapApplicationConfig
+import io.ktor.server.engine.applicationEnvironment
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import pos.ambrosia.api.handler
+import pos.ambrosia.configureAuthentication
+import pos.ambrosia.db.tables.PermissionEntity
+import pos.ambrosia.db.tables.PermissionsTable
+import pos.ambrosia.db.tables.RoleEntity
+import pos.ambrosia.db.tables.UserEntity
+import pos.ambrosia.services.PermissionsService
+import java.util.UUID
+
+fun routeTest(block: suspend ApplicationTestBuilder.() -> Unit) {
+    val databaseFile = ExposedTestDb.connect()
+    try {
+        testApplication { block() }
+    } finally {
+        ExposedTestDb.cleanup(databaseFile)
+    }
+}
+
+fun ApplicationTestBuilder.installAuthenticationWithoutUser(secret: String = TEST_SECRET) {
+    environment {
+        config =
+            MapApplicationConfig(
+                "secret" to secret,
+                "jwt.issuer" to TEST_ISSUER,
+                "jwt.audience" to TEST_AUDIENCE,
+            )
+    }
+    application { configureAuthentication() }
+}
+
+fun ApplicationTestBuilder.installRoutes(setup: Application.() -> Unit) {
+    application {
+        install(ContentNegotiation) { json() }
+        handler()
+        setup()
+    }
+}
+
+fun HttpRequestBuilder.jsonBody(body: String) {
+    header(HttpHeaders.ContentType, "application/json")
+    setBody(body)
+}
+
+fun grantPermissions(
+    roleName: String,
+    vararg permissions: String,
+) {
+    val roleId = ExposedTestDb.seedRole(roleName)
+    permissions.forEach { permission -> ensurePermission(permission) }
+    PermissionsService().replaceRolePermissions(roleId, permissions.toList())
+}
+
+private fun ensurePermission(name: String): String =
+    transaction {
+        PermissionEntity
+            .find { PermissionsTable.name eq name }
+            .firstOrNull()
+            ?.id
+            ?.value
+            ?.toString()
+            ?: ExposedTestDb.seedPermission(name)
+    }
+
+fun setRolePassword(
+    roleId: String,
+    password: String,
+    secret: String = TEST_SECRET,
+) {
+    val hash = SecurePinProcessor.hashPinForStorage(password.toCharArray(), roleId, testEnvironment(secret))
+    transaction {
+        RoleEntity.findById(UUID.fromString(roleId))?.password = SecurePinProcessor.byteArrayToBase64(hash)
+    }
+}
+
+fun setUserPin(
+    userId: String,
+    pin: String,
+    secret: String = TEST_SECRET,
+) {
+    val hash = SecurePinProcessor.hashPinForStorage(pin.toCharArray(), userId, testEnvironment(secret))
+    transaction {
+        UserEntity.findById(UUID.fromString(userId))?.pin = SecurePinProcessor.byteArrayToBase64(hash)
+    }
+}
+
+fun testEnvironment(secret: String = TEST_SECRET) =
+    applicationEnvironment {
+        config =
+            MapApplicationConfig(
+                "secret" to secret,
+                "jwt.issuer" to TEST_ISSUER,
+                "jwt.audience" to TEST_AUDIENCE,
+            )
+    }

--- a/server/docs/TEST_COVERAGE.md
+++ b/server/docs/TEST_COVERAGE.md
@@ -1,0 +1,215 @@
+# Cobertura de tests del server — estado y prioridades
+
+Documento de referencia para planificar el refactor de arquitectura del server. Mide dónde está
+la red de seguridad hoy, qué se cubrió en la última pasada y qué queda pendiente por orden de
+urgencia.
+
+Medición: `./gradlew koverXmlReport` sobre la rama `development`.
+
+## Por qué importa la distribución, no el total
+
+Los tests que protegen un cambio de arquitectura son los de **contrato HTTP** (entra request →
+sale status + body): sobreviven a que se reorganicen las capas de dentro. Los tests de servicio,
+atados a la implementación, son justo lo que un refactor rompe y obliga a reescribir.
+
+El punto de partida tenía esa proporción invertida: la capa de servicios al 88% y la capa HTTP al
+12.3%. Los 2.003 renglones sin cubrir de `api/` eran a la vez el mayor hueco de cobertura y la
+frontera que debe quedar congelada durante el refactor.
+
+**Matiz sobre la suite e2e.** Los 30 módulos Python de `e2e_tests_py/` (~237 tests) sí ejercen
+muchas de estas rutas, pero corren contra un proceso de servidor aparte, así que Kover no los ve.
+Cubren contratos, pero arrancan un servidor real y tardan minutos: no sirven como red de bucle
+corto durante un refactor. Los tests de ruta en JVM sí. Las dos suites son complementarias.
+
+## Estado actual
+
+| Métrica | Antes | Ahora |
+|---|---|---|
+| Línea | 63.6% | **74.2%** |
+| Rama | 28.2% | **37.4%** |
+| Método | 71.6% | 79.8% |
+| Clase | 56.1% | 70.7% |
+
+| Paquete | Antes | Ahora | Sin cubrir |
+|---|---|---|---|
+| `pos/ambrosia/api` | 12.3% | **44.1%** | 1.276 |
+| `pos/ambrosia/services` | 88.0% | 91.1% | 411 |
+| `pos/ambrosia/utils` | 64.5% | 72.1% | 55 |
+| `pos/ambrosia/models` | 77.8% | 89.8% | 74 |
+| `pos/ambrosia` (Api.kt, Ambrosia.kt) | 11.1% | 16.6% | 226 |
+| `pos/ambrosia/nwc` | 40.1% | 40.1% | 182 |
+| `pos/ambrosia/config` | 31.0% | 31.0% | 87 |
+| `pos/ambrosia/db/tables` | 92.7% | 92.7% | 48 |
+
+Suite: **873 tests, 0 fallos**, 59 clases. Cada clase nueva pasa también en solitario
+(`--tests <Clase> --rerun-tasks`), que es donde se delataría un seam de estado global mal cerrado.
+
+`koverVerify` corre en CI (`.github/workflows/server_unit_tests.yml`). El suelo del ratchet está en
+`app/build.gradle.kts`, dos puntos por debajo de lo medido: **70% línea / 33% rama**.
+
+## Cubierto en esta pasada (P0 + P1)
+
+128 tests nuevos en 8 ficheros, en `app/src/test/kotlin/pos/ambrosia/utest/`.
+
+| Fichero de producción | Antes | Ahora | Test |
+|---|---|---|---|
+| `api/Checkout.kt` | 0.0% | 85.2% | `CheckoutRoutesTest` (15) |
+| `api/Authorize.kt` | 0.0% | 84.2% | `AuthorizeRoutesTest` (14) |
+| `api/Orders.kt` | 0.0% | 82.9% | `OrdersRoutesTest` (24) |
+| `utils/AuthUtils.kt` | 66.2% | 81.7% | `AuthUtilsTest` (10) |
+| `api/Uploads.kt` | 0.0% | 80.0% | `UploadsRoutesTest` (6) |
+| `api/Products.kt` | 0.0% | 76.6% | `ProductsRoutesTest` (18) |
+| `api/Wallet.kt` | 0.0% | 72.9% | `WalletRoutesTest` (25) |
+| `api/ProductVariants.kt` | 0.0% | 66.7% | `ProductsRoutesTest` |
+| `api/Payments.kt` | 0.0% | 66.4% | `PaymentsRoutesTest` (16) |
+| `api/StoreOrders.kt` | 0.0% | 54.5% | `CheckoutRoutesTest` |
+| `api/Handler.kt` | 43.1% | 50.5% | de rebote, en todos |
+
+### Contratos que quedan fijados
+
+Lo que estos tests congelan de cara al refactor, más allá del CRUD:
+
+- **Separación de esquemas del wallet.** `walletAccessToken` con `scope=wallet_access` y cookie
+  `HttpOnly`/`SameSite=Strict`; el logout revoca contra la BD (`users.wallet_token`), no solo por
+  firma. `POST /wallet/invoice` es la excepción declarada que va con `accessToken` a secas.
+- **Rate limiter de login.** Bloqueo tras 5 fallos con `Retry-After`, y un login correcto no
+  atraviesa el bloqueo. Un login válido resetea el contador.
+- **PIN legacy de 4 dígitos.** La regla de 6 dígitos es de alta/edición; `/auth/login` nunca debe
+  validar longitud.
+- **`requireAdmin()` depende de la cookie `refreshToken`**, no del principal JWT ya validado.
+- **Uploads sin auth solo antes del initial setup**, y el nombre de fichero del cliente se descarta
+  (solo sobrevive la extensión), así que no hay traversal.
+- **`POST /products/stock` va con `orders_create`**, no con `products_update`.
+- **El descuento en checkout es un `requirePermission` en línea**, no un decorador de ruta.
+- **Idempotencia de checkout**: repetir el mismo `paymentHash` devuelve la venta original (200),
+  no crea una segunda (201). Una factura sin liquidar responde 202 `pending`, no una venta.
+- **Cancelación de pedido de tienda** solo sobre pedidos `open` y sin mesa.
+
+## Bugs encontrados y corregidos
+
+Los tres los destapó la cobertura nueva; los tres eran fallos reales en producción.
+
+1. **`GET /orders/{id}/complete` devolvía 500.** `CompleteOrder` cruzaba el límite HTTP sin
+   `@Serializable`. El endpoint nunca funcionó.
+2. **`POST /orders/with-dishes` devolvía 500.** Mismo motivo, en `OrderWithDishesRequest`.
+3. **`PUT /orders/{id}/calculate-total` devolvía 500.** Respondía un
+   `mapOf("message" to String, "total" to Double)`, es decir un `Map<String, Any>` que kotlinx no
+   sabe serializar. Sustituido por un `OrderTotalResponse` serializable que conserva el mismo JSON.
+
+**Patrón a vigilar**: un modelo sin `@Serializable` o un `Map` heterogéneo en un `respond`/`receive`
+compila sin problemas y solo falla en tiempo de ejecución. Los `Map` homogéneos
+(`Map<String,String>`, `Map<String,Int>`) sí serializan. Queda un caso sin verificar fuera del
+alcance de esta pasada: `api/Routing.kt:19`, `mapOf("currency_id" to null)` en la ruta pública
+`/base-currency`.
+
+## Pendiente, por orden de urgencia
+
+### P2 — Superficie admin/config
+
+| Fichero | Cobertura | Sin cubrir | Por qué |
+|---|---|---|---|
+| `api/AdminNotifications.kt` | 2.5% | 119 | 9 endpoints admin más suscripciones web-push |
+| `api/InitialSetup.kt` | 21.0% | 79 | Sin auth; crea el primer admin y recarga el backend lightning |
+| `api/Reports.kt` | 0.0% | 71 | El servicio está al 96%, las rutas a cero |
+| `api/Shifts.kt` | 0.0% | 66 | `POST /{id}/close` cuelga de `shifts_create`, no de `shifts_update` |
+| `api/Users.kt` | 34.0% | 64 | `/public` sin auth; `requireAdmin()` en línea al tocar rol admin |
+| `api/Roles.kt` | 32.9% | 51 | `PUT /{id}/permissions` dentro del bloque admin de `roles_update` |
+| `api/Handler.kt` | 50.5% | 54 | **Rama al 5.3%**: ~30 mapeos de excepción casi sin ejercitar |
+| `api/Printers.kt` | 0.0% | 56 | Lecturas con `auth-jwt` a secas, mutaciones con `printer_update` |
+
+`Handler.kt` merece atención propia: es el que decide qué status ve el cliente ante cada
+excepción, y un refactor que mueva excepciones de sitio lo rompe en silencio. Sube algo de rebote
+con cada test de ruta, pero su cobertura de rama sigue en 5.3%.
+
+### P3 — CRUD de cola larga
+
+`Categories.kt` (59), `Tables.kt` (53), `Ingredients.kt` (53), `Suppliers.kt` (45), `Spaces.kt`
+(43), `Tickets.kt` (43), `Dishes.kt` (41), `TicketTemplates.kt` (34), `Currency.kt` (24), todos al
+0%. ~395 líneas. Mecánico: un fichero de test por módulo siguiendo el patrón ya establecido.
+
+### P4 — Servicios con rama floja
+
+| Fichero | Línea | Rama |
+|---|---|---|
+| `services/PrintService.kt` | 18.2% | 7.5% |
+| `services/AuthService.kt` | 42.0% | 25.0% |
+| `services/WalletAdminNotificationService.kt` | 43.2% | 26.8% |
+| `services/UsersService.kt` | 45.9% | 31.4% |
+| `services/ActiveLightningBackend.kt` | 33.3% | 30.0% |
+| `services/TokenService.kt` | 83.2% | 36.7% |
+| `nwc/NwcClient.kt` | 19.2% | — |
+| `nwc/NostrEvent.kt` | 0.0% | — |
+
+`NostrEvent.createSignedEvent` (firma Schnorr) y `NwcClient` (cifrado NIP-04/NIP-47) están sin
+cubrir y son criptografía sobre el camino del dinero cuando NWC es el backend activo.
+
+### No merece la pena
+
+`Ambrosia.kt` (175 líneas, CLI Clikt), `config/InjectLogs.kt`, `config/SeedGenerator.kt`,
+`config/AppConfig.kt`, `models/` restante (serialización), `db/tables/` (declarativo).
+
+## Cómo escribir un test de ruta
+
+La infraestructura vive en `app/src/test/kotlin/pos/ambrosia/utils/`.
+
+Casi todos los módulos de `api/` ya separan la construcción de dependencias de la definición de
+rutas, y ese seam es lo que hace el test barato:
+
+```kotlin
+fun Application.configureOrders() { /* construye servicios reales */ }
+fun Route.orders(orderService: OrderService) { /* rutas */ }
+```
+
+El test monta el `fun Route.xxx(...)` con dependencias controladas y se salta el `configureXxx()`:
+
+```kotlin
+private fun ordersTest(block: suspend ApplicationTestBuilder.(AuthCookies) -> Unit) =
+    routeTest {                                   // SQLite temporal + cleanup garantizado
+        val auth = installAdminAuth()             // instala auth-jwt y auth-jwt-wallet, siembra usuario
+        grantPermissions("admin-test-role", "orders_read", "orders_create")
+        installRoutes {                           // ContentNegotiation + handler() + el módulo
+            routing { route("/orders") { orders(OrderService()) } }
+        }
+        block(auth)
+    }
+```
+
+Piezas disponibles:
+
+| Helper | Fichero | Para qué |
+|---|---|---|
+| `routeTest { }` | `RouteTestSupport.kt` | Abre la BD temporal y la limpia en `finally` |
+| `installRoutes { }` | `RouteTestSupport.kt` | `ContentNegotiation` + `handler()` + rutas |
+| `grantPermissions(rol, vararg)` | `RouteTestSupport.kt` | Crea permisos si faltan y los asigna |
+| `jsonBody("…")` | `RouteTestSupport.kt` | `Content-Type` + cuerpo |
+| `installAuthentication()` | `RouteTestSupport.kt` | Solo los esquemas, sin sembrar usuario |
+| `setUserPin` / `setRolePassword` | `RouteTestSupport.kt` | Credenciales con hash PBKDF2 real |
+| `installAdminAuth` / `installNonAdminAuth` / `installWalletAuth` | `AdminAuthTestFixture.kt` | Cookies de sesión |
+| `withAuthCookies` / `withAccessTokenOnly` | `AdminAuthTestFixture.kt` | Con o sin cookie de wallet |
+| `ExposedTestDb.seedX(...)` | `ExposedTestDb.kt` | ~35 factorías de datos |
+| `FakeLightningBackend` | `FakeLightningBackend.kt` | Backend lightning falso, registra llamadas |
+
+Convenciones del repo: JUnit 4 (`org.junit.Before`/`After`) con `kotlin.test.Test`, `runBlocking`
+(no `runTest`), mockito-kotlin (no MockK), nombres de test entre backticks en inglés, paquete
+`pos.ambrosia.utest`.
+
+Dos avisos de estado global, que es donde se rompe el aislamiento entre tests:
+
+- `LoginRateLimiter` (`api/Authorize.kt`) es un objeto de proceso cacheado por IP, y en
+  `testApplication` todas las peticiones comparten dirección. Llama a `LoginRateLimiter.resetAll()`
+  en el `@Before`. A largo plazo lo correcto es inyectarlo en `Route.auth(...)`.
+- `ActiveLightningBackend` es un singleton. Ponlo con `set(FakeLightningBackend())` y suéltalo con
+  `closeActive()` en el `@After`.
+
+Los ficheros de test anteriores a esta pasada siguen con su pareja `@Before`/`@After` a mano; no se
+migraron. Los nuevos usan `routeTest`.
+
+## Comandos
+
+```bash
+./gradlew test                              # suite completa
+./gradlew test --tests "WalletRoutesTest"   # una clase
+./gradlew koverHtmlReport                   # app/build/reports/kover/html/index.html
+./gradlew :app:koverVerify                  # el ratchet que corre en CI
+./gradlew ktlintFormat                      # obligatorio antes del PR
+```

--- a/server/docs/TEST_COVERAGE.md
+++ b/server/docs/TEST_COVERAGE.md
@@ -1,38 +1,37 @@
-# Cobertura de tests del server — estado y prioridades
+# Server test coverage — state and priorities
 
-Documento de referencia para planificar el refactor de arquitectura del server. Mide dónde está
-la red de seguridad hoy, qué se cubrió en la última pasada y qué queda pendiente por orden de
-urgencia.
+Reference document for planning the server architecture refactor. It measures where the safety net
+stands today, what the last pass covered, and what is still pending, in order of urgency.
 
-Medición: `./gradlew koverXmlReport` sobre la rama `development`.
+Measured with `./gradlew koverXmlReport`.
 
-## Por qué importa la distribución, no el total
+## Why the distribution matters more than the total
 
-Los tests que protegen un cambio de arquitectura son los de **contrato HTTP** (entra request →
-sale status + body): sobreviven a que se reorganicen las capas de dentro. Los tests de servicio,
-atados a la implementación, son justo lo que un refactor rompe y obliga a reescribir.
+The tests that protect an architecture change are the **HTTP contract** ones (request in → status
+and body out): they survive the inner layers being rearranged. Service tests, bound to the
+implementation, are exactly what a refactor breaks and forces you to rewrite.
 
-El punto de partida tenía esa proporción invertida: la capa de servicios al 88% y la capa HTTP al
-12.3%. Los 2.003 renglones sin cubrir de `api/` eran a la vez el mayor hueco de cobertura y la
-frontera que debe quedar congelada durante el refactor.
+The starting point had that ratio inverted: the service layer at 88% and the HTTP layer at 12.3%.
+The 2,003 uncovered lines in `api/` were both the largest coverage gap and the boundary that has to
+stay frozen during the refactor.
 
-**Matiz sobre la suite e2e.** Los 30 módulos Python de `e2e_tests_py/` (~237 tests) sí ejercen
-muchas de estas rutas, pero corren contra un proceso de servidor aparte, así que Kover no los ve.
-Cubren contratos, pero arrancan un servidor real y tardan minutos: no sirven como red de bucle
-corto durante un refactor. Los tests de ruta en JVM sí. Las dos suites son complementarias.
+**A note on the e2e suite.** The 30 Python modules in `e2e_tests_py/` (~237 tests) do exercise many
+of these routes, but they run against a separate server process, so Kover does not see them. They
+cover contracts, but they boot a real server and take minutes: they are not a short-loop safety net
+during a refactor. JVM route tests are. The two suites are complementary.
 
-## Estado actual
+## Current state
 
-| Métrica | Antes | Ahora |
+| Metric | Before | Now |
 |---|---|---|
-| Línea | 63.6% | **74.2%** |
-| Rama | 28.2% | **37.4%** |
-| Método | 71.6% | 79.8% |
-| Clase | 56.1% | 70.7% |
+| Line | 63.6% | **74.2%** |
+| Branch | 28.2% | **37.4%** |
+| Method | 71.6% | 79.8% |
+| Class | 56.1% | 70.7% |
 
-| Paquete | Antes | Ahora | Sin cubrir |
+| Package | Before | Now | Uncovered |
 |---|---|---|---|
-| `pos/ambrosia/api` | 12.3% | **44.1%** | 1.276 |
+| `pos/ambrosia/api` | 12.3% | **44.1%** | 1,276 |
 | `pos/ambrosia/services` | 88.0% | 91.1% | 411 |
 | `pos/ambrosia/utils` | 64.5% | 72.1% | 55 |
 | `pos/ambrosia/models` | 77.8% | 89.8% | 74 |
@@ -41,17 +40,17 @@ corto durante un refactor. Los tests de ruta en JVM sí. Las dos suites son comp
 | `pos/ambrosia/config` | 31.0% | 31.0% | 87 |
 | `pos/ambrosia/db/tables` | 92.7% | 92.7% | 48 |
 
-Suite: **873 tests, 0 fallos**, 59 clases. Cada clase nueva pasa también en solitario
-(`--tests <Clase> --rerun-tasks`), que es donde se delataría un seam de estado global mal cerrado.
+Suite: **873 tests, 0 failures**, 59 classes. Every new class also passes on its own
+(`--tests <Class> --rerun-tasks`), which is where a badly closed global-state seam would show up.
 
-`koverVerify` corre en CI (`.github/workflows/server_unit_tests.yml`). El suelo del ratchet está en
-`app/build.gradle.kts`, dos puntos por debajo de lo medido: **70% línea / 33% rama**.
+`koverVerify` runs in CI (`.github/workflows/server_unit_tests.yml`). The ratchet floor lives in
+`app/build.gradle.kts`, a couple of points below what was measured: **70% line / 33% branch**.
 
-## Cubierto en esta pasada (P0 + P1)
+## Covered in this pass (P0 + P1)
 
-128 tests nuevos en 8 ficheros, en `app/src/test/kotlin/pos/ambrosia/utest/`.
+128 new tests across 8 files, in `app/src/test/kotlin/pos/ambrosia/utest/`.
 
-| Fichero de producción | Antes | Ahora | Test |
+| Production file | Before | Now | Test |
 |---|---|---|---|
 | `api/Checkout.kt` | 0.0% | 85.2% | `CheckoutRoutesTest` (15) |
 | `api/Authorize.kt` | 0.0% | 84.2% | `AuthorizeRoutesTest` (14) |
@@ -63,73 +62,75 @@ Suite: **873 tests, 0 fallos**, 59 clases. Cada clase nueva pasa también en sol
 | `api/ProductVariants.kt` | 0.0% | 66.7% | `ProductsRoutesTest` |
 | `api/Payments.kt` | 0.0% | 66.4% | `PaymentsRoutesTest` (16) |
 | `api/StoreOrders.kt` | 0.0% | 54.5% | `CheckoutRoutesTest` |
-| `api/Handler.kt` | 43.1% | 50.5% | de rebote, en todos |
+| `api/Handler.kt` | 43.1% | 50.5% | incidentally, from all of them |
 
-### Contratos que quedan fijados
+### Contracts now pinned
 
-Lo que estos tests congelan de cara al refactor, más allá del CRUD:
+What these tests freeze ahead of the refactor, beyond plain CRUD:
 
-- **Separación de esquemas del wallet.** `walletAccessToken` con `scope=wallet_access` y cookie
-  `HttpOnly`/`SameSite=Strict`; el logout revoca contra la BD (`users.wallet_token`), no solo por
-  firma. `POST /wallet/invoice` es la excepción declarada que va con `accessToken` a secas.
-- **Rate limiter de login.** Bloqueo tras 5 fallos con `Retry-After`, y un login correcto no
-  atraviesa el bloqueo. Un login válido resetea el contador.
-- **PIN legacy de 4 dígitos.** La regla de 6 dígitos es de alta/edición; `/auth/login` nunca debe
-  validar longitud.
-- **`requireAdmin()` depende de la cookie `refreshToken`**, no del principal JWT ya validado.
-- **Uploads sin auth solo antes del initial setup**, y el nombre de fichero del cliente se descarta
-  (solo sobrevive la extensión), así que no hay traversal.
-- **`POST /products/stock` va con `orders_create`**, no con `products_update`.
-- **El descuento en checkout es un `requirePermission` en línea**, no un decorador de ruta.
-- **Idempotencia de checkout**: repetir el mismo `paymentHash` devuelve la venta original (200),
-  no crea una segunda (201). Una factura sin liquidar responde 202 `pending`, no una venta.
-- **Cancelación de pedido de tienda** solo sobre pedidos `open` y sin mesa.
+- **Wallet scheme separation.** `walletAccessToken` carries `scope=wallet_access` on an
+  `HttpOnly`/`SameSite=Strict` cookie; logout revokes against the database (`users.wallet_token`),
+  not just by signature. `POST /wallet/invoice` is the declared exception that works with a plain
+  `accessToken`.
+- **Login rate limiter.** Blocks after 5 failures with `Retry-After`, and a correct login does not
+  get through the block. A successful login resets the counter.
+- **Legacy 4-digit PINs.** The 6-digit rule belongs to user creation and editing; `/auth/login`
+  must never validate length.
+- **`requireAdmin()` depends on the `refreshToken` cookie**, not on the already-validated JWT
+  principal.
+- **Uploads are unauthenticated only before initial setup**, and the client filename is discarded
+  (only the extension survives), so there is no traversal.
+- **`POST /products/stock` is guarded by `orders_create`**, not by `products_update`.
+- **The checkout discount check is an inline `requirePermission`**, not a route decorator.
+- **Checkout idempotency**: replaying the same `paymentHash` returns the original sale (200), it
+  does not create a second one (201). An unsettled invoice answers 202 `pending`, not a sale.
+- **Store order cancellation** applies only to `open` orders with no table.
 
-## Bugs encontrados y corregidos
+## Bugs found and fixed
 
-Los tres los destapó la cobertura nueva; los tres eran fallos reales en producción.
+All three were surfaced by the new coverage, and all three were real production failures.
 
-1. **`GET /orders/{id}/complete` devolvía 500.** `CompleteOrder` cruzaba el límite HTTP sin
-   `@Serializable`. El endpoint nunca funcionó.
-2. **`POST /orders/with-dishes` devolvía 500.** Mismo motivo, en `OrderWithDishesRequest`.
-3. **`PUT /orders/{id}/calculate-total` devolvía 500.** Respondía un
-   `mapOf("message" to String, "total" to Double)`, es decir un `Map<String, Any>` que kotlinx no
-   sabe serializar. Sustituido por un `OrderTotalResponse` serializable que conserva el mismo JSON.
+1. **`GET /orders/{id}/complete` returned 500.** `CompleteOrder` crossed the HTTP boundary without
+   `@Serializable`. The endpoint had never worked.
+2. **`POST /orders/with-dishes` returned 500.** Same cause, in `OrderWithDishesRequest`.
+3. **`PUT /orders/{id}/calculate-total` returned 500.** It responded with
+   `mapOf("message" to String, "total" to Double)` — a `Map<String, Any>` kotlinx cannot serialize.
+   Replaced by a serializable `OrderTotalResponse` that keeps the same JSON shape.
 
-**Patrón a vigilar**: un modelo sin `@Serializable` o un `Map` heterogéneo en un `respond`/`receive`
-compila sin problemas y solo falla en tiempo de ejecución. Los `Map` homogéneos
-(`Map<String,String>`, `Map<String,Int>`) sí serializan. Queda un caso sin verificar fuera del
-alcance de esta pasada: `api/Routing.kt:19`, `mapOf("currency_id" to null)` en la ruta pública
-`/base-currency`.
+**Pattern to watch for**: a model without `@Serializable`, or a heterogeneous `Map`, inside a
+`respond`/`receive` compiles fine and only fails at runtime. Homogeneous maps
+(`Map<String,String>`, `Map<String,Int>`) do serialize. One case is still unverified, outside the
+scope of this pass: `api/Routing.kt:19`, `mapOf("currency_id" to null)` on the public
+`/base-currency` route.
 
-## Pendiente, por orden de urgencia
+## Pending, in order of urgency
 
-### P2 — Superficie admin/config
+### P2 — Admin and config surface
 
-| Fichero | Cobertura | Sin cubrir | Por qué |
+| File | Coverage | Uncovered | Why |
 |---|---|---|---|
-| `api/AdminNotifications.kt` | 2.5% | 119 | 9 endpoints admin más suscripciones web-push |
-| `api/InitialSetup.kt` | 21.0% | 79 | Sin auth; crea el primer admin y recarga el backend lightning |
-| `api/Reports.kt` | 0.0% | 71 | El servicio está al 96%, las rutas a cero |
-| `api/Shifts.kt` | 0.0% | 66 | `POST /{id}/close` cuelga de `shifts_create`, no de `shifts_update` |
-| `api/Users.kt` | 34.0% | 64 | `/public` sin auth; `requireAdmin()` en línea al tocar rol admin |
-| `api/Roles.kt` | 32.9% | 51 | `PUT /{id}/permissions` dentro del bloque admin de `roles_update` |
-| `api/Handler.kt` | 50.5% | 54 | **Rama al 5.3%**: ~30 mapeos de excepción casi sin ejercitar |
-| `api/Printers.kt` | 0.0% | 56 | Lecturas con `auth-jwt` a secas, mutaciones con `printer_update` |
+| `api/AdminNotifications.kt` | 2.5% | 119 | 9 admin endpoints plus web-push subscriptions |
+| `api/InitialSetup.kt` | 21.0% | 79 | No auth; creates the first admin and reloads the lightning backend |
+| `api/Reports.kt` | 0.0% | 71 | The service is at 96%, the routes at zero |
+| `api/Shifts.kt` | 0.0% | 66 | `POST /{id}/close` hangs off `shifts_create`, not `shifts_update` |
+| `api/Users.kt` | 34.0% | 64 | `/public` has no auth; inline `requireAdmin()` when the admin role is involved |
+| `api/Roles.kt` | 32.9% | 51 | `PUT /{id}/permissions` sits inside the `roles_update` admin block |
+| `api/Handler.kt` | 50.5% | 54 | **Branch at 5.3%**: ~30 exception mappings barely exercised |
+| `api/Printers.kt` | 0.0% | 56 | Reads use plain `auth-jwt`, mutations use `printer_update` |
 
-`Handler.kt` merece atención propia: es el que decide qué status ve el cliente ante cada
-excepción, y un refactor que mueva excepciones de sitio lo rompe en silencio. Sube algo de rebote
-con cada test de ruta, pero su cobertura de rama sigue en 5.3%.
+`Handler.kt` deserves attention of its own: it decides which status the client sees for every
+exception, and a refactor that moves exceptions around breaks it silently. It rises incidentally
+with each route test, but its branch coverage is still 5.3%.
 
-### P3 — CRUD de cola larga
+### P3 — CRUD long tail
 
 `Categories.kt` (59), `Tables.kt` (53), `Ingredients.kt` (53), `Suppliers.kt` (45), `Spaces.kt`
-(43), `Tickets.kt` (43), `Dishes.kt` (41), `TicketTemplates.kt` (34), `Currency.kt` (24), todos al
-0%. ~395 líneas. Mecánico: un fichero de test por módulo siguiendo el patrón ya establecido.
+(43), `Tickets.kt` (43), `Dishes.kt` (41), `TicketTemplates.kt` (34), `Currency.kt` (24), all at
+0%. ~395 lines. Mechanical: one test file per module following the established pattern.
 
-### P4 — Servicios con rama floja
+### P4 — Services with weak branch coverage
 
-| Fichero | Línea | Rama |
+| File | Line | Branch |
 |---|---|---|
 | `services/PrintService.kt` | 18.2% | 7.5% |
 | `services/AuthService.kt` | 42.0% | 25.0% |
@@ -140,76 +141,84 @@ con cada test de ruta, pero su cobertura de rama sigue en 5.3%.
 | `nwc/NwcClient.kt` | 19.2% | — |
 | `nwc/NostrEvent.kt` | 0.0% | — |
 
-`NostrEvent.createSignedEvent` (firma Schnorr) y `NwcClient` (cifrado NIP-04/NIP-47) están sin
-cubrir y son criptografía sobre el camino del dinero cuando NWC es el backend activo.
+`NostrEvent.createSignedEvent` (Schnorr signing) and `NwcClient` (NIP-04/NIP-47 encryption) are
+uncovered, and they are cryptography on the money path whenever NWC is the active backend.
 
-### No merece la pena
+### Not worth it
 
-`Ambrosia.kt` (175 líneas, CLI Clikt), `config/InjectLogs.kt`, `config/SeedGenerator.kt`,
-`config/AppConfig.kt`, `models/` restante (serialización), `db/tables/` (declarativo).
+`Ambrosia.kt` (175 lines, Clikt CLI), `config/InjectLogs.kt`, `config/SeedGenerator.kt`,
+`config/AppConfig.kt`, the rest of `models/` (serialization), `db/tables/` (declarative).
 
-## Cómo escribir un test de ruta
+## How to write a route test
 
-La infraestructura vive en `app/src/test/kotlin/pos/ambrosia/utils/`.
+The infrastructure lives in `app/src/test/kotlin/pos/ambrosia/utils/`.
 
-Casi todos los módulos de `api/` ya separan la construcción de dependencias de la definición de
-rutas, y ese seam es lo que hace el test barato:
+Almost every module in `api/` already separates dependency construction from route definition, and
+that seam is what makes the test cheap:
 
 ```kotlin
-fun Application.configureOrders() { /* construye servicios reales */ }
-fun Route.orders(orderService: OrderService) { /* rutas */ }
+fun Application.configureOrders() { /* builds real services */ }
+fun Route.orders(orderService: OrderService) { /* routes */ }
 ```
 
-El test monta el `fun Route.xxx(...)` con dependencias controladas y se salta el `configureXxx()`:
+The test mounts `fun Route.xxx(...)` with controlled dependencies and skips `configureXxx()`:
 
 ```kotlin
 private fun ordersTest(block: suspend ApplicationTestBuilder.(AuthCookies) -> Unit) =
-    routeTest {                                   // SQLite temporal + cleanup garantizado
-        val auth = installAdminAuth()             // instala auth-jwt y auth-jwt-wallet, siembra usuario
+    routeTest {
+        val auth = installAdminAuth()
         grantPermissions("admin-test-role", "orders_read", "orders_create")
-        installRoutes {                           // ContentNegotiation + handler() + el módulo
+        installRoutes {
             routing { route("/orders") { orders(OrderService()) } }
         }
         block(auth)
     }
 ```
 
-Piezas disponibles:
+`routeTest` opens the temporary SQLite database and guarantees cleanup; `installAdminAuth` installs
+both auth schemes and seeds a user; `installRoutes` adds `ContentNegotiation` and `handler()` on top
+of the module under test.
 
-| Helper | Fichero | Para qué |
+Available pieces:
+
+| Helper | File | Purpose |
 |---|---|---|
-| `routeTest { }` | `RouteTestSupport.kt` | Abre la BD temporal y la limpia en `finally` |
-| `installRoutes { }` | `RouteTestSupport.kt` | `ContentNegotiation` + `handler()` + rutas |
-| `grantPermissions(rol, vararg)` | `RouteTestSupport.kt` | Crea permisos si faltan y los asigna |
-| `jsonBody("…")` | `RouteTestSupport.kt` | `Content-Type` + cuerpo |
-| `installAuthentication()` | `RouteTestSupport.kt` | Solo los esquemas, sin sembrar usuario |
-| `setUserPin` / `setRolePassword` | `RouteTestSupport.kt` | Credenciales con hash PBKDF2 real |
-| `installAdminAuth` / `installNonAdminAuth` / `installWalletAuth` | `AdminAuthTestFixture.kt` | Cookies de sesión |
-| `withAuthCookies` / `withAccessTokenOnly` | `AdminAuthTestFixture.kt` | Con o sin cookie de wallet |
-| `ExposedTestDb.seedX(...)` | `ExposedTestDb.kt` | ~35 factorías de datos |
-| `FakeLightningBackend` | `FakeLightningBackend.kt` | Backend lightning falso, registra llamadas |
+| `routeTest { }` | `RouteTestSupport.kt` | Opens the temp database and cleans it up in `finally` |
+| `installRoutes { }` | `RouteTestSupport.kt` | `ContentNegotiation` + `handler()` + routes |
+| `grantPermissions(role, vararg)` | `RouteTestSupport.kt` | Creates missing permissions and assigns them |
+| `jsonBody("…")` | `RouteTestSupport.kt` | `Content-Type` + body |
+| `installAuthenticationWithoutUser()` | `RouteTestSupport.kt` | Schemes only, seeds no user |
+| `setUserPin` / `setRolePassword` | `RouteTestSupport.kt` | Credentials with a real PBKDF2 hash |
+| `installAdminAuth` / `installNonAdminAuth` / `installWalletAuth` | `AdminAuthTestFixture.kt` | Session cookies |
+| `withAuthCookies` / `withAccessTokenOnly` | `AdminAuthTestFixture.kt` | With or without the wallet cookie |
+| `ExposedTestDb.seedX(...)` | `ExposedTestDb.kt` | ~35 data factories |
+| `FakeLightningBackend` | `FakeLightningBackend.kt` | Fake lightning backend, records calls |
 
-Convenciones del repo: JUnit 4 (`org.junit.Before`/`After`) con `kotlin.test.Test`, `runBlocking`
-(no `runTest`), mockito-kotlin (no MockK), nombres de test entre backticks en inglés, paquete
+`installAuthenticationWithoutUser` must not be combined with `installAdminAuth` or
+`installWalletAuth`: those install the authentication plugin themselves, and installing it twice
+fails.
+
+Repo conventions: JUnit 4 (`org.junit.Before`/`After`) with `kotlin.test.Test`, `runBlocking` (not
+`runTest`), mockito-kotlin (not MockK), backtick-quoted test names in English, package
 `pos.ambrosia.utest`.
 
-Dos avisos de estado global, que es donde se rompe el aislamiento entre tests:
+Two global-state warnings, which is where isolation between tests breaks:
 
-- `LoginRateLimiter` (`api/Authorize.kt`) es un objeto de proceso cacheado por IP, y en
-  `testApplication` todas las peticiones comparten dirección. Llama a `LoginRateLimiter.resetAll()`
-  en el `@Before`. A largo plazo lo correcto es inyectarlo en `Route.auth(...)`.
-- `ActiveLightningBackend` es un singleton. Ponlo con `set(FakeLightningBackend())` y suéltalo con
-  `closeActive()` en el `@After`.
+- `LoginRateLimiter` (`api/Authorize.kt`) is a process-wide object keyed by IP, and under
+  `testApplication` every request shares one address. Call `LoginRateLimiter.resetAll()` in
+  `@Before`. The right long-term fix is to inject it into `Route.auth(...)`.
+- `ActiveLightningBackend` is a singleton. Set it with `set(FakeLightningBackend())` and release it
+  with `closeActive()` in `@After`.
 
-Los ficheros de test anteriores a esta pasada siguen con su pareja `@Before`/`@After` a mano; no se
-migraron. Los nuevos usan `routeTest`.
+Test files written before this pass still have their hand-written `@Before`/`@After` pair; they
+were not migrated. New ones use `routeTest`.
 
-## Comandos
+## Commands
 
 ```bash
-./gradlew test                              # suite completa
-./gradlew test --tests "WalletRoutesTest"   # una clase
+./gradlew test                              # full suite
+./gradlew test --tests "WalletRoutesTest"   # a single class
 ./gradlew koverHtmlReport                   # app/build/reports/kover/html/index.html
-./gradlew :app:koverVerify                  # el ratchet que corre en CI
-./gradlew ktlintFormat                      # obligatorio antes del PR
+./gradlew :app:koverVerify                  # the ratchet CI enforces
+./gradlew ktlintFormat                      # required before opening the PR
 ```


### PR DESCRIPTION
## Why

We want to make architecture changes to the server in the medium term, and that needs a safety net
first. The problem was never the total coverage but its distribution: the service layer sat at 88%
while the HTTP layer sat at **12.3%** — the wrong way round for a refactor.

Route tests (request in → status and body out) survive the inner layers being rearranged. Service
tests, bound to the implementation, are exactly what a refactor breaks and forces you to rewrite.
So the 2,003 uncovered lines in `api/` were both the largest gap and the boundary that has to stay
frozen while we move things around.

## What this changes

| Metric | Before | After |
|---|---|---|
| Line | 63.6% | **74.2%** |
| Branch | 28.2% | **37.4%** |
| `pos/ambrosia/api` | 12.3% | **44.1%** |

128 new tests in 8 files. Suite goes from 745 to **873 tests, 0 failures**.

| Module | Before | After |
|---|---|---|
| `api/Checkout.kt` | 0.0% | 85.2% |
| `api/Authorize.kt` | 0.0% | 84.2% |
| `api/Orders.kt` | 0.0% | 82.9% |
| `utils/AuthUtils.kt` | 66.2% | 81.7% |
| `api/Uploads.kt` | 0.0% | 80.0% |
| `api/Products.kt` | 0.0% | 76.6% |
| `api/Wallet.kt` | 0.0% | 72.9% |
| `api/ProductVariants.kt` | 0.0% | 66.7% |
| `api/Payments.kt` | 0.0% | 66.4% |
| `api/StoreOrders.kt` | 0.0% | 54.5% |

The Kover ratchet in `app/build.gradle.kts` goes from 58/23 to **70/33**, a couple of points below
what was measured. CI already runs `koverVerify`, so the new floor applies on its own.

## Three production bugs this surfaced

All three returned **500** and had never worked. Fixed in `197f35f5`.

1. `GET /orders/{id}/complete` — `CompleteOrder` crossed the HTTP boundary without `@Serializable`.
2. `POST /orders/with-dishes` — same cause, in `OrderWithDishesRequest`.
3. `PUT /orders/{id}/calculate-total` — responded with
   `mapOf("message" to String, "total" to Double)`, a `Map<String, Any>` kotlinx cannot serialize.
   Replaced by a serializable `OrderTotalResponse` that keeps the same JSON shape.

Worth knowing when reviewing: a model missing `@Serializable`, or a heterogeneous `Map`, in a
`respond`/`receive` compiles fine and only fails at runtime. Homogeneous maps do serialize.

## Contracts now pinned

Beyond plain CRUD, these tests freeze behaviour that is easy to lose in a refactor:

- **Wallet scheme separation.** `walletAccessToken` carries `scope=wallet_access` on an
  `HttpOnly`/`SameSite=Strict` cookie; logout revokes against `users.wallet_token`, not just by
  signature. `POST /wallet/invoice` is the declared exception that works with a plain `accessToken`.
- **Login rate limiter.** Blocks after 5 failures with `Retry-After`; a correct login does not get
  through the block, and a successful one resets the counter.
- **Legacy 4-digit PINs** keep working — the 6-digit rule belongs to user creation and editing,
  `/auth/login` must never validate length.
- **`requireAdmin()` reads the `refreshToken` cookie**, not the already-validated JWT principal.
- **Uploads are unauthenticated only before initial setup**, and the client filename is discarded
  (only the extension survives), so there is no traversal.
- **`POST /products/stock` is guarded by `orders_create`**, not `products_update`.
- **The checkout discount check is an inline `requirePermission`**, not a route decorator.
- **Checkout idempotency** — replaying a `paymentHash` returns the original sale (200) instead of
  creating a second one; an unsettled invoice answers 202 `pending`, not a sale.

## Production changes

Kept to the minimum needed to open test seams — no behaviour changes beyond the three fixes above.

- `api/Uploads.kt` — extracted `Route.uploads(uploadService, configService)`; `configureUploads()`
  now calls it. It was the only route module with no seam, so its upload path could not be tested.
- `api/Authorize.kt` — `LoginRateLimiter` is now `internal` with a `resetAll()`. It is
  process-global state keyed by IP, and under `testApplication` every request shares one address,
  so without a reset the tests become order-dependent. Injecting it into `Route.auth(...)` would be
  the better long-term fix.

## Test infrastructure

New `app/src/test/kotlin/pos/ambrosia/utils/RouteTestSupport.kt` — `routeTest` (temp SQLite plus
guaranteed cleanup), `installRoutes`, `grantPermissions`, `jsonBody`, and PBKDF2 credential seeding.
`AdminAuthTestFixture` gains `installWalletAuth`, and `FakeLightningBackend` now records calls and
can simulate failures and unsettled invoices.

Tests mount the `Route.xxx(...)` seam directly with controlled dependencies and skip
`configureXxx()`. `server/docs/TEST_COVERAGE.md` documents the pattern, the available helpers, and
the two global-state traps.

## Still pending

`server/docs/TEST_COVERAGE.md` carries the full ranking. Highlights:

- Some P1 modules are covered but **happy-path only**. Five endpoints are never invoked by any
  test — `POST /store/orders/{id}/refund` is the notable one, since it is the money path.
- **P2**: `AdminNotifications` (2.5%), `InitialSetup` (21%), `Reports` and `Shifts` (0%), `Users`
  (34%), `Roles` (33%). Watch `Handler.kt`: 50.5% line but **5.3% branch**, and it decides which
  status every exception becomes.
- **P4**: `nwc/NostrEvent.createSignedEvent` is at 0% — Schnorr signing on the money path when NWC
  is the active backend.

Note for reviewers: roughly 45 lines in `api/` are path-parameter guards
(`?: respond(400, "Missing…")`) that Ktor's router can never reach, because it does not match the
route when the segment is absent. They are dead code, not pending coverage, and are worth deleting
during the refactor.

## Verification

```bash
cd server
./gradlew test            # 873 tests, 0 failures
./gradlew :app:koverVerify
./gradlew ktlintCheck
```

Each new class also passes on its own (`--tests <Class> --rerun-tasks`), which is where a badly
closed global-state seam would show up.
