### PR TITLE
Feat(server): Time entries

### DIFF
--- a/server/app/src/main/kotlin/pos/ambrosia/Api.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/Api.kt
@@ -50,6 +50,7 @@ import pos.ambrosia.api.configureSuppliers
 import pos.ambrosia.api.configureTables
 import pos.ambrosia.api.configureTicketTemplates
 import pos.ambrosia.api.configureTickets
+import pos.ambrosia.api.configureTimeEntries
 import pos.ambrosia.api.configureUploads
 import pos.ambrosia.api.configureUsers
 import pos.ambrosia.api.configureWallet
@@ -111,6 +112,7 @@ class Api {
         configureClients()
         configureProjects()
         configureCurrency()
+        configureTimeEntries()
         configureInitialSetup()
         if (environment.config.propertyOrNull("nwc-uri") == null) {
             configurePhoenixWebhook()

--- a/server/app/src/main/kotlin/pos/ambrosia/api/Handler.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/api/Handler.kt
@@ -17,6 +17,7 @@ import pos.ambrosia.utils.DatabaseException
 import pos.ambrosia.utils.DuplicateUserNameException
 import pos.ambrosia.utils.InitialSetupException
 import pos.ambrosia.utils.InvalidCredentialsException
+import pos.ambrosia.utils.InvalidTimeEntryException
 import pos.ambrosia.utils.InvalidTokenException
 import pos.ambrosia.utils.LastAdminRemovalException
 import pos.ambrosia.utils.LastUserDeletionException
@@ -34,6 +35,8 @@ import pos.ambrosia.utils.PhoenixServiceException
 import pos.ambrosia.utils.PrintTicketException
 import pos.ambrosia.utils.ProductIsBundleComponentException
 import pos.ambrosia.utils.ResourceNotFoundException
+import pos.ambrosia.utils.TimeEntryLockedException
+import pos.ambrosia.utils.TimeEntryRateNotFoundException
 import pos.ambrosia.utils.UnauthorizedApiException
 import pos.ambrosia.utils.UnsupportedBackendOperationException
 import pos.ambrosia.utils.WalletOnlyException
@@ -52,6 +55,18 @@ fun Application.handler() {
         exception<ResourceNotFoundException> { call, cause ->
             logger.warn("Resource not found: ${cause.message}")
             call.respond(HttpStatusCode.NotFound, Message(cause.message ?: "Resource not found"))
+        }
+        exception<InvalidTimeEntryException> { call, cause ->
+            logger.warn("Invalid time entry: ${cause.message}")
+            call.respond(HttpStatusCode.BadRequest, Message(cause.message ?: "Invalid time entry"))
+        }
+        exception<TimeEntryRateNotFoundException> { call, cause ->
+            logger.warn("Time entry rate not found: ${cause.message}")
+            call.respond(HttpStatusCode.BadRequest, Message(cause.message ?: "No billing rate is available"))
+        }
+        exception<TimeEntryLockedException> { call, cause ->
+            logger.warn("Locked time entry mutation rejected: ${cause.message}")
+            call.respond(HttpStatusCode.Conflict, Message(cause.message ?: "Time entry is locked"))
         }
         exception<InvalidCredentialsException> { call, cause ->
             logger.warn("Invalid login attempt: ${cause.message}")

--- a/server/app/src/main/kotlin/pos/ambrosia/api/Handler.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/api/Handler.kt
@@ -36,7 +36,6 @@ import pos.ambrosia.utils.PrintTicketException
 import pos.ambrosia.utils.ProductIsBundleComponentException
 import pos.ambrosia.utils.ResourceNotFoundException
 import pos.ambrosia.utils.TimeEntryLockedException
-import pos.ambrosia.utils.TimeEntryRateNotFoundException
 import pos.ambrosia.utils.UnauthorizedApiException
 import pos.ambrosia.utils.UnsupportedBackendOperationException
 import pos.ambrosia.utils.WalletOnlyException
@@ -59,10 +58,6 @@ fun Application.handler() {
         exception<InvalidTimeEntryException> { call, cause ->
             logger.warn("Invalid time entry: ${cause.message}")
             call.respond(HttpStatusCode.BadRequest, Message(cause.message ?: "Invalid time entry"))
-        }
-        exception<TimeEntryRateNotFoundException> { call, cause ->
-            logger.warn("Time entry rate not found: ${cause.message}")
-            call.respond(HttpStatusCode.BadRequest, Message(cause.message ?: "No billing rate is available"))
         }
         exception<TimeEntryLockedException> { call, cause ->
             logger.warn("Locked time entry mutation rejected: ${cause.message}")

--- a/server/app/src/main/kotlin/pos/ambrosia/api/TimeEntries.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/api/TimeEntries.kt
@@ -41,10 +41,10 @@ fun Route.timeEntries(timeEntryService: TimeEntryService) {
             call.respond(
                 HttpStatusCode.OK,
                 timeEntryService.getTimeEntries(
-                    from = from,
-                    to = to,
-                    projectId = call.request.queryParameters["project_id"],
-                    taskId = call.request.queryParameters["task_id"],
+                    startDate = from,
+                    endDate = to,
+                    selectedProjectId = call.request.queryParameters["project_id"],
+                    selectedTaskId = call.request.queryParameters["task_id"],
                 ),
             )
         }

--- a/server/app/src/main/kotlin/pos/ambrosia/api/TimeEntries.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/api/TimeEntries.kt
@@ -1,0 +1,104 @@
+package pos.ambrosia.api
+
+import io.ktor.http.HttpStatusCode
+import io.ktor.serialization.ContentConvertException
+import io.ktor.server.application.Application
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.plugins.BadRequestException
+import io.ktor.server.plugins.ContentTransformationException
+import io.ktor.server.request.receive
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.delete
+import io.ktor.server.routing.get
+import io.ktor.server.routing.post
+import io.ktor.server.routing.put
+import io.ktor.server.routing.route
+import io.ktor.server.routing.routing
+import pos.ambrosia.models.CreateTimeEntryRequest
+import pos.ambrosia.models.UpdateTimeEntryRequest
+import pos.ambrosia.services.TimeEntryService
+import pos.ambrosia.utils.InvalidTimeEntryException
+import pos.ambrosia.utils.ResourceNotFoundException
+import pos.ambrosia.utils.UnauthorizedApiException
+import pos.ambrosia.utils.authorizePermission
+import pos.ambrosia.utils.getCurrentUser
+
+fun Application.configureTimeEntries() {
+    val timeEntryService = TimeEntryService()
+    routing { route("/time-entries") { timeEntries(timeEntryService) } }
+}
+
+fun Route.timeEntries(timeEntryService: TimeEntryService) {
+    authorizePermission("time_entries_read") {
+        get("") {
+            val currentUser = call.getCurrentUser() ?: throw UnauthorizedApiException()
+            val from =
+                call.request.queryParameters["from"]
+                    ?: throw InvalidTimeEntryException("Both from and to dates are required")
+            val to =
+                call.request.queryParameters["to"]
+                    ?: throw InvalidTimeEntryException("Both from and to dates are required")
+            call.respond(
+                HttpStatusCode.OK,
+                timeEntryService.getTimeEntries(
+                    userId = currentUser.userId,
+                    from = from,
+                    to = to,
+                    projectId = call.request.queryParameters["project_id"],
+                    taskId = call.request.queryParameters["task_id"],
+                ),
+            )
+        }
+
+        get("/{id}") {
+            val currentUser = call.getCurrentUser() ?: throw UnauthorizedApiException()
+            val id = call.parameters["id"] ?: throw InvalidTimeEntryException("Missing time entry ID")
+            val entry =
+                timeEntryService.getTimeEntryById(currentUser.userId, id)
+                    ?: throw ResourceNotFoundException("Time entry not found")
+            call.respond(HttpStatusCode.OK, entry)
+        }
+    }
+
+    authorizePermission("time_entries_create") {
+        post("") {
+            val currentUser = call.getCurrentUser() ?: throw UnauthorizedApiException()
+            val request = call.receiveCreateRequest()
+            call.respond(HttpStatusCode.Created, timeEntryService.createTimeEntry(currentUser.userId, request))
+        }
+    }
+
+    authorizePermission("time_entries_update") {
+        put("/{id}") {
+            val currentUser = call.getCurrentUser() ?: throw UnauthorizedApiException()
+            val id = call.parameters["id"] ?: throw InvalidTimeEntryException("Missing time entry ID")
+            val request = call.receiveUpdateRequest()
+            call.respond(HttpStatusCode.OK, timeEntryService.updateTimeEntry(currentUser.userId, id, request))
+        }
+    }
+
+    authorizePermission("time_entries_delete") {
+        delete("/{id}") {
+            val currentUser = call.getCurrentUser() ?: throw UnauthorizedApiException()
+            val id = call.parameters["id"] ?: throw InvalidTimeEntryException("Missing time entry ID")
+            timeEntryService.deleteTimeEntry(currentUser.userId, id)
+            call.respond(HttpStatusCode.NoContent)
+        }
+    }
+}
+
+private suspend fun ApplicationCall.receiveCreateRequest(): CreateTimeEntryRequest = receiveTimeEntryRequest()
+
+private suspend fun ApplicationCall.receiveUpdateRequest(): UpdateTimeEntryRequest = receiveTimeEntryRequest()
+
+private suspend inline fun <reified T : Any> ApplicationCall.receiveTimeEntryRequest(): T =
+    try {
+        receive<T>()
+    } catch (_: BadRequestException) {
+        throw InvalidTimeEntryException("Invalid time entry request body")
+    } catch (_: ContentTransformationException) {
+        throw InvalidTimeEntryException("Invalid time entry request body")
+    } catch (_: ContentConvertException) {
+        throw InvalidTimeEntryException("Invalid time entry request body")
+    }

--- a/server/app/src/main/kotlin/pos/ambrosia/api/TimeEntries.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/api/TimeEntries.kt
@@ -32,7 +32,6 @@ fun Application.configureTimeEntries() {
 fun Route.timeEntries(timeEntryService: TimeEntryService) {
     authorizePermission("time_entries_read") {
         get("") {
-            val currentUser = call.getCurrentUser() ?: throw UnauthorizedApiException()
             val from =
                 call.request.queryParameters["from"]
                     ?: throw InvalidTimeEntryException("Both from and to dates are required")
@@ -51,7 +50,6 @@ fun Route.timeEntries(timeEntryService: TimeEntryService) {
         }
 
         get("/{id}") {
-            val currentUser = call.getCurrentUser() ?: throw UnauthorizedApiException()
             val id = call.parameters["id"] ?: throw InvalidTimeEntryException("Missing time entry ID")
             val entry =
                 timeEntryService.getTimeEntryById(id)
@@ -62,7 +60,6 @@ fun Route.timeEntries(timeEntryService: TimeEntryService) {
 
     authorizePermission("time_entries_create") {
         post("") {
-            val currentUser = call.getCurrentUser() ?: throw UnauthorizedApiException()
             val request = call.receiveCreateRequest()
             call.respond(HttpStatusCode.Created, timeEntryService.createTimeEntry(request))
         }
@@ -70,7 +67,6 @@ fun Route.timeEntries(timeEntryService: TimeEntryService) {
 
     authorizePermission("time_entries_update") {
         put("/{id}") {
-            val currentUser = call.getCurrentUser() ?: throw UnauthorizedApiException()
             val id = call.parameters["id"] ?: throw InvalidTimeEntryException("Missing time entry ID")
             val request = call.receiveUpdateRequest()
             call.respond(HttpStatusCode.OK, timeEntryService.updateTimeEntry(id, request))
@@ -79,7 +75,6 @@ fun Route.timeEntries(timeEntryService: TimeEntryService) {
 
     authorizePermission("time_entries_delete") {
         delete("/{id}") {
-            val currentUser = call.getCurrentUser() ?: throw UnauthorizedApiException()
             val id = call.parameters["id"] ?: throw InvalidTimeEntryException("Missing time entry ID")
             timeEntryService.deleteTimeEntry(id)
             call.respond(HttpStatusCode.NoContent)

--- a/server/app/src/main/kotlin/pos/ambrosia/api/TimeEntries.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/api/TimeEntries.kt
@@ -42,7 +42,6 @@ fun Route.timeEntries(timeEntryService: TimeEntryService) {
             call.respond(
                 HttpStatusCode.OK,
                 timeEntryService.getTimeEntries(
-                    userId = currentUser.userId,
                     from = from,
                     to = to,
                     projectId = call.request.queryParameters["project_id"],
@@ -55,7 +54,7 @@ fun Route.timeEntries(timeEntryService: TimeEntryService) {
             val currentUser = call.getCurrentUser() ?: throw UnauthorizedApiException()
             val id = call.parameters["id"] ?: throw InvalidTimeEntryException("Missing time entry ID")
             val entry =
-                timeEntryService.getTimeEntryById(currentUser.userId, id)
+                timeEntryService.getTimeEntryById(id)
                     ?: throw ResourceNotFoundException("Time entry not found")
             call.respond(HttpStatusCode.OK, entry)
         }
@@ -65,7 +64,7 @@ fun Route.timeEntries(timeEntryService: TimeEntryService) {
         post("") {
             val currentUser = call.getCurrentUser() ?: throw UnauthorizedApiException()
             val request = call.receiveCreateRequest()
-            call.respond(HttpStatusCode.Created, timeEntryService.createTimeEntry(currentUser.userId, request))
+            call.respond(HttpStatusCode.Created, timeEntryService.createTimeEntry(request))
         }
     }
 
@@ -74,7 +73,7 @@ fun Route.timeEntries(timeEntryService: TimeEntryService) {
             val currentUser = call.getCurrentUser() ?: throw UnauthorizedApiException()
             val id = call.parameters["id"] ?: throw InvalidTimeEntryException("Missing time entry ID")
             val request = call.receiveUpdateRequest()
-            call.respond(HttpStatusCode.OK, timeEntryService.updateTimeEntry(currentUser.userId, id, request))
+            call.respond(HttpStatusCode.OK, timeEntryService.updateTimeEntry(id, request))
         }
     }
 
@@ -82,7 +81,7 @@ fun Route.timeEntries(timeEntryService: TimeEntryService) {
         delete("/{id}") {
             val currentUser = call.getCurrentUser() ?: throw UnauthorizedApiException()
             val id = call.parameters["id"] ?: throw InvalidTimeEntryException("Missing time entry ID")
-            timeEntryService.deleteTimeEntry(currentUser.userId, id)
+            timeEntryService.deleteTimeEntry(id)
             call.respond(HttpStatusCode.NoContent)
         }
     }

--- a/server/app/src/main/kotlin/pos/ambrosia/db/tables/TimeEntriesTable.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/db/tables/TimeEntriesTable.kt
@@ -9,13 +9,12 @@ import java.util.UUID
 object TimeEntriesTable : SQLiteUUIDTable("time_entries") {
     val projectId = reference("project_id", ProjectsTable)
     val taskId = reference("task_id", TasksTable)
-    val userId = reference("user_id", UsersTable)
     val entryDate = varchar("entry_date", 20)
     val startTime = varchar("start_time", 20).nullable()
     val endTime = varchar("end_time", 20).nullable()
     val description = text("description").nullable()
     val durationMinutes = integer("duration_minutes")
-    val rateCents = integer("rate_cents").nullable()
+    val isBillable = bool("is_billable").default(true)
     val invoiceId = optReference("invoice_id", InvoicesTable)
     val isLocked = bool("is_locked").default(false)
     val createdAt = varchar("created_at", 50)
@@ -33,13 +32,12 @@ class TimeEntryEntity(
 
     var projectId by TimeEntriesTable.projectId
     var taskId by TimeEntriesTable.taskId
-    var userId by TimeEntriesTable.userId
     var entryDate by TimeEntriesTable.entryDate
     var startTime by TimeEntriesTable.startTime
     var endTime by TimeEntriesTable.endTime
     var description by TimeEntriesTable.description
     var durationMinutes by TimeEntriesTable.durationMinutes
-    var rateCents by TimeEntriesTable.rateCents
+    var isBillable by TimeEntriesTable.isBillable
     var invoiceId by TimeEntriesTable.invoiceId
     var isLocked by TimeEntriesTable.isLocked
     var createdAt by TimeEntriesTable.createdAt

--- a/server/app/src/main/kotlin/pos/ambrosia/db/tables/TimeEntriesTable.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/db/tables/TimeEntriesTable.kt
@@ -19,6 +19,11 @@ object TimeEntriesTable : SQLiteUUIDTable("time_entries") {
     val invoiceId = optReference("invoice_id", InvoicesTable)
     val isLocked = bool("is_locked").default(false)
     val createdAt = varchar("created_at", 50)
+
+    init {
+        index(false, projectId, entryDate)
+        index(false, invoiceId)
+    }
 }
 
 class TimeEntryEntity(

--- a/server/app/src/main/kotlin/pos/ambrosia/models/AppModels.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/models/AppModels.kt
@@ -830,3 +830,51 @@ data class IncomingPaymentWithRate(
     val fiatAmountAtPayment: Double? = null,
     val refunded: Boolean,
 )
+
+@Serializable
+data class CreateTimeEntryRequest(
+    val projectId: String,
+    val taskId: String,
+    val entryDate: String,
+    val startTime: String? = null,
+    val endTime: String? = null,
+    val description: String? = null,
+    val durationMinutes: Int,
+    val rateCents: Int? = null,
+)
+
+@Serializable
+data class UpdateTimeEntryRequest(
+    val projectId: String,
+    val taskId: String,
+    val entryDate: String,
+    val startTime: String? = null,
+    val endTime: String? = null,
+    val description: String? = null,
+    val durationMinutes: Int,
+    val rateCents: Int? = null,
+)
+
+@Serializable
+data class TimeEntryResponse(
+    val id: String,
+    val projectId: String,
+    val projectName: String,
+    val taskId: String,
+    val taskName: String,
+    val clientId: String,
+    val clientName: String,
+    val currencyId: String,
+    val currencyAcronym: String,
+    val userId: String,
+    val entryDate: String,
+    val startTime: String?,
+    val endTime: String?,
+    val description: String?,
+    val durationMinutes: Int,
+    val rateCents: Int,
+    val amountCents: Int,
+    val invoiceId: String?,
+    val isLocked: Boolean,
+    val createdAt: String,
+)

--- a/server/app/src/main/kotlin/pos/ambrosia/models/AppModels.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/models/AppModels.kt
@@ -862,6 +862,7 @@ data class TimeEntryResponse(
     val projectName: String,
     val taskId: String,
     val taskName: String,
+    val isBillable: Boolean,
     val clientId: String,
     val clientName: String,
     val currencyId: String,

--- a/server/app/src/main/kotlin/pos/ambrosia/models/AppModels.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/models/AppModels.kt
@@ -840,7 +840,6 @@ data class CreateTimeEntryRequest(
     val endTime: String? = null,
     val description: String? = null,
     val durationMinutes: Int,
-    val rateCents: Int? = null,
 )
 
 @Serializable
@@ -852,7 +851,6 @@ data class UpdateTimeEntryRequest(
     val endTime: String? = null,
     val description: String? = null,
     val durationMinutes: Int,
-    val rateCents: Int? = null,
 )
 
 @Serializable
@@ -867,14 +865,11 @@ data class TimeEntryResponse(
     val clientName: String,
     val currencyId: String,
     val currencyAcronym: String,
-    val userId: String,
     val entryDate: String,
     val startTime: String?,
     val endTime: String?,
     val description: String?,
     val durationMinutes: Int,
-    val rateCents: Int,
-    val amountCents: Int,
     val invoiceId: String?,
     val isLocked: Boolean,
     val createdAt: String,

--- a/server/app/src/main/kotlin/pos/ambrosia/services/TimeEntryService.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/services/TimeEntryService.kt
@@ -47,16 +47,16 @@ class TimeEntryService {
 
             var condition: Op<Boolean> =
                 (TimeEntriesTable.entryDate greaterEq fromDate.toString()) and
-                    (TimeEntriesTable.entryDate lessEq toDate.toString())
+                        (TimeEntriesTable.entryDate lessEq toDate.toString())
             projectId?.let {
                 condition =
                     condition and
-                    (TimeEntriesTable.projectId eq EntityID(parseUuid(it, "project_id"), ProjectsTable))
+                            (TimeEntriesTable.projectId eq EntityID(parseUuid(it, "project_id"), ProjectsTable))
             }
             taskId?.let {
                 condition =
                     condition and
-                    (TimeEntriesTable.taskId eq EntityID(parseUuid(it, "task_id"), TasksTable))
+                            (TimeEntriesTable.taskId eq EntityID(parseUuid(it, "task_id"), TasksTable))
             }
 
             val entries =
@@ -167,9 +167,6 @@ class TimeEntryService {
             throw InvalidTimeEntryException("Invalid project status. Time tracking is only allowed in the 'in_progress' state.")
         }
 
-        val client =
-            ClientEntity.findById(project.clientId)?.takeIf { !it.isDeleted }
-                ?: throw ResourceNotFoundException("Client not found")
         val task =
             TaskEntity.findById(parseUuid(taskId, "taskId"))?.takeIf { !it.isDeleted }
                 ?: throw ResourceNotFoundException("Task not found")

--- a/server/app/src/main/kotlin/pos/ambrosia/services/TimeEntryService.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/services/TimeEntryService.kt
@@ -54,17 +54,17 @@ class TimeEntryService {
 
             var condition: Op<Boolean> =
                 (TimeEntriesTable.userId eq EntityID(userUuid, UsersTable)) and
-                    (TimeEntriesTable.entryDate greaterEq fromDate.toString()) and
-                    (TimeEntriesTable.entryDate lessEq toDate.toString())
+                        (TimeEntriesTable.entryDate greaterEq fromDate.toString()) and
+                        (TimeEntriesTable.entryDate lessEq toDate.toString())
             projectId?.let {
                 condition =
                     condition and
-                    (TimeEntriesTable.projectId eq EntityID(parseUuid(it, "project_id"), ProjectsTable))
+                            (TimeEntriesTable.projectId eq EntityID(parseUuid(it, "project_id"), ProjectsTable))
             }
             taskId?.let {
                 condition =
                     condition and
-                    (TimeEntriesTable.taskId eq EntityID(parseUuid(it, "task_id"), TasksTable))
+                            (TimeEntriesTable.taskId eq EntityID(parseUuid(it, "task_id"), TasksTable))
             }
 
             val entries =
@@ -174,7 +174,7 @@ class TimeEntryService {
         return TimeEntryEntity
             .find {
                 (TimeEntriesTable.id eq EntityID(entryUuid, TimeEntriesTable)) and
-                    (TimeEntriesTable.userId eq EntityID(userUuid, UsersTable))
+                        (TimeEntriesTable.userId eq EntityID(userUuid, UsersTable))
             }.firstOrNull()
     }
 
@@ -200,13 +200,24 @@ class TimeEntryService {
         val project =
             ProjectEntity.findById(parseUuid(projectId, "projectId"))?.takeIf { !it.isDeleted }
                 ?: throw ResourceNotFoundException("Project not found")
+
+        if (project.status != "in_progress") {
+            throw InvalidTimeEntryException("Invalid project status. Time tracking is only allowed in the 'in_progress' state.")
+        }
+
         val client =
             ClientEntity.findById(project.clientId)?.takeIf { !it.isDeleted }
                 ?: throw ResourceNotFoundException("Client not found")
         val task =
             TaskEntity.findById(parseUuid(taskId, "taskId"))?.takeIf { !it.isDeleted }
                 ?: throw ResourceNotFoundException("Task not found")
-        val resolvedRate = resolveRateCents(requestedRateCents, project.hourlyRateCents, client.hourlyRateCents)
+        val isBillable = task.isBillable && project.isBillable
+        val resolvedRate =
+            if (!isBillable) {
+                0
+            } else {
+                resolveRateCents(requestedRateCents, project.hourlyRateCents, client.hourlyRateCents)
+            }
 
         return ValidatedTimeEntry(
             user = user,
@@ -217,6 +228,7 @@ class TimeEntryService {
             endTime = parseTime(endTime, "endTime"),
             description = description,
             durationMinutes = durationMinutes,
+            isBillable = isBillable,
             rateCents = resolvedRate,
         )
     }
@@ -245,13 +257,21 @@ class TimeEntryService {
             references?.currencies?.get(client.currencyId)
                 ?: CurrencyEntity.findById(client.currencyId)
                 ?: throw ResourceNotFoundException("Currency not found")
-        val rate = resolveRateCents(entity.rateCents, project.hourlyRateCents, client.hourlyRateCents)
+        val isBillable = task.isBillable && project.isBillable
+        val (rate, amount) =
+            if (!isBillable) {
+                Pair(0, 0)
+            } else {
+                val r = resolveRateCents(entity.rateCents, project.hourlyRateCents, client.hourlyRateCents)
+                Pair(r, calculateAmountCents(r, entity.durationMinutes))
+            }
         return TimeEntryResponse(
             id = entity.id.value.toString(),
             projectId = project.id.value.toString(),
             projectName = project.name,
             taskId = task.id.value.toString(),
             taskName = task.name,
+            isBillable = isBillable,
             clientId = client.id.value.toString(),
             clientName = client.name,
             currencyId = currency.id.value.toString(),
@@ -263,7 +283,7 @@ class TimeEntryService {
             description = entity.description,
             durationMinutes = entity.durationMinutes,
             rateCents = rate,
-            amountCents = calculateAmountCents(rate, entity.durationMinutes),
+            amountCents = amount,
             invoiceId = entity.invoiceId?.value?.toString(),
             isLocked = entity.isLocked || entity.invoiceId != null,
             createdAt = entity.createdAt,
@@ -308,6 +328,7 @@ class TimeEntryService {
         val endTime: String?,
         val description: String?,
         val durationMinutes: Int,
+        val isBillable: Boolean,
         val rateCents: Int,
     )
 

--- a/server/app/src/main/kotlin/pos/ambrosia/services/TimeEntryService.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/services/TimeEntryService.kt
@@ -19,17 +19,12 @@ import pos.ambrosia.db.tables.TaskEntity
 import pos.ambrosia.db.tables.TasksTable
 import pos.ambrosia.db.tables.TimeEntriesTable
 import pos.ambrosia.db.tables.TimeEntryEntity
-import pos.ambrosia.db.tables.UserEntity
-import pos.ambrosia.db.tables.UsersTable
 import pos.ambrosia.models.CreateTimeEntryRequest
 import pos.ambrosia.models.TimeEntryResponse
 import pos.ambrosia.models.UpdateTimeEntryRequest
 import pos.ambrosia.utils.InvalidTimeEntryException
 import pos.ambrosia.utils.ResourceNotFoundException
 import pos.ambrosia.utils.TimeEntryLockedException
-import pos.ambrosia.utils.TimeEntryRateNotFoundException
-import java.math.BigDecimal
-import java.math.RoundingMode
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -40,31 +35,28 @@ import java.util.UUID
 
 class TimeEntryService {
     fun getTimeEntries(
-        userId: String,
         from: String,
         to: String,
         projectId: String? = null,
         taskId: String? = null,
     ): List<TimeEntryResponse> =
         transaction {
-            val userUuid = parseUuid(userId, "userId")
             val fromDate = parseDate(from, "from")
             val toDate = parseDate(to, "to")
             if (fromDate > toDate) throw InvalidTimeEntryException("from must be before or equal to to")
 
             var condition: Op<Boolean> =
-                (TimeEntriesTable.userId eq EntityID(userUuid, UsersTable)) and
-                        (TimeEntriesTable.entryDate greaterEq fromDate.toString()) and
-                        (TimeEntriesTable.entryDate lessEq toDate.toString())
+                (TimeEntriesTable.entryDate greaterEq fromDate.toString()) and
+                    (TimeEntriesTable.entryDate lessEq toDate.toString())
             projectId?.let {
                 condition =
                     condition and
-                            (TimeEntriesTable.projectId eq EntityID(parseUuid(it, "project_id"), ProjectsTable))
+                    (TimeEntriesTable.projectId eq EntityID(parseUuid(it, "project_id"), ProjectsTable))
             }
             taskId?.let {
                 condition =
                     condition and
-                            (TimeEntriesTable.taskId eq EntityID(parseUuid(it, "task_id"), TasksTable))
+                    (TimeEntriesTable.taskId eq EntityID(parseUuid(it, "task_id"), TasksTable))
             }
 
             val entries =
@@ -79,22 +71,15 @@ class TimeEntryService {
             entries.map { toResponse(it, references) }
         }
 
-    fun getTimeEntryById(
-        userId: String,
-        id: String,
-    ): TimeEntryResponse? =
+    fun getTimeEntryById(id: String): TimeEntryResponse? =
         transaction {
-            findOwnedEntry(userId, id)?.let(::toResponse)
+            findEntry(id)?.let(::toResponse)
         }
 
-    fun createTimeEntry(
-        userId: String,
-        request: CreateTimeEntryRequest,
-    ): TimeEntryResponse =
+    fun createTimeEntry(request: CreateTimeEntryRequest): TimeEntryResponse =
         transaction {
             val validated =
                 validateInput(
-                    userId = userId,
                     projectId = request.projectId,
                     taskId = request.taskId,
                     entryDate = request.entryDate,
@@ -102,19 +87,17 @@ class TimeEntryService {
                     endTime = request.endTime,
                     description = request.description,
                     durationMinutes = request.durationMinutes,
-                    requestedRateCents = request.rateCents,
                 )
             val entity =
                 TimeEntryEntity.new(UUID.randomUUID()) {
                     projectId = validated.project.id
                     taskId = validated.task.id
-                    this.userId = validated.user.id
                     entryDate = validated.entryDate
                     startTime = validated.startTime
                     endTime = validated.endTime
                     description = validated.description
                     durationMinutes = validated.durationMinutes
-                    rateCents = validated.rateCents
+                    isBillable = validated.isBillable
                     invoiceId = null
                     isLocked = false
                     createdAt = currentTimestamp()
@@ -123,16 +106,14 @@ class TimeEntryService {
         }
 
     fun updateTimeEntry(
-        userId: String,
         id: String,
         request: UpdateTimeEntryRequest,
     ): TimeEntryResponse =
         transaction {
-            val entity = findOwnedEntry(userId, id) ?: throw ResourceNotFoundException("Time entry not found")
+            val entity = findEntry(id) ?: throw ResourceNotFoundException("Time entry not found")
             ensureUnlocked(entity)
             val validated =
                 validateInput(
-                    userId = userId,
                     projectId = request.projectId,
                     taskId = request.taskId,
                     entryDate = request.entryDate,
@@ -140,7 +121,6 @@ class TimeEntryService {
                     endTime = request.endTime,
                     description = request.description,
                     durationMinutes = request.durationMinutes,
-                    requestedRateCents = request.rateCents,
                 )
 
             entity.projectId = validated.project.id
@@ -150,36 +130,26 @@ class TimeEntryService {
             entity.endTime = validated.endTime
             entity.description = validated.description
             entity.durationMinutes = validated.durationMinutes
-            entity.rateCents = validated.rateCents
+            entity.isBillable = validated.isBillable
             toResponse(entity)
         }
 
-    fun deleteTimeEntry(
-        userId: String,
-        id: String,
-    ) {
+    fun deleteTimeEntry(id: String) {
         transaction {
-            val entity = findOwnedEntry(userId, id) ?: throw ResourceNotFoundException("Time entry not found")
+            val entity = findEntry(id) ?: throw ResourceNotFoundException("Time entry not found")
             ensureUnlocked(entity)
             entity.delete()
         }
     }
 
-    private fun findOwnedEntry(
-        userId: String,
-        id: String,
-    ): TimeEntryEntity? {
-        val userUuid = parseUuid(userId, "userId")
+    private fun findEntry(id: String): TimeEntryEntity? {
         val entryUuid = parseUuid(id, "id")
         return TimeEntryEntity
-            .find {
-                (TimeEntriesTable.id eq EntityID(entryUuid, TimeEntriesTable)) and
-                        (TimeEntriesTable.userId eq EntityID(userUuid, UsersTable))
-            }.firstOrNull()
+            .find { TimeEntriesTable.id eq EntityID(entryUuid, TimeEntriesTable) }
+            .firstOrNull()
     }
 
     private fun validateInput(
-        userId: String,
         projectId: String,
         taskId: String,
         entryDate: String,
@@ -187,16 +157,8 @@ class TimeEntryService {
         endTime: String?,
         description: String?,
         durationMinutes: Int,
-        requestedRateCents: Int?,
     ): ValidatedTimeEntry {
         if (durationMinutes <= 0) throw InvalidTimeEntryException("durationMinutes must be greater than 0")
-        if (requestedRateCents != null && requestedRateCents < 0) {
-            throw InvalidTimeEntryException("rateCents must be greater than or equal to 0")
-        }
-
-        val user =
-            UserEntity.findById(parseUuid(userId, "userId"))?.takeIf { !it.isDeleted }
-                ?: throw ResourceNotFoundException("User not found")
         val project =
             ProjectEntity.findById(parseUuid(projectId, "projectId"))?.takeIf { !it.isDeleted }
                 ?: throw ResourceNotFoundException("Project not found")
@@ -212,15 +174,8 @@ class TimeEntryService {
             TaskEntity.findById(parseUuid(taskId, "taskId"))?.takeIf { !it.isDeleted }
                 ?: throw ResourceNotFoundException("Task not found")
         val isBillable = task.isBillable && project.isBillable
-        val resolvedRate =
-            if (!isBillable) {
-                0
-            } else {
-                resolveRateCents(requestedRateCents, project.hourlyRateCents, client.hourlyRateCents)
-            }
 
         return ValidatedTimeEntry(
-            user = user,
             project = project,
             task = task,
             entryDate = parseDate(entryDate, "entryDate").toString(),
@@ -229,7 +184,6 @@ class TimeEntryService {
             description = description,
             durationMinutes = durationMinutes,
             isBillable = isBillable,
-            rateCents = resolvedRate,
         )
     }
 
@@ -257,33 +211,22 @@ class TimeEntryService {
             references?.currencies?.get(client.currencyId)
                 ?: CurrencyEntity.findById(client.currencyId)
                 ?: throw ResourceNotFoundException("Currency not found")
-        val isBillable = task.isBillable && project.isBillable
-        val (rate, amount) =
-            if (!isBillable) {
-                Pair(0, 0)
-            } else {
-                val r = resolveRateCents(entity.rateCents, project.hourlyRateCents, client.hourlyRateCents)
-                Pair(r, calculateAmountCents(r, entity.durationMinutes))
-            }
         return TimeEntryResponse(
             id = entity.id.value.toString(),
             projectId = project.id.value.toString(),
             projectName = project.name,
             taskId = task.id.value.toString(),
             taskName = task.name,
-            isBillable = isBillable,
+            isBillable = entity.isBillable,
             clientId = client.id.value.toString(),
             clientName = client.name,
             currencyId = currency.id.value.toString(),
             currencyAcronym = currency.acronym,
-            userId = entity.userId.value.toString(),
             entryDate = entity.entryDate,
             startTime = entity.startTime,
             endTime = entity.endTime,
             description = entity.description,
             durationMinutes = entity.durationMinutes,
-            rateCents = rate,
-            amountCents = amount,
             invoiceId = entity.invoiceId?.value?.toString(),
             isLocked = entity.isLocked || entity.invoiceId != null,
             createdAt = entity.createdAt,
@@ -320,7 +263,6 @@ class TimeEntryService {
     )
 
     private data class ValidatedTimeEntry(
-        val user: UserEntity,
         val project: ProjectEntity,
         val task: TaskEntity,
         val entryDate: String,
@@ -329,35 +271,11 @@ class TimeEntryService {
         val description: String?,
         val durationMinutes: Int,
         val isBillable: Boolean,
-        val rateCents: Int,
     )
 
     companion object {
         private val isoDatePattern = Regex("\\d{4}-\\d{2}-\\d{2}")
         private val timestampFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
-
-        internal fun resolveRateCents(
-            entryRateCents: Int?,
-            projectRateCents: Int?,
-            clientRateCents: Int?,
-        ): Int = entryRateCents ?: projectRateCents ?: clientRateCents ?: throw TimeEntryRateNotFoundException()
-
-        internal fun calculateAmountCents(
-            rateCents: Int,
-            durationMinutes: Int,
-        ): Int {
-            if (rateCents < 0) throw InvalidTimeEntryException("rateCents must be greater than or equal to 0")
-            if (durationMinutes <= 0) throw InvalidTimeEntryException("durationMinutes must be greater than 0")
-            return try {
-                BigDecimal
-                    .valueOf(rateCents.toLong())
-                    .multiply(BigDecimal.valueOf(durationMinutes.toLong()))
-                    .divide(BigDecimal.valueOf(60L), 0, RoundingMode.HALF_UP)
-                    .intValueExact()
-            } catch (_: ArithmeticException) {
-                throw InvalidTimeEntryException("Calculated amount exceeds the supported range")
-            }
-        }
 
         private fun parseUuid(
             value: String,

--- a/server/app/src/main/kotlin/pos/ambrosia/services/TimeEntryService.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/services/TimeEntryService.kt
@@ -1,0 +1,379 @@
+package pos.ambrosia.services
+
+import org.jetbrains.exposed.v1.core.Op
+import org.jetbrains.exposed.v1.core.SortOrder
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.dao.id.EntityID
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.greaterEq
+import org.jetbrains.exposed.v1.core.inList
+import org.jetbrains.exposed.v1.core.lessEq
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import pos.ambrosia.db.tables.ClientEntity
+import pos.ambrosia.db.tables.ClientsTable
+import pos.ambrosia.db.tables.CurrencyEntity
+import pos.ambrosia.db.tables.CurrencyTable
+import pos.ambrosia.db.tables.ProjectEntity
+import pos.ambrosia.db.tables.ProjectsTable
+import pos.ambrosia.db.tables.TaskEntity
+import pos.ambrosia.db.tables.TasksTable
+import pos.ambrosia.db.tables.TimeEntriesTable
+import pos.ambrosia.db.tables.TimeEntryEntity
+import pos.ambrosia.db.tables.UserEntity
+import pos.ambrosia.db.tables.UsersTable
+import pos.ambrosia.models.CreateTimeEntryRequest
+import pos.ambrosia.models.TimeEntryResponse
+import pos.ambrosia.models.UpdateTimeEntryRequest
+import pos.ambrosia.utils.InvalidTimeEntryException
+import pos.ambrosia.utils.ResourceNotFoundException
+import pos.ambrosia.utils.TimeEntryLockedException
+import pos.ambrosia.utils.TimeEntryRateNotFoundException
+import java.math.BigDecimal
+import java.math.RoundingMode
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
+import java.util.UUID
+
+class TimeEntryService {
+    fun getTimeEntries(
+        userId: String,
+        from: String,
+        to: String,
+        projectId: String? = null,
+        taskId: String? = null,
+    ): List<TimeEntryResponse> =
+        transaction {
+            val userUuid = parseUuid(userId, "userId")
+            val fromDate = parseDate(from, "from")
+            val toDate = parseDate(to, "to")
+            if (fromDate > toDate) throw InvalidTimeEntryException("from must be before or equal to to")
+
+            var condition: Op<Boolean> =
+                (TimeEntriesTable.userId eq EntityID(userUuid, UsersTable)) and
+                    (TimeEntriesTable.entryDate greaterEq fromDate.toString()) and
+                    (TimeEntriesTable.entryDate lessEq toDate.toString())
+            projectId?.let {
+                condition =
+                    condition and
+                    (TimeEntriesTable.projectId eq EntityID(parseUuid(it, "project_id"), ProjectsTable))
+            }
+            taskId?.let {
+                condition =
+                    condition and
+                    (TimeEntriesTable.taskId eq EntityID(parseUuid(it, "task_id"), TasksTable))
+            }
+
+            val entries =
+                TimeEntryEntity
+                    .find { condition }
+                    .orderBy(
+                        TimeEntriesTable.entryDate to SortOrder.ASC,
+                        TimeEntriesTable.startTime to SortOrder.ASC,
+                        TimeEntriesTable.createdAt to SortOrder.ASC,
+                    ).toList()
+            val references = loadResponseReferences(entries)
+            entries.map { toResponse(it, references) }
+        }
+
+    fun getTimeEntryById(
+        userId: String,
+        id: String,
+    ): TimeEntryResponse? =
+        transaction {
+            findOwnedEntry(userId, id)?.let(::toResponse)
+        }
+
+    fun createTimeEntry(
+        userId: String,
+        request: CreateTimeEntryRequest,
+    ): TimeEntryResponse =
+        transaction {
+            val validated =
+                validateInput(
+                    userId = userId,
+                    projectId = request.projectId,
+                    taskId = request.taskId,
+                    entryDate = request.entryDate,
+                    startTime = request.startTime,
+                    endTime = request.endTime,
+                    description = request.description,
+                    durationMinutes = request.durationMinutes,
+                    requestedRateCents = request.rateCents,
+                )
+            val entity =
+                TimeEntryEntity.new(UUID.randomUUID()) {
+                    projectId = validated.project.id
+                    taskId = validated.task.id
+                    this.userId = validated.user.id
+                    entryDate = validated.entryDate
+                    startTime = validated.startTime
+                    endTime = validated.endTime
+                    description = validated.description
+                    durationMinutes = validated.durationMinutes
+                    rateCents = validated.rateCents
+                    invoiceId = null
+                    isLocked = false
+                    createdAt = currentTimestamp()
+                }
+            toResponse(entity)
+        }
+
+    fun updateTimeEntry(
+        userId: String,
+        id: String,
+        request: UpdateTimeEntryRequest,
+    ): TimeEntryResponse =
+        transaction {
+            val entity = findOwnedEntry(userId, id) ?: throw ResourceNotFoundException("Time entry not found")
+            ensureUnlocked(entity)
+            val validated =
+                validateInput(
+                    userId = userId,
+                    projectId = request.projectId,
+                    taskId = request.taskId,
+                    entryDate = request.entryDate,
+                    startTime = request.startTime,
+                    endTime = request.endTime,
+                    description = request.description,
+                    durationMinutes = request.durationMinutes,
+                    requestedRateCents = request.rateCents,
+                )
+
+            entity.projectId = validated.project.id
+            entity.taskId = validated.task.id
+            entity.entryDate = validated.entryDate
+            entity.startTime = validated.startTime
+            entity.endTime = validated.endTime
+            entity.description = validated.description
+            entity.durationMinutes = validated.durationMinutes
+            entity.rateCents = validated.rateCents
+            toResponse(entity)
+        }
+
+    fun deleteTimeEntry(
+        userId: String,
+        id: String,
+    ) {
+        transaction {
+            val entity = findOwnedEntry(userId, id) ?: throw ResourceNotFoundException("Time entry not found")
+            ensureUnlocked(entity)
+            entity.delete()
+        }
+    }
+
+    private fun findOwnedEntry(
+        userId: String,
+        id: String,
+    ): TimeEntryEntity? {
+        val userUuid = parseUuid(userId, "userId")
+        val entryUuid = parseUuid(id, "id")
+        return TimeEntryEntity
+            .find {
+                (TimeEntriesTable.id eq EntityID(entryUuid, TimeEntriesTable)) and
+                    (TimeEntriesTable.userId eq EntityID(userUuid, UsersTable))
+            }.firstOrNull()
+    }
+
+    private fun validateInput(
+        userId: String,
+        projectId: String,
+        taskId: String,
+        entryDate: String,
+        startTime: String?,
+        endTime: String?,
+        description: String?,
+        durationMinutes: Int,
+        requestedRateCents: Int?,
+    ): ValidatedTimeEntry {
+        if (durationMinutes <= 0) throw InvalidTimeEntryException("durationMinutes must be greater than 0")
+        if (requestedRateCents != null && requestedRateCents < 0) {
+            throw InvalidTimeEntryException("rateCents must be greater than or equal to 0")
+        }
+
+        val user =
+            UserEntity.findById(parseUuid(userId, "userId"))?.takeIf { !it.isDeleted }
+                ?: throw ResourceNotFoundException("User not found")
+        val project =
+            ProjectEntity.findById(parseUuid(projectId, "projectId"))?.takeIf { !it.isDeleted }
+                ?: throw ResourceNotFoundException("Project not found")
+        val client =
+            ClientEntity.findById(project.clientId)?.takeIf { !it.isDeleted }
+                ?: throw ResourceNotFoundException("Client not found")
+        val task =
+            TaskEntity.findById(parseUuid(taskId, "taskId"))?.takeIf { !it.isDeleted }
+                ?: throw ResourceNotFoundException("Task not found")
+        val resolvedRate = resolveRateCents(requestedRateCents, project.hourlyRateCents, client.hourlyRateCents)
+
+        return ValidatedTimeEntry(
+            user = user,
+            project = project,
+            task = task,
+            entryDate = parseDate(entryDate, "entryDate").toString(),
+            startTime = parseTime(startTime, "startTime"),
+            endTime = parseTime(endTime, "endTime"),
+            description = description,
+            durationMinutes = durationMinutes,
+            rateCents = resolvedRate,
+        )
+    }
+
+    private fun ensureUnlocked(entity: TimeEntryEntity) {
+        if (entity.invoiceId != null || entity.isLocked) throw TimeEntryLockedException()
+    }
+
+    private fun toResponse(
+        entity: TimeEntryEntity,
+        references: ResponseReferences? = null,
+    ): TimeEntryResponse {
+        val project =
+            references?.projects?.get(entity.projectId)
+                ?: ProjectEntity.findById(entity.projectId)
+                ?: throw ResourceNotFoundException("Project not found")
+        val client =
+            references?.clients?.get(project.clientId)
+                ?: ClientEntity.findById(project.clientId)
+                ?: throw ResourceNotFoundException("Client not found")
+        val task =
+            references?.tasks?.get(entity.taskId)
+                ?: TaskEntity.findById(entity.taskId)
+                ?: throw ResourceNotFoundException("Task not found")
+        val currency =
+            references?.currencies?.get(client.currencyId)
+                ?: CurrencyEntity.findById(client.currencyId)
+                ?: throw ResourceNotFoundException("Currency not found")
+        val rate = resolveRateCents(entity.rateCents, project.hourlyRateCents, client.hourlyRateCents)
+        return TimeEntryResponse(
+            id = entity.id.value.toString(),
+            projectId = project.id.value.toString(),
+            projectName = project.name,
+            taskId = task.id.value.toString(),
+            taskName = task.name,
+            clientId = client.id.value.toString(),
+            clientName = client.name,
+            currencyId = currency.id.value.toString(),
+            currencyAcronym = currency.acronym,
+            userId = entity.userId.value.toString(),
+            entryDate = entity.entryDate,
+            startTime = entity.startTime,
+            endTime = entity.endTime,
+            description = entity.description,
+            durationMinutes = entity.durationMinutes,
+            rateCents = rate,
+            amountCents = calculateAmountCents(rate, entity.durationMinutes),
+            invoiceId = entity.invoiceId?.value?.toString(),
+            isLocked = entity.isLocked || entity.invoiceId != null,
+            createdAt = entity.createdAt,
+        )
+    }
+
+    private fun loadResponseReferences(entries: List<TimeEntryEntity>): ResponseReferences {
+        if (entries.isEmpty()) return ResponseReferences()
+
+        val projects =
+            ProjectEntity
+                .find { ProjectsTable.id inList entries.map { it.projectId }.distinct() }
+                .associateBy { it.id }
+        val clients =
+            ClientEntity
+                .find { ClientsTable.id inList projects.values.map { it.clientId }.distinct() }
+                .associateBy { it.id }
+        val tasks =
+            TaskEntity
+                .find { TasksTable.id inList entries.map { it.taskId }.distinct() }
+                .associateBy { it.id }
+        val currencies =
+            CurrencyEntity
+                .find { CurrencyTable.id inList clients.values.map { it.currencyId }.distinct() }
+                .associateBy { it.id }
+        return ResponseReferences(projects, clients, tasks, currencies)
+    }
+
+    private data class ResponseReferences(
+        val projects: Map<EntityID<UUID>, ProjectEntity> = emptyMap(),
+        val clients: Map<EntityID<UUID>, ClientEntity> = emptyMap(),
+        val tasks: Map<EntityID<UUID>, TaskEntity> = emptyMap(),
+        val currencies: Map<EntityID<UUID>, CurrencyEntity> = emptyMap(),
+    )
+
+    private data class ValidatedTimeEntry(
+        val user: UserEntity,
+        val project: ProjectEntity,
+        val task: TaskEntity,
+        val entryDate: String,
+        val startTime: String?,
+        val endTime: String?,
+        val description: String?,
+        val durationMinutes: Int,
+        val rateCents: Int,
+    )
+
+    companion object {
+        private val isoDatePattern = Regex("\\d{4}-\\d{2}-\\d{2}")
+        private val timestampFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+
+        internal fun resolveRateCents(
+            entryRateCents: Int?,
+            projectRateCents: Int?,
+            clientRateCents: Int?,
+        ): Int = entryRateCents ?: projectRateCents ?: clientRateCents ?: throw TimeEntryRateNotFoundException()
+
+        internal fun calculateAmountCents(
+            rateCents: Int,
+            durationMinutes: Int,
+        ): Int {
+            if (rateCents < 0) throw InvalidTimeEntryException("rateCents must be greater than or equal to 0")
+            if (durationMinutes <= 0) throw InvalidTimeEntryException("durationMinutes must be greater than 0")
+            return try {
+                BigDecimal
+                    .valueOf(rateCents.toLong())
+                    .multiply(BigDecimal.valueOf(durationMinutes.toLong()))
+                    .divide(BigDecimal.valueOf(60L), 0, RoundingMode.HALF_UP)
+                    .intValueExact()
+            } catch (_: ArithmeticException) {
+                throw InvalidTimeEntryException("Calculated amount exceeds the supported range")
+            }
+        }
+
+        private fun parseUuid(
+            value: String,
+            field: String,
+        ): UUID =
+            try {
+                UUID.fromString(value)
+            } catch (_: IllegalArgumentException) {
+                throw InvalidTimeEntryException("$field must be a valid UUID")
+            }
+
+        private fun parseDate(
+            value: String,
+            field: String,
+        ): LocalDate {
+            if (!isoDatePattern.matches(value)) {
+                throw InvalidTimeEntryException("$field must use YYYY-MM-DD format")
+            }
+            return try {
+                LocalDate.parse(value, DateTimeFormatter.ISO_LOCAL_DATE)
+            } catch (_: DateTimeParseException) {
+                throw InvalidTimeEntryException("$field must use YYYY-MM-DD format")
+            }
+        }
+
+        private fun parseTime(
+            value: String?,
+            field: String,
+        ): String? =
+            value?.let {
+                try {
+                    LocalTime.parse(it, DateTimeFormatter.ISO_LOCAL_TIME).toString()
+                } catch (_: DateTimeParseException) {
+                    throw InvalidTimeEntryException("$field must use ISO local time format")
+                }
+            }
+
+        private fun currentTimestamp(): String = LocalDateTime.now(ZoneOffset.UTC).format(timestampFormatter)
+    }
+}

--- a/server/app/src/main/kotlin/pos/ambrosia/services/TimeEntryService.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/services/TimeEntryService.kt
@@ -35,40 +35,40 @@ import java.util.UUID
 
 class TimeEntryService {
     fun getTimeEntries(
-        from: String,
-        to: String,
-        projectId: String? = null,
-        taskId: String? = null,
+        startDate: String,
+        endDate: String,
+        selectedProjectId: String? = null,
+        selectedTaskId: String? = null,
     ): List<TimeEntryResponse> =
         transaction {
-            val fromDate = parseDate(from, "from")
-            val toDate = parseDate(to, "to")
-            if (fromDate > toDate) throw InvalidTimeEntryException("from must be before or equal to to")
+            val rangeStartDate = parseDate(startDate, "from")
+            val rangeEndDate = parseDate(endDate, "to")
+            if (rangeStartDate > rangeEndDate) throw InvalidTimeEntryException("from must be before or equal to to")
 
-            var condition: Op<Boolean> =
-                (TimeEntriesTable.entryDate greaterEq fromDate.toString()) and
-                        (TimeEntriesTable.entryDate lessEq toDate.toString())
-            projectId?.let {
-                condition =
-                    condition and
-                            (TimeEntriesTable.projectId eq EntityID(parseUuid(it, "project_id"), ProjectsTable))
+            var queryCondition: Op<Boolean> =
+                (TimeEntriesTable.entryDate greaterEq rangeStartDate.toString()) and
+                    (TimeEntriesTable.entryDate lessEq rangeEndDate.toString())
+            selectedProjectId?.let { requestedProjectId ->
+                queryCondition =
+                    queryCondition and
+                    (TimeEntriesTable.projectId eq EntityID(parseUuid(requestedProjectId, "project_id"), ProjectsTable))
             }
-            taskId?.let {
-                condition =
-                    condition and
-                            (TimeEntriesTable.taskId eq EntityID(parseUuid(it, "task_id"), TasksTable))
+            selectedTaskId?.let { requestedTaskId ->
+                queryCondition =
+                    queryCondition and
+                    (TimeEntriesTable.taskId eq EntityID(parseUuid(requestedTaskId, "task_id"), TasksTable))
             }
 
-            val entries =
+            val timeEntries =
                 TimeEntryEntity
-                    .find { condition }
+                    .find { queryCondition }
                     .orderBy(
                         TimeEntriesTable.entryDate to SortOrder.ASC,
                         TimeEntriesTable.startTime to SortOrder.ASC,
                         TimeEntriesTable.createdAt to SortOrder.ASC,
                     ).toList()
-            val references = loadResponseReferences(entries)
-            entries.map { toResponse(it, references) }
+            val responseReferences = loadResponseReferences(timeEntries)
+            timeEntries.map { timeEntry -> toResponse(timeEntry, responseReferences) }
         }
 
     fun getTimeEntryById(id: String): TimeEntryResponse? =
@@ -78,7 +78,7 @@ class TimeEntryService {
 
     fun createTimeEntry(request: CreateTimeEntryRequest): TimeEntryResponse =
         transaction {
-            val validated =
+            val validatedTimeEntryInput =
                 validateInput(
                     projectId = request.projectId,
                     taskId = request.taskId,
@@ -88,21 +88,21 @@ class TimeEntryService {
                     description = request.description,
                     durationMinutes = request.durationMinutes,
                 )
-            val entity =
+            val timeEntry =
                 TimeEntryEntity.new(UUID.randomUUID()) {
-                    projectId = validated.project.id
-                    taskId = validated.task.id
-                    entryDate = validated.entryDate
-                    startTime = validated.startTime
-                    endTime = validated.endTime
-                    description = validated.description
-                    durationMinutes = validated.durationMinutes
-                    isBillable = validated.isBillable
+                    projectId = validatedTimeEntryInput.project.id
+                    taskId = validatedTimeEntryInput.task.id
+                    entryDate = validatedTimeEntryInput.entryDate
+                    startTime = validatedTimeEntryInput.startTime
+                    endTime = validatedTimeEntryInput.endTime
+                    description = validatedTimeEntryInput.description
+                    durationMinutes = validatedTimeEntryInput.durationMinutes
+                    isBillable = validatedTimeEntryInput.isBillable
                     invoiceId = null
                     isLocked = false
                     createdAt = currentTimestamp()
                 }
-            toResponse(entity)
+            toResponse(timeEntry)
         }
 
     fun updateTimeEntry(
@@ -110,9 +110,9 @@ class TimeEntryService {
         request: UpdateTimeEntryRequest,
     ): TimeEntryResponse =
         transaction {
-            val entity = findEntry(id) ?: throw ResourceNotFoundException("Time entry not found")
-            ensureUnlocked(entity)
-            val validated =
+            val timeEntry = findEntry(id) ?: throw ResourceNotFoundException("Time entry not found")
+            ensureUnlocked(timeEntry)
+            val validatedTimeEntryInput =
                 validateInput(
                     projectId = request.projectId,
                     taskId = request.taskId,
@@ -123,22 +123,22 @@ class TimeEntryService {
                     durationMinutes = request.durationMinutes,
                 )
 
-            entity.projectId = validated.project.id
-            entity.taskId = validated.task.id
-            entity.entryDate = validated.entryDate
-            entity.startTime = validated.startTime
-            entity.endTime = validated.endTime
-            entity.description = validated.description
-            entity.durationMinutes = validated.durationMinutes
-            entity.isBillable = validated.isBillable
-            toResponse(entity)
+            timeEntry.projectId = validatedTimeEntryInput.project.id
+            timeEntry.taskId = validatedTimeEntryInput.task.id
+            timeEntry.entryDate = validatedTimeEntryInput.entryDate
+            timeEntry.startTime = validatedTimeEntryInput.startTime
+            timeEntry.endTime = validatedTimeEntryInput.endTime
+            timeEntry.description = validatedTimeEntryInput.description
+            timeEntry.durationMinutes = validatedTimeEntryInput.durationMinutes
+            timeEntry.isBillable = validatedTimeEntryInput.isBillable
+            toResponse(timeEntry)
         }
 
     fun deleteTimeEntry(id: String) {
         transaction {
-            val entity = findEntry(id) ?: throw ResourceNotFoundException("Time entry not found")
-            ensureUnlocked(entity)
-            entity.delete()
+            val timeEntry = findEntry(id) ?: throw ResourceNotFoundException("Time entry not found")
+            ensureUnlocked(timeEntry)
+            timeEntry.delete()
         }
     }
 
@@ -184,58 +184,58 @@ class TimeEntryService {
         )
     }
 
-    private fun ensureUnlocked(entity: TimeEntryEntity) {
-        if (entity.invoiceId != null || entity.isLocked) throw TimeEntryLockedException()
+    private fun ensureUnlocked(timeEntry: TimeEntryEntity) {
+        if (timeEntry.invoiceId != null || timeEntry.isLocked) throw TimeEntryLockedException()
     }
 
     private fun toResponse(
-        entity: TimeEntryEntity,
-        references: ResponseReferences? = null,
+        timeEntry: TimeEntryEntity,
+        responseReferences: ResponseReferences? = null,
     ): TimeEntryResponse {
         val project =
-            references?.projects?.get(entity.projectId)
-                ?: ProjectEntity.findById(entity.projectId)
+            responseReferences?.projectsById?.get(timeEntry.projectId)
+                ?: ProjectEntity.findById(timeEntry.projectId)
                 ?: throw ResourceNotFoundException("Project not found")
         val client =
-            references?.clients?.get(project.clientId)
+            responseReferences?.clientsById?.get(project.clientId)
                 ?: ClientEntity.findById(project.clientId)
                 ?: throw ResourceNotFoundException("Client not found")
         val task =
-            references?.tasks?.get(entity.taskId)
-                ?: TaskEntity.findById(entity.taskId)
+            responseReferences?.tasksById?.get(timeEntry.taskId)
+                ?: TaskEntity.findById(timeEntry.taskId)
                 ?: throw ResourceNotFoundException("Task not found")
         val currency =
-            references?.currencies?.get(client.currencyId)
+            responseReferences?.currenciesById?.get(client.currencyId)
                 ?: CurrencyEntity.findById(client.currencyId)
                 ?: throw ResourceNotFoundException("Currency not found")
         return TimeEntryResponse(
-            id = entity.id.value.toString(),
+            id = timeEntry.id.value.toString(),
             projectId = project.id.value.toString(),
             projectName = project.name,
             taskId = task.id.value.toString(),
             taskName = task.name,
-            isBillable = entity.isBillable,
+            isBillable = timeEntry.isBillable,
             clientId = client.id.value.toString(),
             clientName = client.name,
             currencyId = currency.id.value.toString(),
             currencyAcronym = currency.acronym,
-            entryDate = entity.entryDate,
-            startTime = entity.startTime,
-            endTime = entity.endTime,
-            description = entity.description,
-            durationMinutes = entity.durationMinutes,
-            invoiceId = entity.invoiceId?.value?.toString(),
-            isLocked = entity.isLocked || entity.invoiceId != null,
-            createdAt = entity.createdAt,
+            entryDate = timeEntry.entryDate,
+            startTime = timeEntry.startTime,
+            endTime = timeEntry.endTime,
+            description = timeEntry.description,
+            durationMinutes = timeEntry.durationMinutes,
+            invoiceId = timeEntry.invoiceId?.value?.toString(),
+            isLocked = timeEntry.isLocked || timeEntry.invoiceId != null,
+            createdAt = timeEntry.createdAt,
         )
     }
 
-    private fun loadResponseReferences(entries: List<TimeEntryEntity>): ResponseReferences {
-        if (entries.isEmpty()) return ResponseReferences()
+    private fun loadResponseReferences(timeEntries: List<TimeEntryEntity>): ResponseReferences {
+        if (timeEntries.isEmpty()) return ResponseReferences()
 
         val projects =
             ProjectEntity
-                .find { ProjectsTable.id inList entries.map { it.projectId }.distinct() }
+                .find { ProjectsTable.id inList timeEntries.map { it.projectId }.distinct() }
                 .associateBy { it.id }
         val clients =
             ClientEntity
@@ -243,7 +243,7 @@ class TimeEntryService {
                 .associateBy { it.id }
         val tasks =
             TaskEntity
-                .find { TasksTable.id inList entries.map { it.taskId }.distinct() }
+                .find { TasksTable.id inList timeEntries.map { it.taskId }.distinct() }
                 .associateBy { it.id }
         val currencies =
             CurrencyEntity
@@ -253,10 +253,10 @@ class TimeEntryService {
     }
 
     private data class ResponseReferences(
-        val projects: Map<EntityID<UUID>, ProjectEntity> = emptyMap(),
-        val clients: Map<EntityID<UUID>, ClientEntity> = emptyMap(),
-        val tasks: Map<EntityID<UUID>, TaskEntity> = emptyMap(),
-        val currencies: Map<EntityID<UUID>, CurrencyEntity> = emptyMap(),
+        val projectsById: Map<EntityID<UUID>, ProjectEntity> = emptyMap(),
+        val clientsById: Map<EntityID<UUID>, ClientEntity> = emptyMap(),
+        val tasksById: Map<EntityID<UUID>, TaskEntity> = emptyMap(),
+        val currenciesById: Map<EntityID<UUID>, CurrencyEntity> = emptyMap(),
     )
 
     private data class ValidatedTimeEntry(
@@ -275,38 +275,38 @@ class TimeEntryService {
         private val timestampFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
 
         private fun parseUuid(
-            value: String,
-            field: String,
+            rawValue: String,
+            fieldName: String,
         ): UUID =
             try {
-                UUID.fromString(value)
+                UUID.fromString(rawValue)
             } catch (_: IllegalArgumentException) {
-                throw InvalidTimeEntryException("$field must be a valid UUID")
+                throw InvalidTimeEntryException("$fieldName must be a valid UUID")
             }
 
         private fun parseDate(
-            value: String,
-            field: String,
+            rawValue: String,
+            fieldName: String,
         ): LocalDate {
-            if (!isoDatePattern.matches(value)) {
-                throw InvalidTimeEntryException("$field must use YYYY-MM-DD format")
+            if (!isoDatePattern.matches(rawValue)) {
+                throw InvalidTimeEntryException("$fieldName must use YYYY-MM-DD format")
             }
             return try {
-                LocalDate.parse(value, DateTimeFormatter.ISO_LOCAL_DATE)
+                LocalDate.parse(rawValue, DateTimeFormatter.ISO_LOCAL_DATE)
             } catch (_: DateTimeParseException) {
-                throw InvalidTimeEntryException("$field must use YYYY-MM-DD format")
+                throw InvalidTimeEntryException("$fieldName must use YYYY-MM-DD format")
             }
         }
 
         private fun parseTime(
-            value: String?,
-            field: String,
+            timeValue: String?,
+            fieldName: String,
         ): String? =
-            value?.let {
+            timeValue?.let {
                 try {
                     LocalTime.parse(it, DateTimeFormatter.ISO_LOCAL_TIME).toString()
                 } catch (_: DateTimeParseException) {
-                    throw InvalidTimeEntryException("$field must use ISO local time format")
+                    throw InvalidTimeEntryException("$fieldName must use ISO local time format")
                 }
             }
 

--- a/server/app/src/main/kotlin/pos/ambrosia/utils/Exceptions.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/utils/Exceptions.kt
@@ -84,6 +84,18 @@ class ResourceNotFoundException(
     message: String = "Resource not found",
 ) : RuntimeException(message)
 
+class InvalidTimeEntryException(
+    message: String = "Invalid time entry",
+) : IllegalArgumentException(message)
+
+class TimeEntryRateNotFoundException(
+    message: String = "No billing rate is available for this time entry",
+) : IllegalArgumentException(message)
+
+class TimeEntryLockedException(
+    message: String = "Time entry is locked because it belongs to an invoice",
+) : IllegalStateException(message)
+
 class InitialSetupException(
     message: String = "Initial setup failed",
 ) : RuntimeException(message)

--- a/server/app/src/main/kotlin/pos/ambrosia/utils/Exceptions.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/utils/Exceptions.kt
@@ -88,10 +88,6 @@ class InvalidTimeEntryException(
     message: String = "Invalid time entry",
 ) : IllegalArgumentException(message)
 
-class TimeEntryRateNotFoundException(
-    message: String = "No billing rate is available for this time entry",
-) : IllegalArgumentException(message)
-
 class TimeEntryLockedException(
     message: String = "Time entry is locked because it belongs to an invoice",
 ) : IllegalStateException(message)

--- a/server/app/src/main/resources/db/migration/V44__add_freelance_tables.sql
+++ b/server/app/src/main/resources/db/migration/V44__add_freelance_tables.sql
@@ -42,21 +42,19 @@ CREATE TABLE time_entries (
 	id BLOB NOT NULL,
 	project_id BLOB NOT NULL,
 	task_id BLOB NOT NULL,
-	user_id BLOB NOT NULL,
 	entry_date TEXT NOT NULL,
   start_time TEXT,
   end_time TEXT,
 	description TEXT,
 	duration_minutes INTEGER NOT NULL CHECK (duration_minutes >= 0),
-	rate_cents INTEGER CHECK (rate_cents >= 0),
+	is_billable BOOLEAN NOT NULL DEFAULT 1,
 	invoice_id BLOB,
 	is_locked BOOLEAN NOT NULL DEFAULT 0,
   created_at TEXT NOT NULL DEFAULT (datetime('now')),
 	PRIMARY KEY(id),
 	FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE RESTRICT,
 	FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE RESTRICT,
-	FOREIGN KEY (invoice_id) REFERENCES invoices(id) ON DELETE RESTRICT,
-	FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE RESTRICT
+	FOREIGN KEY (invoice_id) REFERENCES invoices(id) ON DELETE RESTRICT
 );
 
 CREATE TABLE payout_accounts (

--- a/server/app/src/main/resources/db/migration/V46__add_time_entry_indexes.sql
+++ b/server/app/src/main/resources/db/migration/V46__add_time_entry_indexes.sql
@@ -1,0 +1,5 @@
+CREATE INDEX idx_time_entries_project_date
+    ON time_entries(project_id, entry_date);
+
+CREATE INDEX idx_time_entries_invoice
+    ON time_entries(invoice_id);

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/TimeEntriesRouteTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/TimeEntriesRouteTest.kt
@@ -1,0 +1,330 @@
+package pos.ambrosia.utest
+
+import io.ktor.client.request.delete
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.put
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.install
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.testing.testApplication
+import kotlinx.serialization.json.Json
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.junit.After
+import org.junit.Before
+import pos.ambrosia.api.configureTimeEntries
+import pos.ambrosia.api.handler
+import pos.ambrosia.db.tables.TimeEntryEntity
+import pos.ambrosia.db.tables.UserEntity
+import pos.ambrosia.db.tables.UsersTable
+import pos.ambrosia.models.TimeEntryResponse
+import pos.ambrosia.utils.ExposedTestDb
+import pos.ambrosia.utils.grantPermission
+import pos.ambrosia.utils.grantPermissions
+import pos.ambrosia.utils.installNonAdminAuth
+import pos.ambrosia.utils.withAuthCookies
+import java.io.File
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class TimeEntriesRouteTest {
+    private lateinit var databaseFile: File
+
+    @Before
+    fun setUp() {
+        databaseFile = ExposedTestDb.connect()
+    }
+
+    @After
+    fun tearDown() {
+        ExposedTestDb.cleanup(databaseFile)
+    }
+
+    @Test
+    fun `routes require authentication and the matching permission`() =
+        testApplication {
+            val auth = installNonAdminAuth("time-no-permission", "time-no-permission-user")
+            application {
+                install(ContentNegotiation) { json() }
+                handler()
+                configureTimeEntries()
+            }
+
+            assertEquals(
+                HttpStatusCode.Unauthorized,
+                client.get("/time-entries?from=2026-08-17&to=2026-08-23").status,
+            )
+            assertEquals(HttpStatusCode.Unauthorized, client.post("/time-entries").status)
+            assertEquals(HttpStatusCode.Unauthorized, client.put("/time-entries/${UUID.randomUUID()}").status)
+            assertEquals(HttpStatusCode.Unauthorized, client.delete("/time-entries/${UUID.randomUUID()}").status)
+
+            assertEquals(
+                HttpStatusCode.Forbidden,
+                client
+                    .get("/time-entries?from=2026-08-17&to=2026-08-23") {
+                        withAuthCookies(auth)
+                    }.status,
+            )
+            assertEquals(
+                HttpStatusCode.Forbidden,
+                client.post("/time-entries") { withAuthCookies(auth) }.status,
+            )
+            assertEquals(
+                HttpStatusCode.Forbidden,
+                client.put("/time-entries/${UUID.randomUUID()}") { withAuthCookies(auth) }.status,
+            )
+            assertEquals(
+                HttpStatusCode.Forbidden,
+                client.delete("/time-entries/${UUID.randomUUID()}") { withAuthCookies(auth) }.status,
+            )
+        }
+
+    @Test
+    fun `post uses authenticated user and returns enriched entry`() =
+        testApplication {
+            val auth = installNonAdminAuth("time-create-role", "time-create-user")
+            grantPermission("time-create-role", "time_entries_create")
+            val fixture = seedFixture()
+            application {
+                install(ContentNegotiation) { json() }
+                handler()
+                configureTimeEntries()
+            }
+
+            val response =
+                client.post("/time-entries") {
+                    withAuthCookies(auth)
+                    header(HttpHeaders.ContentType, "application/json")
+                    setBody(requestBody(fixture.projectId, fixture.taskId))
+                }
+
+            assertEquals(HttpStatusCode.Created, response.status)
+            val body = Json.decodeFromString<TimeEntryResponse>(response.bodyAsText())
+            assertEquals(authenticatedUserId("time-create-user"), body.userId)
+            assertEquals("Project Alpha", body.projectName)
+            assertEquals("Development", body.taskName)
+            assertEquals(12_000, body.rateCents)
+            assertEquals(3_400, body.amountCents)
+        }
+
+    @Test
+    fun `get requires from and to and returns weekly entries`() =
+        testApplication {
+            val auth = installNonAdminAuth("time-read-role", "time-read-user")
+            grantPermission("time-read-role", "time_entries_read")
+            val fixture = seedFixture()
+            val userId = authenticatedUserId("time-read-user")
+            ExposedTestDb.seedTimeEntry(userId, fixture.projectId, fixture.taskId, "2026-08-19")
+            application {
+                install(ContentNegotiation) { json() }
+                handler()
+                configureTimeEntries()
+            }
+
+            assertEquals(
+                HttpStatusCode.BadRequest,
+                client.get("/time-entries?from=2026-08-17") { withAuthCookies(auth) }.status,
+            )
+            val response =
+                client.get("/time-entries?from=2026-08-17&to=2026-08-23") {
+                    withAuthCookies(auth)
+                }
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertEquals(1, Json.decodeFromString<List<TimeEntryResponse>>(response.bodyAsText()).size)
+        }
+
+    @Test
+    fun `put rejects an invoice linked entry with conflict`() =
+        testApplication {
+            val auth = installNonAdminAuth("time-update-role", "time-update-user")
+            grantPermission("time-update-role", "time_entries_update")
+            val fixture = seedFixture()
+            val userId = authenticatedUserId("time-update-user")
+            val invoiceId = ExposedTestDb.seedInvoice(fixture.clientId, fixture.currencyId)
+            val entryId =
+                ExposedTestDb.seedTimeEntry(userId, fixture.projectId, fixture.taskId, invoiceId = invoiceId)
+            application {
+                install(ContentNegotiation) { json() }
+                handler()
+                configureTimeEntries()
+            }
+
+            val response =
+                client.put("/time-entries/$entryId") {
+                    withAuthCookies(auth)
+                    header(HttpHeaders.ContentType, "application/json")
+                    setBody(requestBody(fixture.projectId, fixture.taskId))
+                }
+
+            assertEquals(HttpStatusCode.Conflict, response.status)
+        }
+
+    @Test
+    fun `delete removes an unlocked entry and rejects a locked entry`() =
+        testApplication {
+            val auth = installNonAdminAuth("time-delete-role", "time-delete-user")
+            grantPermission("time-delete-role", "time_entries_delete")
+            val fixture = seedFixture()
+            val userId = authenticatedUserId("time-delete-user")
+            val unlockedId = ExposedTestDb.seedTimeEntry(userId, fixture.projectId, fixture.taskId)
+            val lockedId = ExposedTestDb.seedTimeEntry(userId, fixture.projectId, fixture.taskId, isLocked = true)
+            application {
+                install(ContentNegotiation) { json() }
+                handler()
+                configureTimeEntries()
+            }
+
+            assertEquals(
+                HttpStatusCode.NoContent,
+                client.delete("/time-entries/$unlockedId") { withAuthCookies(auth) }.status,
+            )
+            assertEquals(
+                HttpStatusCode.Conflict,
+                client.delete("/time-entries/$lockedId") { withAuthCookies(auth) }.status,
+            )
+        }
+
+    @Test
+    fun `malformed id and invalid request return bad request`() =
+        testApplication {
+            val auth = installNonAdminAuth("time-invalid-role", "time-invalid-user")
+            grantPermissions("time-invalid-role", "time_entries_read", "time_entries_create")
+            application {
+                install(ContentNegotiation) { json() }
+                handler()
+                configureTimeEntries()
+            }
+
+            assertEquals(
+                HttpStatusCode.BadRequest,
+                client.get("/time-entries/not-a-uuid") { withAuthCookies(auth) }.status,
+            )
+            assertEquals(
+                HttpStatusCode.BadRequest,
+                client.get("/time-entries?from=2026-08-24&to=2026-08-17") { withAuthCookies(auth) }.status,
+            )
+            val malformedBodyResponse =
+                client.post("/time-entries") {
+                    withAuthCookies(auth)
+                    header(HttpHeaders.ContentType, "application/json")
+                    setBody("{")
+                }
+            assertEquals(HttpStatusCode.BadRequest, malformedBodyResponse.status)
+        }
+
+    @Test
+    fun `routes complete create read update and physical delete`() =
+        testApplication {
+            val auth = installNonAdminAuth("time-crud-role", "time-crud-user")
+            grantPermissions(
+                "time-crud-role",
+                "time_entries_read",
+                "time_entries_create",
+                "time_entries_update",
+                "time_entries_delete",
+            )
+            val fixture = seedFixture()
+            application {
+                install(ContentNegotiation) { json() }
+                handler()
+                configureTimeEntries()
+            }
+
+            val createdResponse =
+                client.post("/time-entries") {
+                    withAuthCookies(auth)
+                    header(HttpHeaders.ContentType, "application/json")
+                    setBody(requestBody(fixture.projectId, fixture.taskId))
+                }
+            assertEquals(HttpStatusCode.Created, createdResponse.status)
+            val created = Json.decodeFromString<TimeEntryResponse>(createdResponse.bodyAsText())
+
+            val getResponse = client.get("/time-entries/${created.id}") { withAuthCookies(auth) }
+            assertEquals(HttpStatusCode.OK, getResponse.status)
+            assertEquals(created.id, Json.decodeFromString<TimeEntryResponse>(getResponse.bodyAsText()).id)
+
+            val putResponse =
+                client.put("/time-entries/${created.id}") {
+                    withAuthCookies(auth)
+                    header(HttpHeaders.ContentType, "application/json")
+                    setBody(
+                        requestBody(
+                            fixture.projectId,
+                            fixture.taskId,
+                            entryDate = "2026-08-20",
+                            description = "Updated detail",
+                            durationMinutes = 18,
+                        ),
+                    )
+                }
+            assertEquals(HttpStatusCode.OK, putResponse.status)
+            val updated = Json.decodeFromString<TimeEntryResponse>(putResponse.bodyAsText())
+            assertEquals("2026-08-20", updated.entryDate)
+            assertEquals("Updated detail", updated.description)
+            assertEquals(18, updated.durationMinutes)
+
+            assertEquals(
+                HttpStatusCode.NoContent,
+                client.delete("/time-entries/${created.id}") { withAuthCookies(auth) }.status,
+            )
+            assertEquals(
+                HttpStatusCode.NotFound,
+                client.get("/time-entries/${created.id}") { withAuthCookies(auth) }.status,
+            )
+            transaction {
+                assertNull(TimeEntryEntity.findById(UUID.fromString(created.id)))
+            }
+        }
+
+    private fun seedFixture(): Fixture {
+        val currencyId = ExposedTestDb.seedCurrency("USD")
+        val clientId = ExposedTestDb.seedClient("Client Alpha", currencyId, 10_000)
+        val projectId = ExposedTestDb.seedProject(clientId, "Project Alpha", 12_000)
+        val taskId = ExposedTestDb.seedTask("Development")
+        return Fixture(currencyId, clientId, projectId, taskId)
+    }
+
+    private fun authenticatedUserId(name: String): String =
+        transaction {
+            UserEntity
+                .find { UsersTable.name eq name }
+                .single()
+                .id.value
+                .toString()
+        }
+
+    private fun requestBody(
+        projectId: String,
+        taskId: String,
+        entryDate: String = "2026-08-19",
+        description: String = "Implemented the API",
+        durationMinutes: Int = 17,
+    ): String =
+        """
+        {
+            "projectId":"$projectId",
+            "taskId":"$taskId",
+            "entryDate":"$entryDate",
+            "startTime":"09:00",
+            "endTime":"10:00",
+            "description":"$description",
+            "durationMinutes":$durationMinutes,
+            "rateCents":null
+        }
+        """.trimIndent()
+
+    private data class Fixture(
+        val currencyId: String,
+        val clientId: String,
+        val projectId: String,
+        val taskId: String,
+    )
+}

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/TimeEntriesRouteTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/TimeEntriesRouteTest.kt
@@ -21,8 +21,6 @@ import org.junit.Before
 import pos.ambrosia.api.configureTimeEntries
 import pos.ambrosia.api.handler
 import pos.ambrosia.db.tables.TimeEntryEntity
-import pos.ambrosia.db.tables.UserEntity
-import pos.ambrosia.db.tables.UsersTable
 import pos.ambrosia.models.TimeEntryResponse
 import pos.ambrosia.utils.ExposedTestDb
 import pos.ambrosia.utils.grantPermission
@@ -33,7 +31,9 @@ import java.io.File
 import java.util.UUID
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class TimeEntriesRouteTest {
     private lateinit var databaseFile: File
@@ -88,7 +88,7 @@ class TimeEntriesRouteTest {
         }
 
     @Test
-    fun `post uses authenticated user and returns enriched entry`() =
+    fun `post returns an enriched entry`() =
         testApplication {
             val auth = installNonAdminAuth("time-create-role", "time-create-user")
             grantPermission("time-create-role", "time_entries_create")
@@ -108,11 +108,8 @@ class TimeEntriesRouteTest {
 
             assertEquals(HttpStatusCode.Created, response.status)
             val body = Json.decodeFromString<TimeEntryResponse>(response.bodyAsText())
-            assertEquals(authenticatedUserId("time-create-user"), body.userId)
             assertEquals("Project Alpha", body.projectName)
             assertEquals("Development", body.taskName)
-            assertEquals(12_000, body.rateCents)
-            assertEquals(3_400, body.amountCents)
         }
 
     @Test
@@ -121,8 +118,7 @@ class TimeEntriesRouteTest {
             val auth = installNonAdminAuth("time-read-role", "time-read-user")
             grantPermission("time-read-role", "time_entries_read")
             val fixture = seedFixture()
-            val userId = authenticatedUserId("time-read-user")
-            ExposedTestDb.seedTimeEntry(userId, fixture.projectId, fixture.taskId, "2026-08-19")
+            ExposedTestDb.seedTimeEntry(fixture.projectId, fixture.taskId, "2026-08-19")
             application {
                 install(ContentNegotiation) { json() }
                 handler()
@@ -147,10 +143,9 @@ class TimeEntriesRouteTest {
             val auth = installNonAdminAuth("time-update-role", "time-update-user")
             grantPermission("time-update-role", "time_entries_update")
             val fixture = seedFixture()
-            val userId = authenticatedUserId("time-update-user")
             val invoiceId = ExposedTestDb.seedInvoice(fixture.clientId, fixture.currencyId)
             val entryId =
-                ExposedTestDb.seedTimeEntry(userId, fixture.projectId, fixture.taskId, invoiceId = invoiceId)
+                ExposedTestDb.seedTimeEntry(fixture.projectId, fixture.taskId, invoiceId = invoiceId)
             application {
                 install(ContentNegotiation) { json() }
                 handler()
@@ -173,9 +168,8 @@ class TimeEntriesRouteTest {
             val auth = installNonAdminAuth("time-delete-role", "time-delete-user")
             grantPermission("time-delete-role", "time_entries_delete")
             val fixture = seedFixture()
-            val userId = authenticatedUserId("time-delete-user")
-            val unlockedId = ExposedTestDb.seedTimeEntry(userId, fixture.projectId, fixture.taskId)
-            val lockedId = ExposedTestDb.seedTimeEntry(userId, fixture.projectId, fixture.taskId, isLocked = true)
+            val unlockedId = ExposedTestDb.seedTimeEntry(fixture.projectId, fixture.taskId)
+            val lockedId = ExposedTestDb.seedTimeEntry(fixture.projectId, fixture.taskId, isLocked = true)
             application {
                 install(ContentNegotiation) { json() }
                 handler()
@@ -284,6 +278,83 @@ class TimeEntriesRouteTest {
             }
         }
 
+    @Test
+    fun `post returns isBillable false when project is not billable`() =
+        testApplication {
+            val auth = installNonAdminAuth("time-nb-project-role", "time-nb-project-user")
+            grantPermission("time-nb-project-role", "time_entries_create")
+            val currencyId = ExposedTestDb.seedCurrency("USD")
+            val clientId = ExposedTestDb.seedClient("Client NB", currencyId, 10_000)
+            val projectId = ExposedTestDb.seedProject(clientId, "Non-Billable Project", 12_000, isBillable = false)
+            val taskId = ExposedTestDb.seedTask("Development")
+            application {
+                install(ContentNegotiation) { json() }
+                handler()
+                configureTimeEntries()
+            }
+
+            val response =
+                client.post("/time-entries") {
+                    withAuthCookies(auth)
+                    header(HttpHeaders.ContentType, "application/json")
+                    setBody(requestBody(projectId, taskId))
+                }
+
+            assertEquals(HttpStatusCode.Created, response.status)
+            val body = Json.decodeFromString<TimeEntryResponse>(response.bodyAsText())
+            assertFalse(body.isBillable)
+        }
+
+    @Test
+    fun `post returns isBillable false when task is not billable`() =
+        testApplication {
+            val auth = installNonAdminAuth("time-nb-task-role", "time-nb-task-user")
+            grantPermission("time-nb-task-role", "time_entries_create")
+            val currencyId = ExposedTestDb.seedCurrency("USD")
+            val clientId = ExposedTestDb.seedClient("Client BT", currencyId, 10_000)
+            val projectId = ExposedTestDb.seedProject(clientId, "Billable Project", 12_000)
+            val taskId = ExposedTestDb.seedTask("Internal", isBillable = false)
+            application {
+                install(ContentNegotiation) { json() }
+                handler()
+                configureTimeEntries()
+            }
+
+            val response =
+                client.post("/time-entries") {
+                    withAuthCookies(auth)
+                    header(HttpHeaders.ContentType, "application/json")
+                    setBody(requestBody(projectId, taskId))
+                }
+
+            assertEquals(HttpStatusCode.Created, response.status)
+            val body = Json.decodeFromString<TimeEntryResponse>(response.bodyAsText())
+            assertFalse(body.isBillable)
+        }
+
+    @Test
+    fun `post returns isBillable true when both project and task are billable`() =
+        testApplication {
+            val auth = installNonAdminAuth("time-billable-role", "time-billable-user")
+            grantPermission("time-billable-role", "time_entries_create")
+            val fixture = seedFixture()
+            application {
+                install(ContentNegotiation) { json() }
+                handler()
+                configureTimeEntries()
+            }
+
+            val response =
+                client.post("/time-entries") {
+                    withAuthCookies(auth)
+                    header(HttpHeaders.ContentType, "application/json")
+                    setBody(requestBody(fixture.projectId, fixture.taskId))
+                }
+
+            assertEquals(HttpStatusCode.Created, response.status)
+            assertTrue(Json.decodeFromString<TimeEntryResponse>(response.bodyAsText()).isBillable)
+        }
+
     private fun seedFixture(): Fixture {
         val currencyId = ExposedTestDb.seedCurrency("USD")
         val clientId = ExposedTestDb.seedClient("Client Alpha", currencyId, 10_000)
@@ -291,15 +362,6 @@ class TimeEntriesRouteTest {
         val taskId = ExposedTestDb.seedTask("Development")
         return Fixture(currencyId, clientId, projectId, taskId)
     }
-
-    private fun authenticatedUserId(name: String): String =
-        transaction {
-            UserEntity
-                .find { UsersTable.name eq name }
-                .single()
-                .id.value
-                .toString()
-        }
 
     private fun requestBody(
         projectId: String,
@@ -316,8 +378,7 @@ class TimeEntriesRouteTest {
             "startTime":"09:00",
             "endTime":"10:00",
             "description":"$description",
-            "durationMinutes":$durationMinutes,
-            "rateCents":null
+            "durationMinutes":$durationMinutes
         }
         """.trimIndent()
 

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/TimeEntryIndexesMigrationTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/TimeEntryIndexesMigrationTest.kt
@@ -1,0 +1,57 @@
+package pos.ambrosia.utest
+
+import org.junit.Test
+import java.nio.file.Files
+import java.sql.DriverManager
+import kotlin.io.path.deleteIfExists
+import kotlin.test.assertEquals
+
+class TimeEntryIndexesMigrationTest {
+    @Test
+    fun `V46 creates both required time entry indexes`() {
+        val databasePath = Files.createTempFile("ambrosia-index-test", ".db")
+        try {
+            DriverManager.getConnection("jdbc:sqlite:$databasePath").use { connection ->
+                connection.createStatement().use { statement ->
+                    statement.execute(
+                        """CREATE TABLE time_entries (
+                            id BLOB PRIMARY KEY,
+                            project_id BLOB NOT NULL,
+                            entry_date TEXT NOT NULL,
+                            invoice_id BLOB
+                        )""",
+                    )
+                    val migration =
+                        checkNotNull(javaClass.classLoader.getResource("db/migration/V46__add_time_entry_indexes.sql"))
+                            .readText()
+                    migration
+                        .split(';')
+                        .map(String::trim)
+                        .filter(String::isNotEmpty)
+                        .forEach(statement::execute)
+
+                    assertEquals(
+                        listOf("project_id", "entry_date"),
+                        indexColumns(statement, "idx_time_entries_project_date"),
+                    )
+                    assertEquals(
+                        listOf("invoice_id"),
+                        indexColumns(statement, "idx_time_entries_invoice"),
+                    )
+                }
+            }
+        } finally {
+            databasePath.deleteIfExists()
+        }
+    }
+
+    private fun indexColumns(
+        statement: java.sql.Statement,
+        indexName: String,
+    ): List<String> =
+        statement.executeQuery("PRAGMA index_info('$indexName')").use { resultSet ->
+            buildList {
+                while (resultSet.next()) add(resultSet.getString("name"))
+            }
+        }
+}

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/TimeEntryServiceTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/TimeEntryServiceTest.kt
@@ -15,7 +15,9 @@ import java.util.UUID
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class TimeEntryServiceTest {
     private lateinit var databaseFile: File
@@ -210,6 +212,89 @@ class TimeEntryServiceTest {
                 createRequest(fixture).copy(taskId = UUID.randomUUID().toString()),
             )
         }
+    }
+
+    @Test
+    fun `non-billable task produces zero rate and amount and is flagged as not billable`() {
+        val roleId = ExposedTestDb.seedRole("freelancer-nb")
+        val userId = ExposedTestDb.seedUser("Freelancer", roleId)
+        val currencyId = ExposedTestDb.seedCurrency("USD")
+        val clientId = ExposedTestDb.seedClient("Client", currencyId, 10_000)
+        val projectId = ExposedTestDb.seedProject(clientId, hourlyRateCents = 12_000)
+        val taskId = ExposedTestDb.seedTask("Internal", isBillable = false)
+
+        val result = service.createTimeEntry(userId, CreateTimeEntryRequest(
+            projectId = projectId,
+            taskId = taskId,
+            entryDate = "2026-08-19",
+            durationMinutes = 60,
+        ))
+
+        assertFalse(result.isBillable)
+        assertEquals(0, result.rateCents)
+        assertEquals(0, result.amountCents)
+        assertNull(result.invoiceId)
+    }
+
+    @Test
+    fun `non-billable project produces zero rate and amount regardless of task billability`() {
+        val roleId = ExposedTestDb.seedRole("freelancer-np")
+        val userId = ExposedTestDb.seedUser("Freelancer", roleId)
+        val currencyId = ExposedTestDb.seedCurrency("USD")
+        val clientId = ExposedTestDb.seedClient("Client", currencyId, 10_000)
+        val projectId = ExposedTestDb.seedProject(clientId, hourlyRateCents = 12_000, isBillable = false)
+        val taskId = ExposedTestDb.seedTask("Development", isBillable = true)
+
+        val result = service.createTimeEntry(userId, CreateTimeEntryRequest(
+            projectId = projectId,
+            taskId = taskId,
+            entryDate = "2026-08-19",
+            durationMinutes = 60,
+        ))
+
+        assertFalse(result.isBillable)
+        assertEquals(0, result.rateCents)
+        assertEquals(0, result.amountCents)
+        assertNull(result.invoiceId)
+    }
+
+    @Test
+    fun `billable task in billable project exposes isBillable true with correct amount`() {
+        val fixture = seedFixture(projectRateCents = 12_000, clientRateCents = 10_000)
+
+        val result = service.createTimeEntry(fixture.userId, createRequest(fixture, durationMinutes = 60))
+
+        assertTrue(result.isBillable)
+        assertEquals(12_000, result.rateCents)
+        assertEquals(12_000, result.amountCents)
+    }
+
+    @Test
+    fun `non-billable entry update preserves zero rate and amount`() {
+        val roleId = ExposedTestDb.seedRole("freelancer-nu")
+        val userId = ExposedTestDb.seedUser("Freelancer", roleId)
+        val currencyId = ExposedTestDb.seedCurrency("USD")
+        val clientId = ExposedTestDb.seedClient("Client", currencyId, 10_000)
+        val projectId = ExposedTestDb.seedProject(clientId, hourlyRateCents = 12_000)
+        val taskId = ExposedTestDb.seedTask("Internal", isBillable = false)
+
+        val created = service.createTimeEntry(userId, CreateTimeEntryRequest(
+            projectId = projectId,
+            taskId = taskId,
+            entryDate = "2026-08-19",
+            durationMinutes = 60,
+        ))
+        val updated = service.updateTimeEntry(userId, created.id, UpdateTimeEntryRequest(
+            projectId = projectId,
+            taskId = taskId,
+            entryDate = "2026-08-20",
+            durationMinutes = 90,
+            rateCents = 99_999,
+        ))
+
+        assertFalse(updated.isBillable)
+        assertEquals(0, updated.rateCents)
+        assertEquals(0, updated.amountCents)
     }
 
     private fun seedFixture(

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/TimeEntryServiceTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/TimeEntryServiceTest.kt
@@ -1,0 +1,265 @@
+package pos.ambrosia.utest
+
+import org.junit.After
+import org.junit.Before
+import pos.ambrosia.models.CreateTimeEntryRequest
+import pos.ambrosia.models.UpdateTimeEntryRequest
+import pos.ambrosia.services.TimeEntryService
+import pos.ambrosia.utils.ExposedTestDb
+import pos.ambrosia.utils.InvalidTimeEntryException
+import pos.ambrosia.utils.ResourceNotFoundException
+import pos.ambrosia.utils.TimeEntryLockedException
+import pos.ambrosia.utils.TimeEntryRateNotFoundException
+import java.io.File
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+
+class TimeEntryServiceTest {
+    private lateinit var databaseFile: File
+    private val service = TimeEntryService()
+
+    @Before
+    fun setUp() {
+        databaseFile = ExposedTestDb.connect()
+    }
+
+    @After
+    fun tearDown() {
+        ExposedTestDb.cleanup(databaseFile)
+    }
+
+    @Test
+    fun `rate resolver honors all precedence levels`() {
+        assertEquals(12_000, TimeEntryService.resolveRateCents(12_000, 11_000, 10_000))
+        assertEquals(11_000, TimeEntryService.resolveRateCents(null, 11_000, 10_000))
+        assertEquals(10_000, TimeEntryService.resolveRateCents(null, null, 10_000))
+    }
+
+    @Test
+    fun `rate resolver rejects when every rate is null`() {
+        assertFailsWith<TimeEntryRateNotFoundException> {
+            TimeEntryService.resolveRateCents(null, null, null)
+        }
+    }
+
+    @Test
+    fun `amount calculation supports arbitrary minutes and half up rounding`() {
+        assertEquals(2_833, TimeEntryService.calculateAmountCents(10_000, 17))
+        assertEquals(3_000, TimeEntryService.calculateAmountCents(10_000, 18))
+        assertEquals(1, TimeEntryService.calculateAmountCents(1, 30))
+    }
+
+    @Test
+    fun `amount calculation rejects zero negative and overflow`() {
+        assertFailsWith<InvalidTimeEntryException> { TimeEntryService.calculateAmountCents(100, 0) }
+        assertFailsWith<InvalidTimeEntryException> { TimeEntryService.calculateAmountCents(-1, 60) }
+        assertFailsWith<InvalidTimeEntryException> {
+            TimeEntryService.calculateAmountCents(Int.MAX_VALUE, Int.MAX_VALUE)
+        }
+    }
+
+    @Test
+    fun `create stores project rate snapshot and returns enriched response`() {
+        val fixture = seedFixture(projectRateCents = 12_000, clientRateCents = 10_000)
+
+        val result = service.createTimeEntry(fixture.userId, createRequest(fixture, durationMinutes = 17))
+
+        assertEquals(12_000, result.rateCents)
+        assertEquals(3_400, result.amountCents)
+        assertEquals("Project Alpha", result.projectName)
+        assertEquals("Development", result.taskName)
+        assertEquals("Client Alpha", result.clientName)
+        assertEquals("USD", result.currencyAcronym)
+        assertEquals(fixture.userId, result.userId)
+        assertNull(result.invoiceId)
+    }
+
+    @Test
+    fun `create falls back to client rate and accepts explicit zero rate`() {
+        val fixture = seedFixture(projectRateCents = null, clientRateCents = 10_000)
+        val fallback = service.createTimeEntry(fixture.userId, createRequest(fixture))
+        val explicitZero = service.createTimeEntry(fixture.userId, createRequest(fixture, rateCents = 0))
+
+        assertEquals(10_000, fallback.rateCents)
+        assertEquals(0, explicitZero.rateCents)
+        assertEquals(0, explicitZero.amountCents)
+    }
+
+    @Test
+    fun `put with null rate recalculates and persists project rate`() {
+        val fixture = seedFixture(projectRateCents = 12_000, clientRateCents = 10_000)
+        val created = service.createTimeEntry(fixture.userId, createRequest(fixture, rateCents = 20_000))
+
+        val updated = service.updateTimeEntry(fixture.userId, created.id, updateRequest(fixture, rateCents = null))
+        val fetched = service.getTimeEntryById(fixture.userId, created.id)
+
+        assertEquals(12_000, updated.rateCents)
+        assertEquals(12_000, fetched?.rateCents)
+    }
+
+    @Test
+    fun `weekly query returns only owned entries in range and applies filters`() {
+        val fixture = seedFixture()
+        val otherUser = ExposedTestDb.seedUser("Other", ExposedTestDb.seedRole("other-role"))
+        val included = service.createTimeEntry(fixture.userId, createRequest(fixture, entryDate = "2026-08-19"))
+        service.createTimeEntry(fixture.userId, createRequest(fixture, entryDate = "2026-08-25"))
+        ExposedTestDb.seedTimeEntry(otherUser, fixture.projectId, fixture.taskId, "2026-08-19")
+
+        val result =
+            service.getTimeEntries(
+                userId = fixture.userId,
+                from = "2026-08-17",
+                to = "2026-08-23",
+                projectId = fixture.projectId,
+                taskId = fixture.taskId,
+            )
+
+        assertEquals(listOf(included.id), result.map { it.id })
+    }
+
+    @Test
+    fun `another user cannot read update or delete an entry`() {
+        val fixture = seedFixture()
+        val otherUser = ExposedTestDb.seedUser("Other", ExposedTestDb.seedRole("other-role"))
+        val created = service.createTimeEntry(fixture.userId, createRequest(fixture))
+
+        assertNull(service.getTimeEntryById(otherUser, created.id))
+        assertFailsWith<ResourceNotFoundException> {
+            service.updateTimeEntry(otherUser, created.id, updateRequest(fixture))
+        }
+        assertFailsWith<ResourceNotFoundException> {
+            service.deleteTimeEntry(otherUser, created.id)
+        }
+    }
+
+    @Test
+    fun `invoice linked entry rejects update and delete`() {
+        val fixture = seedFixture()
+        val invoiceId = ExposedTestDb.seedInvoice(fixture.clientId, fixture.currencyId)
+        val entryId =
+            ExposedTestDb.seedTimeEntry(
+                userId = fixture.userId,
+                projectId = fixture.projectId,
+                taskId = fixture.taskId,
+                invoiceId = invoiceId,
+            )
+        val before = service.getTimeEntryById(fixture.userId, entryId)
+
+        assertFailsWith<TimeEntryLockedException> {
+            service.updateTimeEntry(fixture.userId, entryId, updateRequest(fixture))
+        }
+        assertFailsWith<TimeEntryLockedException> {
+            service.deleteTimeEntry(fixture.userId, entryId)
+        }
+        assertEquals(before, service.getTimeEntryById(fixture.userId, entryId))
+    }
+
+    @Test
+    fun `explicitly locked entry rejects update and delete`() {
+        val fixture = seedFixture()
+        val entryId =
+            ExposedTestDb.seedTimeEntry(
+                userId = fixture.userId,
+                projectId = fixture.projectId,
+                taskId = fixture.taskId,
+                isLocked = true,
+            )
+        val before = service.getTimeEntryById(fixture.userId, entryId)
+
+        assertFailsWith<TimeEntryLockedException> {
+            service.updateTimeEntry(fixture.userId, entryId, updateRequest(fixture))
+        }
+        assertFailsWith<TimeEntryLockedException> {
+            service.deleteTimeEntry(fixture.userId, entryId)
+        }
+        assertEquals(before, service.getTimeEntryById(fixture.userId, entryId))
+    }
+
+    @Test
+    fun `invalid identifiers dates duration and references are rejected clearly`() {
+        val fixture = seedFixture()
+
+        assertFailsWith<InvalidTimeEntryException> { service.getTimeEntryById(fixture.userId, "not-a-uuid") }
+        assertFailsWith<InvalidTimeEntryException> {
+            service.getTimeEntries(fixture.userId, "08-17-2026", "2026-08-23")
+        }
+        assertFailsWith<InvalidTimeEntryException> {
+            service.createTimeEntry(fixture.userId, createRequest(fixture, entryDate = "+12026-08-19"))
+        }
+        assertFailsWith<InvalidTimeEntryException> {
+            service.createTimeEntry(fixture.userId, createRequest(fixture, durationMinutes = 0))
+        }
+        assertFailsWith<InvalidTimeEntryException> {
+            service.createTimeEntry(fixture.userId, createRequest(fixture).copy(startTime = "nine o'clock"))
+        }
+        assertFailsWith<InvalidTimeEntryException> {
+            service.createTimeEntry(fixture.userId, createRequest(fixture, rateCents = -1))
+        }
+        assertFailsWith<ResourceNotFoundException> {
+            service.createTimeEntry(
+                fixture.userId,
+                createRequest(fixture).copy(projectId = UUID.randomUUID().toString()),
+            )
+        }
+        assertFailsWith<ResourceNotFoundException> {
+            service.createTimeEntry(
+                fixture.userId,
+                createRequest(fixture).copy(taskId = UUID.randomUUID().toString()),
+            )
+        }
+    }
+
+    private fun seedFixture(
+        projectRateCents: Int? = 12_000,
+        clientRateCents: Int = 10_000,
+    ): Fixture {
+        val roleId = ExposedTestDb.seedRole("freelancer")
+        val userId = ExposedTestDb.seedUser("Freelancer", roleId)
+        val currencyId = ExposedTestDb.seedCurrency("USD")
+        val clientId = ExposedTestDb.seedClient("Client Alpha", currencyId, clientRateCents)
+        val projectId = ExposedTestDb.seedProject(clientId, "Project Alpha", projectRateCents)
+        val taskId = ExposedTestDb.seedTask("Development")
+        return Fixture(userId, currencyId, clientId, projectId, taskId)
+    }
+
+    private fun createRequest(
+        fixture: Fixture,
+        entryDate: String = "2026-08-19",
+        durationMinutes: Int = 60,
+        rateCents: Int? = null,
+    ) = CreateTimeEntryRequest(
+        projectId = fixture.projectId,
+        taskId = fixture.taskId,
+        entryDate = entryDate,
+        startTime = "09:00",
+        endTime = "10:00",
+        description = "Implemented the API",
+        durationMinutes = durationMinutes,
+        rateCents = rateCents,
+    )
+
+    private fun updateRequest(
+        fixture: Fixture,
+        rateCents: Int? = null,
+    ) = UpdateTimeEntryRequest(
+        projectId = fixture.projectId,
+        taskId = fixture.taskId,
+        entryDate = "2026-08-20",
+        startTime = "10:00",
+        endTime = "11:00",
+        description = "Updated detail",
+        durationMinutes = 60,
+        rateCents = rateCents,
+    )
+
+    private data class Fixture(
+        val userId: String,
+        val currencyId: String,
+        val clientId: String,
+        val projectId: String,
+        val taskId: String,
+    )
+}

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/TimeEntryServiceTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/TimeEntryServiceTest.kt
@@ -6,18 +6,13 @@ import pos.ambrosia.models.CreateTimeEntryRequest
 import pos.ambrosia.models.UpdateTimeEntryRequest
 import pos.ambrosia.services.TimeEntryService
 import pos.ambrosia.utils.ExposedTestDb
-import pos.ambrosia.utils.InvalidTimeEntryException
-import pos.ambrosia.utils.ResourceNotFoundException
 import pos.ambrosia.utils.TimeEntryLockedException
-import pos.ambrosia.utils.TimeEntryRateNotFoundException
 import java.io.File
-import java.util.UUID
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
-import kotlin.test.assertTrue
 
 class TimeEntryServiceTest {
     private lateinit var databaseFile: File
@@ -34,314 +29,71 @@ class TimeEntryServiceTest {
     }
 
     @Test
-    fun `rate resolver honors all precedence levels`() {
-        assertEquals(12_000, TimeEntryService.resolveRateCents(12_000, 11_000, 10_000))
-        assertEquals(11_000, TimeEntryService.resolveRateCents(null, 11_000, 10_000))
-        assertEquals(10_000, TimeEntryService.resolveRateCents(null, null, 10_000))
-    }
-
-    @Test
-    fun `rate resolver rejects when every rate is null`() {
-        assertFailsWith<TimeEntryRateNotFoundException> {
-            TimeEntryService.resolveRateCents(null, null, null)
-        }
-    }
-
-    @Test
-    fun `amount calculation supports arbitrary minutes and half up rounding`() {
-        assertEquals(2_833, TimeEntryService.calculateAmountCents(10_000, 17))
-        assertEquals(3_000, TimeEntryService.calculateAmountCents(10_000, 18))
-        assertEquals(1, TimeEntryService.calculateAmountCents(1, 30))
-    }
-
-    @Test
-    fun `amount calculation rejects zero negative and overflow`() {
-        assertFailsWith<InvalidTimeEntryException> { TimeEntryService.calculateAmountCents(100, 0) }
-        assertFailsWith<InvalidTimeEntryException> { TimeEntryService.calculateAmountCents(-1, 60) }
-        assertFailsWith<InvalidTimeEntryException> {
-            TimeEntryService.calculateAmountCents(Int.MAX_VALUE, Int.MAX_VALUE)
-        }
-    }
-
-    @Test
-    fun `create stores project rate snapshot and returns enriched response`() {
-        val fixture = seedFixture(projectRateCents = 12_000, clientRateCents = 10_000)
-
-        val result = service.createTimeEntry(fixture.userId, createRequest(fixture, durationMinutes = 17))
-
-        assertEquals(12_000, result.rateCents)
-        assertEquals(3_400, result.amountCents)
-        assertEquals("Project Alpha", result.projectName)
-        assertEquals("Development", result.taskName)
-        assertEquals("Client Alpha", result.clientName)
-        assertEquals("USD", result.currencyAcronym)
-        assertEquals(fixture.userId, result.userId)
-        assertNull(result.invoiceId)
-    }
-
-    @Test
-    fun `create falls back to client rate and accepts explicit zero rate`() {
-        val fixture = seedFixture(projectRateCents = null, clientRateCents = 10_000)
-        val fallback = service.createTimeEntry(fixture.userId, createRequest(fixture))
-        val explicitZero = service.createTimeEntry(fixture.userId, createRequest(fixture, rateCents = 0))
-
-        assertEquals(10_000, fallback.rateCents)
-        assertEquals(0, explicitZero.rateCents)
-        assertEquals(0, explicitZero.amountCents)
-    }
-
-    @Test
-    fun `put with null rate recalculates and persists project rate`() {
-        val fixture = seedFixture(projectRateCents = 12_000, clientRateCents = 10_000)
-        val created = service.createTimeEntry(fixture.userId, createRequest(fixture, rateCents = 20_000))
-
-        val updated = service.updateTimeEntry(fixture.userId, created.id, updateRequest(fixture, rateCents = null))
-        val fetched = service.getTimeEntryById(fixture.userId, created.id)
-
-        assertEquals(12_000, updated.rateCents)
-        assertEquals(12_000, fetched?.rateCents)
-    }
-
-    @Test
-    fun `weekly query returns only owned entries in range and applies filters`() {
+    fun `creates a time entry without user or price`() {
         val fixture = seedFixture()
-        val otherUser = ExposedTestDb.seedUser("Other", ExposedTestDb.seedRole("other-role"))
-        val included = service.createTimeEntry(fixture.userId, createRequest(fixture, entryDate = "2026-08-19"))
-        service.createTimeEntry(fixture.userId, createRequest(fixture, entryDate = "2026-08-25"))
-        ExposedTestDb.seedTimeEntry(otherUser, fixture.projectId, fixture.taskId, "2026-08-19")
+        val entry = service.createTimeEntry(request(fixture))
 
-        val result =
-            service.getTimeEntries(
-                userId = fixture.userId,
-                from = "2026-08-17",
-                to = "2026-08-23",
-                projectId = fixture.projectId,
-                taskId = fixture.taskId,
-            )
-
-        assertEquals(listOf(included.id), result.map { it.id })
+        assertEquals(fixture.projectId, entry.projectId)
+        assertEquals(fixture.taskId, entry.taskId)
+        assertEquals(60, entry.durationMinutes)
+        assertNull(entry.invoiceId)
     }
 
     @Test
-    fun `another user cannot read update or delete an entry`() {
+    fun `lists entries by date and project`() {
         val fixture = seedFixture()
-        val otherUser = ExposedTestDb.seedUser("Other", ExposedTestDb.seedRole("other-role"))
-        val created = service.createTimeEntry(fixture.userId, createRequest(fixture))
+        val included = service.createTimeEntry(request(fixture, "2026-08-19"))
+        service.createTimeEntry(request(fixture, "2026-08-25"))
 
-        assertNull(service.getTimeEntryById(otherUser, created.id))
-        assertFailsWith<ResourceNotFoundException> {
-            service.updateTimeEntry(otherUser, created.id, updateRequest(fixture))
-        }
-        assertFailsWith<ResourceNotFoundException> {
-            service.deleteTimeEntry(otherUser, created.id)
-        }
+        val entries = service.getTimeEntries("2026-08-17", "2026-08-23", fixture.projectId)
+
+        assertEquals(listOf(included.id), entries.map { it.id })
     }
 
     @Test
-    fun `invoice linked entry rejects update and delete`() {
+    fun `preserves whether an entry is billable`() {
+        val fixture = seedFixture(isBillable = false)
+
+        assertFalse(service.createTimeEntry(request(fixture)).isBillable)
+    }
+
+    @Test
+    fun `invoice linked entries cannot be changed or deleted`() {
         val fixture = seedFixture()
         val invoiceId = ExposedTestDb.seedInvoice(fixture.clientId, fixture.currencyId)
-        val entryId =
-            ExposedTestDb.seedTimeEntry(
-                userId = fixture.userId,
-                projectId = fixture.projectId,
-                taskId = fixture.taskId,
-                invoiceId = invoiceId,
-            )
-        val before = service.getTimeEntryById(fixture.userId, entryId)
+        val entryId = ExposedTestDb.seedTimeEntry(fixture.projectId, fixture.taskId, invoiceId = invoiceId)
 
-        assertFailsWith<TimeEntryLockedException> {
-            service.updateTimeEntry(fixture.userId, entryId, updateRequest(fixture))
-        }
-        assertFailsWith<TimeEntryLockedException> {
-            service.deleteTimeEntry(fixture.userId, entryId)
-        }
-        assertEquals(before, service.getTimeEntryById(fixture.userId, entryId))
+        assertFailsWith<TimeEntryLockedException> { service.updateTimeEntry(entryId, updateRequest(fixture)) }
+        assertFailsWith<TimeEntryLockedException> { service.deleteTimeEntry(entryId) }
     }
 
-    @Test
-    fun `explicitly locked entry rejects update and delete`() {
-        val fixture = seedFixture()
-        val entryId =
-            ExposedTestDb.seedTimeEntry(
-                userId = fixture.userId,
-                projectId = fixture.projectId,
-                taskId = fixture.taskId,
-                isLocked = true,
-            )
-        val before = service.getTimeEntryById(fixture.userId, entryId)
-
-        assertFailsWith<TimeEntryLockedException> {
-            service.updateTimeEntry(fixture.userId, entryId, updateRequest(fixture))
-        }
-        assertFailsWith<TimeEntryLockedException> {
-            service.deleteTimeEntry(fixture.userId, entryId)
-        }
-        assertEquals(before, service.getTimeEntryById(fixture.userId, entryId))
-    }
-
-    @Test
-    fun `invalid identifiers dates duration and references are rejected clearly`() {
-        val fixture = seedFixture()
-
-        assertFailsWith<InvalidTimeEntryException> { service.getTimeEntryById(fixture.userId, "not-a-uuid") }
-        assertFailsWith<InvalidTimeEntryException> {
-            service.getTimeEntries(fixture.userId, "08-17-2026", "2026-08-23")
-        }
-        assertFailsWith<InvalidTimeEntryException> {
-            service.createTimeEntry(fixture.userId, createRequest(fixture, entryDate = "+12026-08-19"))
-        }
-        assertFailsWith<InvalidTimeEntryException> {
-            service.createTimeEntry(fixture.userId, createRequest(fixture, durationMinutes = 0))
-        }
-        assertFailsWith<InvalidTimeEntryException> {
-            service.createTimeEntry(fixture.userId, createRequest(fixture).copy(startTime = "nine o'clock"))
-        }
-        assertFailsWith<InvalidTimeEntryException> {
-            service.createTimeEntry(fixture.userId, createRequest(fixture, rateCents = -1))
-        }
-        assertFailsWith<ResourceNotFoundException> {
-            service.createTimeEntry(
-                fixture.userId,
-                createRequest(fixture).copy(projectId = UUID.randomUUID().toString()),
-            )
-        }
-        assertFailsWith<ResourceNotFoundException> {
-            service.createTimeEntry(
-                fixture.userId,
-                createRequest(fixture).copy(taskId = UUID.randomUUID().toString()),
-            )
-        }
-    }
-
-    @Test
-    fun `non-billable task produces zero rate and amount and is flagged as not billable`() {
-        val roleId = ExposedTestDb.seedRole("freelancer-nb")
-        val userId = ExposedTestDb.seedUser("Freelancer", roleId)
+    private fun seedFixture(isBillable: Boolean = true): Fixture {
         val currencyId = ExposedTestDb.seedCurrency("USD")
         val clientId = ExposedTestDb.seedClient("Client", currencyId, 10_000)
-        val projectId = ExposedTestDb.seedProject(clientId, hourlyRateCents = 12_000)
-        val taskId = ExposedTestDb.seedTask("Internal", isBillable = false)
-
-        val result = service.createTimeEntry(userId, CreateTimeEntryRequest(
-            projectId = projectId,
-            taskId = taskId,
-            entryDate = "2026-08-19",
-            durationMinutes = 60,
-        ))
-
-        assertFalse(result.isBillable)
-        assertEquals(0, result.rateCents)
-        assertEquals(0, result.amountCents)
-        assertNull(result.invoiceId)
+        val projectId = ExposedTestDb.seedProject(clientId, isBillable = isBillable)
+        return Fixture(currencyId, clientId, projectId, ExposedTestDb.seedTask("Development"))
     }
 
-    @Test
-    fun `non-billable project produces zero rate and amount regardless of task billability`() {
-        val roleId = ExposedTestDb.seedRole("freelancer-np")
-        val userId = ExposedTestDb.seedUser("Freelancer", roleId)
-        val currencyId = ExposedTestDb.seedCurrency("USD")
-        val clientId = ExposedTestDb.seedClient("Client", currencyId, 10_000)
-        val projectId = ExposedTestDb.seedProject(clientId, hourlyRateCents = 12_000, isBillable = false)
-        val taskId = ExposedTestDb.seedTask("Development", isBillable = true)
-
-        val result = service.createTimeEntry(userId, CreateTimeEntryRequest(
-            projectId = projectId,
-            taskId = taskId,
-            entryDate = "2026-08-19",
-            durationMinutes = 60,
-        ))
-
-        assertFalse(result.isBillable)
-        assertEquals(0, result.rateCents)
-        assertEquals(0, result.amountCents)
-        assertNull(result.invoiceId)
-    }
-
-    @Test
-    fun `billable task in billable project exposes isBillable true with correct amount`() {
-        val fixture = seedFixture(projectRateCents = 12_000, clientRateCents = 10_000)
-
-        val result = service.createTimeEntry(fixture.userId, createRequest(fixture, durationMinutes = 60))
-
-        assertTrue(result.isBillable)
-        assertEquals(12_000, result.rateCents)
-        assertEquals(12_000, result.amountCents)
-    }
-
-    @Test
-    fun `non-billable entry update preserves zero rate and amount`() {
-        val roleId = ExposedTestDb.seedRole("freelancer-nu")
-        val userId = ExposedTestDb.seedUser("Freelancer", roleId)
-        val currencyId = ExposedTestDb.seedCurrency("USD")
-        val clientId = ExposedTestDb.seedClient("Client", currencyId, 10_000)
-        val projectId = ExposedTestDb.seedProject(clientId, hourlyRateCents = 12_000)
-        val taskId = ExposedTestDb.seedTask("Internal", isBillable = false)
-
-        val created = service.createTimeEntry(userId, CreateTimeEntryRequest(
-            projectId = projectId,
-            taskId = taskId,
-            entryDate = "2026-08-19",
-            durationMinutes = 60,
-        ))
-        val updated = service.updateTimeEntry(userId, created.id, UpdateTimeEntryRequest(
-            projectId = projectId,
-            taskId = taskId,
-            entryDate = "2026-08-20",
-            durationMinutes = 90,
-            rateCents = 99_999,
-        ))
-
-        assertFalse(updated.isBillable)
-        assertEquals(0, updated.rateCents)
-        assertEquals(0, updated.amountCents)
-    }
-
-    private fun seedFixture(
-        projectRateCents: Int? = 12_000,
-        clientRateCents: Int = 10_000,
-    ): Fixture {
-        val roleId = ExposedTestDb.seedRole("freelancer")
-        val userId = ExposedTestDb.seedUser("Freelancer", roleId)
-        val currencyId = ExposedTestDb.seedCurrency("USD")
-        val clientId = ExposedTestDb.seedClient("Client Alpha", currencyId, clientRateCents)
-        val projectId = ExposedTestDb.seedProject(clientId, "Project Alpha", projectRateCents)
-        val taskId = ExposedTestDb.seedTask("Development")
-        return Fixture(userId, currencyId, clientId, projectId, taskId)
-    }
-
-    private fun createRequest(
+    private fun request(
         fixture: Fixture,
         entryDate: String = "2026-08-19",
-        durationMinutes: Int = 60,
-        rateCents: Int? = null,
-    ) = CreateTimeEntryRequest(
-        projectId = fixture.projectId,
-        taskId = fixture.taskId,
-        entryDate = entryDate,
-        startTime = "09:00",
-        endTime = "10:00",
-        description = "Implemented the API",
-        durationMinutes = durationMinutes,
-        rateCents = rateCents,
-    )
+    ): CreateTimeEntryRequest =
+        CreateTimeEntryRequest(
+            projectId = fixture.projectId,
+            taskId = fixture.taskId,
+            entryDate = entryDate,
+            durationMinutes = 60,
+        )
 
-    private fun updateRequest(
-        fixture: Fixture,
-        rateCents: Int? = null,
-    ) = UpdateTimeEntryRequest(
-        projectId = fixture.projectId,
-        taskId = fixture.taskId,
-        entryDate = "2026-08-20",
-        startTime = "10:00",
-        endTime = "11:00",
-        description = "Updated detail",
-        durationMinutes = 60,
-        rateCents = rateCents,
-    )
+    private fun updateRequest(fixture: Fixture): UpdateTimeEntryRequest =
+        UpdateTimeEntryRequest(
+            projectId = fixture.projectId,
+            taskId = fixture.taskId,
+            entryDate = "2026-08-20",
+            durationMinutes = 60,
+        )
 
     private data class Fixture(
-        val userId: String,
         val currencyId: String,
         val clientId: String,
         val projectId: String,

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/TimeEntryServiceTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/TimeEntryServiceTest.kt
@@ -15,85 +15,88 @@ import kotlin.test.assertFalse
 import kotlin.test.assertNull
 
 class TimeEntryServiceTest {
-    private lateinit var databaseFile: File
-    private val service = TimeEntryService()
+    private lateinit var testDatabaseFile: File
+    private val timeEntryService = TimeEntryService()
 
     @Before
     fun setUp() {
-        databaseFile = ExposedTestDb.connect()
+        testDatabaseFile = ExposedTestDb.connect()
     }
 
     @After
     fun tearDown() {
-        ExposedTestDb.cleanup(databaseFile)
+        ExposedTestDb.cleanup(testDatabaseFile)
     }
 
     @Test
     fun `creates a time entry without user or price`() {
-        val fixture = seedFixture()
-        val entry = service.createTimeEntry(request(fixture))
+        val timeEntryFixture = createTimeEntryFixture()
+        val createdTimeEntry = timeEntryService.createTimeEntry(createTimeEntryRequest(timeEntryFixture))
 
-        assertEquals(fixture.projectId, entry.projectId)
-        assertEquals(fixture.taskId, entry.taskId)
-        assertEquals(60, entry.durationMinutes)
-        assertNull(entry.invoiceId)
+        assertEquals(timeEntryFixture.projectId, createdTimeEntry.projectId)
+        assertEquals(timeEntryFixture.taskId, createdTimeEntry.taskId)
+        assertEquals(60, createdTimeEntry.durationMinutes)
+        assertNull(createdTimeEntry.invoiceId)
     }
 
     @Test
     fun `lists entries by date and project`() {
-        val fixture = seedFixture()
-        val included = service.createTimeEntry(request(fixture, "2026-08-19"))
-        service.createTimeEntry(request(fixture, "2026-08-25"))
+        val timeEntryFixture = createTimeEntryFixture()
+        val inRangeTimeEntry = timeEntryService.createTimeEntry(createTimeEntryRequest(timeEntryFixture, "2026-08-19"))
+        timeEntryService.createTimeEntry(createTimeEntryRequest(timeEntryFixture, "2026-08-25"))
 
-        val entries = service.getTimeEntries("2026-08-17", "2026-08-23", fixture.projectId)
+        val retrievedTimeEntries = timeEntryService.getTimeEntries("2026-08-17", "2026-08-23", timeEntryFixture.projectId)
 
-        assertEquals(listOf(included.id), entries.map { it.id })
+        assertEquals(listOf(inRangeTimeEntry.id), retrievedTimeEntries.map { timeEntry -> timeEntry.id })
     }
 
     @Test
     fun `preserves whether an entry is billable`() {
-        val fixture = seedFixture(isBillable = false)
+        val timeEntryFixture = createTimeEntryFixture(isBillable = false)
 
-        assertFalse(service.createTimeEntry(request(fixture)).isBillable)
+        assertFalse(timeEntryService.createTimeEntry(createTimeEntryRequest(timeEntryFixture)).isBillable)
     }
 
     @Test
     fun `invoice linked entries cannot be changed or deleted`() {
-        val fixture = seedFixture()
-        val invoiceId = ExposedTestDb.seedInvoice(fixture.clientId, fixture.currencyId)
-        val entryId = ExposedTestDb.seedTimeEntry(fixture.projectId, fixture.taskId, invoiceId = invoiceId)
+        val timeEntryFixture = createTimeEntryFixture()
+        val invoiceId = ExposedTestDb.seedInvoice(timeEntryFixture.clientId, timeEntryFixture.currencyId)
+        val invoiceLinkedTimeEntryId =
+            ExposedTestDb.seedTimeEntry(timeEntryFixture.projectId, timeEntryFixture.taskId, invoiceId = invoiceId)
 
-        assertFailsWith<TimeEntryLockedException> { service.updateTimeEntry(entryId, updateRequest(fixture)) }
-        assertFailsWith<TimeEntryLockedException> { service.deleteTimeEntry(entryId) }
+        assertFailsWith<TimeEntryLockedException> {
+            timeEntryService.updateTimeEntry(invoiceLinkedTimeEntryId, updateTimeEntryRequest(timeEntryFixture))
+        }
+        assertFailsWith<TimeEntryLockedException> { timeEntryService.deleteTimeEntry(invoiceLinkedTimeEntryId) }
     }
 
-    private fun seedFixture(isBillable: Boolean = true): Fixture {
+    private fun createTimeEntryFixture(isBillable: Boolean = true): TimeEntryFixture {
         val currencyId = ExposedTestDb.seedCurrency("USD")
         val clientId = ExposedTestDb.seedClient("Client", currencyId, 10_000)
         val projectId = ExposedTestDb.seedProject(clientId, isBillable = isBillable)
-        return Fixture(currencyId, clientId, projectId, ExposedTestDb.seedTask("Development"))
+        return TimeEntryFixture(currencyId, clientId, projectId, ExposedTestDb.seedTask("Development"))
     }
 
-    private fun request(
-        fixture: Fixture,
+    private fun createTimeEntryRequest(
+        timeEntryFixture: TimeEntryFixture,
         entryDate: String = "2026-08-19",
     ): CreateTimeEntryRequest =
         CreateTimeEntryRequest(
-            projectId = fixture.projectId,
-            taskId = fixture.taskId,
+            projectId = timeEntryFixture.projectId,
+            taskId = timeEntryFixture.taskId,
             entryDate = entryDate,
             durationMinutes = 60,
         )
 
-    private fun updateRequest(fixture: Fixture): UpdateTimeEntryRequest =
+    private fun updateTimeEntryRequest(timeEntryFixture: TimeEntryFixture): UpdateTimeEntryRequest =
         UpdateTimeEntryRequest(
-            projectId = fixture.projectId,
-            taskId = fixture.taskId,
+            projectId = timeEntryFixture.projectId,
+            taskId = timeEntryFixture.taskId,
             entryDate = "2026-08-20",
             durationMinutes = 60,
         )
 
-    private data class Fixture(
+    private data class TimeEntryFixture(
         val currencyId: String,
         val clientId: String,
         val projectId: String,

--- a/server/app/src/test/kotlin/pos/ambrosia/utils/AdminAuthTestFixture.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utils/AdminAuthTestFixture.kt
@@ -78,8 +78,13 @@ fun HttpRequestBuilder.withAuthCookies(cookies: AuthCookies) {
 fun grantPermission(
     roleName: String,
     permission: String,
+) = grantPermissions(roleName, permission)
+
+fun grantPermissions(
+    roleName: String,
+    vararg permissions: String,
 ) {
     val roleId = ExposedTestDb.seedRole(roleName)
-    ExposedTestDb.seedPermission(permission)
-    PermissionsService().replaceRolePermissions(roleId, listOf(permission))
+    permissions.forEach(ExposedTestDb::seedPermission)
+    PermissionsService().replaceRolePermissions(roleId, permissions.toList())
 }

--- a/server/app/src/test/kotlin/pos/ambrosia/utils/ExposedTestDb.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utils/ExposedTestDb.kt
@@ -361,7 +361,10 @@ object ExposedTestDb {
                 .toString()
         }
 
-    fun seedTask(name: String = "Development", isBillable: Boolean = true): String =
+    fun seedTask(
+        name: String = "Development",
+        isBillable: Boolean = true,
+    ): String =
         transaction {
             TaskEntity
                 .new(UUID.randomUUID()) {
@@ -373,12 +376,11 @@ object ExposedTestDb {
         }
 
     fun seedTimeEntry(
-        userId: String,
         projectId: String = seedProject(),
         taskId: String = seedTask(),
         entryDate: String = "2026-08-24",
         durationMinutes: Int = 60,
-        rateCents: Int? = 10_000,
+        isBillable: Boolean = true,
         invoiceId: String? = null,
         isLocked: Boolean = false,
     ): String =
@@ -387,10 +389,9 @@ object ExposedTestDb {
                 .new(UUID.randomUUID()) {
                     this.projectId = EntityID(UUID.fromString(projectId), ProjectsTable)
                     this.taskId = EntityID(UUID.fromString(taskId), TasksTable)
-                    this.userId = EntityID(UUID.fromString(userId), UsersTable)
                     this.entryDate = entryDate
                     this.durationMinutes = durationMinutes
-                    this.rateCents = rateCents
+                    this.isBillable = isBillable
                     this.invoiceId = invoiceId?.let { EntityID(UUID.fromString(it), InvoicesTable) }
                     this.isLocked = isLocked
                     createdAt = "2026-08-24 12:00:00"

--- a/server/app/src/test/kotlin/pos/ambrosia/utils/ExposedTestDb.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utils/ExposedTestDb.kt
@@ -346,23 +346,27 @@ object ExposedTestDb {
         clientId: String = seedClient(),
         name: String = "Project",
         hourlyRateCents: Int? = null,
+        isBillable: Boolean = true,
     ): String =
         transaction {
             ProjectEntity
                 .new(UUID.randomUUID()) {
                     this.clientId = EntityID(UUID.fromString(clientId), ClientsTable)
                     this.name = name
+                    this.status = "in_progress"
                     this.hourlyRateCents = hourlyRateCents
+                    this.isBillable = isBillable
                     createdAt = "2026-08-24 12:00:00"
                 }.id.value
                 .toString()
         }
 
-    fun seedTask(name: String = "Development"): String =
+    fun seedTask(name: String = "Development", isBillable: Boolean = true): String =
         transaction {
             TaskEntity
                 .new(UUID.randomUUID()) {
                     this.name = name
+                    this.isBillable = isBillable
                     createdAt = "2026-08-24 12:00:00"
                 }.id.value
                 .toString()

--- a/server/app/src/test/kotlin/pos/ambrosia/utils/ExposedTestDb.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utils/ExposedTestDb.kt
@@ -27,6 +27,7 @@ import pos.ambrosia.db.tables.DishesTable
 import pos.ambrosia.db.tables.IngredientEntity
 import pos.ambrosia.db.tables.IngredientSuppliersTable
 import pos.ambrosia.db.tables.IngredientsTable
+import pos.ambrosia.db.tables.InvoiceEntity
 import pos.ambrosia.db.tables.InvoiceLineItemsTable
 import pos.ambrosia.db.tables.InvoicePaymentsTable
 import pos.ambrosia.db.tables.InvoicesTable
@@ -67,6 +68,7 @@ import pos.ambrosia.db.tables.SpaceEntity
 import pos.ambrosia.db.tables.SpacesTable
 import pos.ambrosia.db.tables.SupplierEntity
 import pos.ambrosia.db.tables.SuppliersTable
+import pos.ambrosia.db.tables.TaskEntity
 import pos.ambrosia.db.tables.TasksTable
 import pos.ambrosia.db.tables.TicketEntity
 import pos.ambrosia.db.tables.TicketPaymentsTable
@@ -77,6 +79,7 @@ import pos.ambrosia.db.tables.TicketTemplatesTable
 import pos.ambrosia.db.tables.TicketsDishTable
 import pos.ambrosia.db.tables.TicketsTable
 import pos.ambrosia.db.tables.TimeEntriesTable
+import pos.ambrosia.db.tables.TimeEntryEntity
 import pos.ambrosia.db.tables.UserEntity
 import pos.ambrosia.db.tables.UsersTable
 import pos.ambrosia.db.tables.VariantOptionValuesTable
@@ -161,6 +164,14 @@ object ExposedTestDb {
                 TicketTemplatesTable,
                 PrinterConfigsTable,
                 PushSubscriptionsTable,
+                InvoicePaymentsTable,
+                InvoiceLineItemsTable,
+                TimeEntriesTable,
+                InvoicesTable,
+                TasksTable,
+                ProjectsTable,
+                ClientsTable,
+                PayoutAccountsTable,
                 AdminNotificationPreferencesTable,
                 AdminNotificationReceiptsTable,
                 AdminNotificationsTable,
@@ -311,6 +322,98 @@ object ExposedTestDb {
                         this.countryCode = countryCode
                     }.id.value
                     .toString()
+        }
+
+    fun seedClient(
+        name: String = "Client",
+        currencyId: String = seedCurrency("USD"),
+        hourlyRateCents: Int = 10_000,
+    ): String =
+        transaction {
+            ClientEntity
+                .new(UUID.randomUUID()) {
+                    this.name = name
+                    this.currencyId = EntityID(UUID.fromString(currencyId), CurrencyTable)
+                    this.hourlyRateCents = hourlyRateCents
+                    billingCycle = "weekly"
+                    paymentMethod = "bank"
+                    createdAt = "2026-08-24 12:00:00"
+                }.id.value
+                .toString()
+        }
+
+    fun seedProject(
+        clientId: String = seedClient(),
+        name: String = "Project",
+        hourlyRateCents: Int? = null,
+    ): String =
+        transaction {
+            ProjectEntity
+                .new(UUID.randomUUID()) {
+                    this.clientId = EntityID(UUID.fromString(clientId), ClientsTable)
+                    this.name = name
+                    this.hourlyRateCents = hourlyRateCents
+                    createdAt = "2026-08-24 12:00:00"
+                }.id.value
+                .toString()
+        }
+
+    fun seedTask(name: String = "Development"): String =
+        transaction {
+            TaskEntity
+                .new(UUID.randomUUID()) {
+                    this.name = name
+                    createdAt = "2026-08-24 12:00:00"
+                }.id.value
+                .toString()
+        }
+
+    fun seedTimeEntry(
+        userId: String,
+        projectId: String = seedProject(),
+        taskId: String = seedTask(),
+        entryDate: String = "2026-08-24",
+        durationMinutes: Int = 60,
+        rateCents: Int? = 10_000,
+        invoiceId: String? = null,
+        isLocked: Boolean = false,
+    ): String =
+        transaction {
+            TimeEntryEntity
+                .new(UUID.randomUUID()) {
+                    this.projectId = EntityID(UUID.fromString(projectId), ProjectsTable)
+                    this.taskId = EntityID(UUID.fromString(taskId), TasksTable)
+                    this.userId = EntityID(UUID.fromString(userId), UsersTable)
+                    this.entryDate = entryDate
+                    this.durationMinutes = durationMinutes
+                    this.rateCents = rateCents
+                    this.invoiceId = invoiceId?.let { EntityID(UUID.fromString(it), InvoicesTable) }
+                    this.isLocked = isLocked
+                    createdAt = "2026-08-24 12:00:00"
+                }.id.value
+                .toString()
+        }
+
+    fun seedInvoice(
+        clientId: String,
+        currencyId: String,
+        invoiceNumber: String = "2026-${UUID.randomUUID().toString().take(8)}",
+    ): String =
+        transaction {
+            InvoiceEntity
+                .new(UUID.randomUUID()) {
+                    invoiceYear = 2026
+                    this.invoiceNumber = invoiceNumber
+                    this.clientId = EntityID(UUID.fromString(clientId), ClientsTable)
+                    status = "generated"
+                    this.currencyId = EntityID(UUID.fromString(currencyId), CurrencyTable)
+                    periodStart = "2026-08-01"
+                    periodEnd = "2026-08-31"
+                    totalCents = 10_000
+                    paymentMethod = "bank"
+                    createdAt = "2026-08-24 12:00:00"
+                }.id.value
+                .toString()
         }
 
     fun seedConfig(timezone: String) {


### PR DESCRIPTION
## Summary

Adds the time entry API for the freelance workflow.

Time entries are linked to a project and task, capture work duration and context, and preserve the billable status derived from the project/task. Rates and amounts are intentionally excluded from time entries; they will be calculated and frozen when an invoice is generated.

## Main changes

- Adds CRUD endpoints under `/time-entries` with read, create, update, and delete permissions.
- Requires authentication without associating entries with a specific user.
- Supports date-range listing and optional project/task filters.
- Validates active projects, clients, and tasks.
- Only allows creating or updating entries for `in_progress` projects.
- Persists `isBillable` as a snapshot, preserving an entry’s billable status after project or task settings change.
- Prevents updates and deletions for invoiced or locked entries.
- Adds indexes for project/date and invoice queries.
- Updates the initial freelance migration with the final `time_entries` schema.
- Adds service, route, and migration test coverage.

## Out of scope

- Invoice and invoice line item generation.
- Rate and amount calculation/storage in `time_entries`.
- A start/stop work timer.

## Verification

- `./gradlew test --tests 'pos.ambrosia.utest.TimeEntryServiceTest' --tests 'pos.ambrosia.utest.TimeEntriesRouteTest' --tests 'pos.ambrosia.utest.TimeEntryIndexesMigrationTest'`
- `./gradlew ktlintCheck`