### PR TITLE
Fix/import apply restart token

### DIFF
--- a/client/src/components/pages/Onboarding/RestoreFromBackup.jsx
+++ b/client/src/components/pages/Onboarding/RestoreFromBackup.jsx
@@ -8,7 +8,7 @@ import { useTranslations } from "next-intl";
 import { restartBackendAfterImport } from "@/utils/restartBackendAfterImport";
 import { BackupPasswordAndFileFields } from "@components/shared/BackupPasswordAndFileFields";
 import { RestartRequiredModal } from "@components/shared/RestartRequiredModal";
-import { restoreFromBackup } from "@services/initialSetupService";
+import { confirmPendingRestore, restoreFromBackup } from "@services/initialSetupService";
 
 function restorePhaseLabel(restoreTranslations, phase) {
   if (phase === "uploading") return restoreTranslations("restore.phaseUploading");
@@ -51,6 +51,7 @@ export function RestoreFromBackupStep({ onBack }) {
         color: "success",
       });
 
+      await confirmPendingRestore();
       const restartTriggeredAutomatically = await restartBackendAfterImport();
       if (restartTriggeredAutomatically) {
         addToast({

--- a/client/src/components/pages/Onboarding/__tests__/RestoreFromBackup.test.jsx
+++ b/client/src/components/pages/Onboarding/__tests__/RestoreFromBackup.test.jsx
@@ -1,13 +1,14 @@
 import { render, screen, fireEvent, act, waitFor } from "@testing-library/react";
 
 import { restartBackendAfterImport } from "@/utils/restartBackendAfterImport";
-import { restoreFromBackup } from "@services/initialSetupService";
+import { confirmPendingRestore, restoreFromBackup } from "@services/initialSetupService";
 import { selectBackupFile } from "@test-utils/selectBackupFile";
 
 import { RestoreFromBackupStep } from "../RestoreFromBackup";
 
 jest.mock("@services/initialSetupService", () => ({
   restoreFromBackup: jest.fn(),
+  confirmPendingRestore: jest.fn(),
 }));
 
 jest.mock("@/utils/restartBackendAfterImport", () => ({
@@ -31,6 +32,7 @@ describe("RestoreFromBackupStep", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     restartBackendAfterImport.mockResolvedValue(false);
+    confirmPendingRestore.mockResolvedValue(undefined);
   });
 
   it("renders the password and file fields", async () => {
@@ -177,6 +179,31 @@ describe("RestoreFromBackupStep", () => {
     expect(mockAddToast).not.toHaveBeenCalledWith(
       expect.objectContaining({ description: "restore.restartRequiredElectron" }),
     );
+  });
+
+  it("confirms the pending restore before triggering the restart", async () => {
+    const callOrder = [];
+    confirmPendingRestore.mockImplementation(async () => {
+      callOrder.push("confirm");
+    });
+    restartBackendAfterImport.mockImplementation(async () => {
+      callOrder.push("restart");
+      return false;
+    });
+    restoreFromBackup.mockResolvedValue({ ok: true });
+
+    await act(async () => {
+      renderStep();
+    });
+
+    fireEvent.change(screen.getByLabelText("hide-show-backup-password"), { target: { value: "secret" } });
+    selectBackupFile();
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("restore.submitButton"));
+    });
+
+    expect(callOrder).toEqual(["confirm", "restart"]);
   });
 
   it("shows the Electron restart message on success when the backend restarts automatically", async () => {

--- a/client/src/components/pages/Store/Settings/ImportData/ImportData.jsx
+++ b/client/src/components/pages/Store/Settings/ImportData/ImportData.jsx
@@ -5,7 +5,7 @@ import { useState } from "react";
 import { addToast } from "@heroui/react";
 import { useTranslations } from "next-intl";
 
-import { importBackup } from "@/services/backupService";
+import { confirmPendingImport, importBackup } from "@/services/backupService";
 import { restartBackendAfterImport } from "@/utils/restartBackendAfterImport";
 import { RestartRequiredModal } from "@components/shared/RestartRequiredModal";
 
@@ -21,6 +21,7 @@ export function ImportData() {
     await importBackup(rolePassword, backupPassword, backupFile, onProgress);
     addToast({ color: "success", description: importDataTranslations("cardImportData.success") });
 
+    await confirmPendingImport();
     const restartTriggeredAutomatically = await restartBackendAfterImport();
     if (restartTriggeredAutomatically) {
       addToast({

--- a/client/src/components/pages/Store/Settings/ImportData/__tests__/ImportData.test.jsx
+++ b/client/src/components/pages/Store/Settings/ImportData/__tests__/ImportData.test.jsx
@@ -73,6 +73,7 @@ async function unlockSelectFileAndImport() {
 beforeEach(() => {
   jest.clearAllMocks();
   restartBackendAfterImport.mockResolvedValue(false);
+  jest.spyOn(backupService, "confirmPendingImport").mockResolvedValue(undefined);
 });
 
 afterEach(() => {
@@ -155,6 +156,23 @@ describe("ImportData", () => {
       expect(addToast).not.toHaveBeenCalledWith(
         expect.objectContaining({ description: "cardImportData.restartRequiredElectron" }),
       );
+    });
+
+    it("confirms the pending import before triggering the restart", async () => {
+      const callOrder = [];
+      jest.spyOn(backupService, "importBackup").mockResolvedValue({ businessName: "Awesome Store" });
+      backupService.confirmPendingImport.mockImplementation(async () => {
+        callOrder.push("confirm");
+      });
+      restartBackendAfterImport.mockImplementation(async () => {
+        callOrder.push("restart");
+        return false;
+      });
+      render(<ImportData />);
+
+      await unlockSelectFileAndImport();
+
+      expect(callOrder).toEqual(["confirm", "restart"]);
     });
 
     it("shows the Electron restart message when the backend restarts automatically", async () => {

--- a/client/src/services/__tests__/backupService.test.js
+++ b/client/src/services/__tests__/backupService.test.js
@@ -22,7 +22,7 @@ import { downloadBlob } from "@/utils/downloadBlob";
 import { waitForInstance } from "@test-utils/waitForInstance";
 
 import { closeBackupProgressChannel, openBackupProgressChannel } from "../backupProgressChannel";
-import { exportBackup, importBackup } from "../backupService";
+import { confirmPendingImport, exportBackup, importBackup } from "../backupService";
 
 function makeResponse({ ok, status, contentDisposition, blob }) {
   return {
@@ -297,6 +297,16 @@ describe("backupService", () => {
 
         expect(closeBackupProgressChannel).toHaveBeenCalledWith(progressChannel);
       });
+    });
+  });
+
+  describe("confirmPendingImport", () => {
+    it("calls POST /backup/confirm-pending-import", async () => {
+      httpClient.mockResolvedValue({ ok: true });
+
+      await confirmPendingImport();
+
+      expect(httpClient).toHaveBeenCalledWith("/backup/confirm-pending-import", { method: "POST" });
     });
   });
 });

--- a/client/src/services/__tests__/initialSetupService.test.js
+++ b/client/src/services/__tests__/initialSetupService.test.js
@@ -12,7 +12,7 @@ import { httpClient, parseJsonResponse } from "@/lib/http";
 import { waitForInstance } from "@test-utils/waitForInstance";
 
 import { closeBackupProgressChannel, openBackupProgressChannel } from "../backupProgressChannel";
-import { getInitialSetupStatus, submitInitialSetup, restoreFromBackup } from "../initialSetupService";
+import { confirmPendingRestore, getInitialSetupStatus, submitInitialSetup, restoreFromBackup } from "../initialSetupService";
 
 class FakeXMLHttpRequest {
   constructor() {
@@ -192,6 +192,19 @@ describe("initialSetupService", () => {
         await restoreFromBackupPromise;
 
         expect(closeBackupProgressChannel).toHaveBeenCalledWith(progressChannel);
+      });
+    });
+  });
+
+  describe("confirmPendingRestore", () => {
+    it("calls POST /initial-setup/confirm-pending-restore with skipRefresh", async () => {
+      httpClient.mockResolvedValue({ ok: true });
+
+      await confirmPendingRestore();
+
+      expect(httpClient).toHaveBeenCalledWith("/initial-setup/confirm-pending-restore", {
+        method: "POST",
+        skipRefresh: true,
       });
     });
   });

--- a/client/src/services/backupService.js
+++ b/client/src/services/backupService.js
@@ -100,3 +100,7 @@ export async function importBackup(rolePassword, backupPassword, backupFile, onP
 
   return backupImportBody;
 }
+
+export async function confirmPendingImport() {
+  await httpClient("/backup/confirm-pending-import", { method: "POST" });
+}

--- a/client/src/services/initialSetupService.js
+++ b/client/src/services/initialSetupService.js
@@ -56,3 +56,7 @@ export async function restoreFromBackup(password, backupFile, onProgress) {
 
   return { ok: true };
 }
+
+export async function confirmPendingRestore() {
+  await httpClient("/initial-setup/confirm-pending-restore", { method: "POST", skipRefresh: true });
+}

--- a/server/app/src/main/kotlin/pos/ambrosia/Ambrosia.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/Ambrosia.kt
@@ -16,11 +16,16 @@ import com.github.ajalt.mordant.rendering.TextColors.yellow
 import io.ktor.network.tls.certificates.buildKeyStore
 import io.ktor.network.tls.certificates.saveToFile
 import io.ktor.server.config.MapApplicationConfig
+import io.ktor.server.engine.EmbeddedServer
 import io.ktor.server.engine.applicationEnvironment
 import io.ktor.server.engine.connector
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.engine.sslConnector
 import io.ktor.server.netty.Netty
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlinx.io.buffered
 import kotlinx.io.files.Path
 import kotlinx.io.files.SystemFileSystem
@@ -35,6 +40,7 @@ import pos.ambrosia.config.replaceConfFileProperty
 import pos.ambrosia.config.writeConfValues
 import pos.ambrosia.db.DatabaseConnection
 import pos.ambrosia.services.BackupService
+import pos.ambrosia.services.TokenService
 import pos.ambrosia.services.VapidKeyService
 import pos.ambrosia.services.VapidKeys
 import java.io.File
@@ -53,9 +59,19 @@ val phoenixDatadir: Path =
 var pendingDataImportWasApplied: Boolean = false
     private set
 
+var runningEmbeddedServer: EmbeddedServer<*, *>? = null
+    private set
+
 fun main(args: Array<String>) {
     pendingDataImportWasApplied = BackupService().applyPendingImport()
     Ambrosia().main(args)
+}
+
+fun scheduleDockerRestart() {
+    CoroutineScope(Dispatchers.IO).launch {
+        delay(500)
+        runningEmbeddedServer?.stopSuspend()
+    }
 }
 
 class Ambrosia : CliktCommand() {
@@ -214,8 +230,9 @@ class Ambrosia : CliktCommand() {
                             config =
                                 MapApplicationConfig().apply {
                                     put("jwt.accessTokenExpirationSeconds", options.jwtAccessTokenExpirationSeconds)
-                                    put("jwt.issuer", "ambrosia-pos")
-                                    put("jwt.audience", "ambrosia-pos-users")
+                                    put("jwt.issuer", TokenService.JWT_ISSUER)
+                                    put("jwt.audience", TokenService.JWT_AUDIENCE)
+                                    put("docker", options.docker.toString())
                                     put("secret", options.secret)
                                     put("phoenixd-url", options.phoenixdUrl)
                                     put("phoenixd-password", options.phoenixdPassword)
@@ -252,6 +269,7 @@ class Ambrosia : CliktCommand() {
                     },
                     module = { Api().run { module() } },
                 )
+            runningEmbeddedServer = server
             if (options.nwcUri == null) {
                 ensurePhoenixWebhookConfigured(options.phoenixdWebhookUrl)
             } else {

--- a/server/app/src/main/kotlin/pos/ambrosia/api/Backup.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/api/Backup.kt
@@ -27,11 +27,13 @@ import kotlinx.coroutines.runBlocking
 import pos.ambrosia.logger
 import pos.ambrosia.models.BackupProgressPhase
 import pos.ambrosia.models.RolePassword
+import pos.ambrosia.scheduleDockerRestart
 import pos.ambrosia.services.AuthService
 import pos.ambrosia.services.BackupService
 import pos.ambrosia.services.ConfigService
 import pos.ambrosia.services.TokenService
 import pos.ambrosia.utils.InvalidCredentialsException
+import pos.ambrosia.utils.isDockerMode
 import java.nio.file.Files
 import java.nio.file.Path
 import java.time.LocalDate
@@ -65,6 +67,15 @@ fun Route.backup(
             val operationId = UUID.randomUUID().toString()
             val progressToken = tokenService.generateBackupProgressToken(userId, operationId)
             call.respond(HttpStatusCode.OK, mapOf("operationId" to operationId, "token" to progressToken))
+        }
+
+        post("/confirm-pending-import") {
+            call.backupActorUserId() ?: throw InvalidCredentialsException()
+            backupService.stagedOperationId()?.let { operationId ->
+                backupService.writeConfirmationToken(tokenService.generateBackupConfirmationToken(operationId))
+                if (call.isDockerMode()) scheduleDockerRestart()
+            }
+            call.respond(HttpStatusCode.OK)
         }
 
         post("/export") {

--- a/server/app/src/main/kotlin/pos/ambrosia/api/InitialSetup.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/api/InitialSetup.kt
@@ -23,6 +23,7 @@ import pos.ambrosia.models.InitialSetupResponse
 import pos.ambrosia.models.InitialSetupStatus
 import pos.ambrosia.models.Role
 import pos.ambrosia.models.User
+import pos.ambrosia.scheduleDockerRestart
 import pos.ambrosia.services.ActiveLightningBackend
 import pos.ambrosia.services.BackupService
 import pos.ambrosia.services.ConfigService
@@ -33,6 +34,7 @@ import pos.ambrosia.services.TokenService
 import pos.ambrosia.services.UsersService
 import pos.ambrosia.services.WalletAdminNotificationService
 import pos.ambrosia.utils.InitialSetupException
+import pos.ambrosia.utils.isDockerMode
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.Path
@@ -273,5 +275,21 @@ private fun Route.initialSetupRoutes() {
         val tokenService = TokenService(call.application.environment)
         val progressToken = tokenService.generateBackupProgressToken(ONBOARDING_PROGRESS_TOKEN_USER_ID, operationId)
         call.respond(HttpStatusCode.OK, mapOf("operationId" to operationId, "token" to progressToken))
+    }
+
+    post("/confirm-pending-restore") {
+        val configService = ConfigService()
+        if (configService.getConfig() != null) {
+            call.respond(HttpStatusCode.Conflict, mapOf("message" to "Initial setup already completed"))
+            return@post
+        }
+
+        val backupService = BackupService()
+        backupService.stagedOperationId()?.let { operationId ->
+            val tokenService = TokenService(call.application.environment)
+            backupService.writeConfirmationToken(tokenService.generateBackupConfirmationToken(operationId))
+            if (call.isDockerMode()) scheduleDockerRestart()
+        }
+        call.respond(HttpStatusCode.OK)
     }
 }

--- a/server/app/src/main/kotlin/pos/ambrosia/services/BackupService.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/services/BackupService.kt
@@ -20,6 +20,7 @@ import java.security.SecureRandom
 import java.sql.DriverManager
 import java.time.Duration
 import java.time.Instant
+import java.util.UUID
 import java.util.zip.ZipEntry
 import java.util.zip.ZipInputStream
 import java.util.zip.ZipOutputStream
@@ -65,6 +66,8 @@ class BackupService(
         const val STAGED_DATABASE_FILE_NAME = "ambrosia.db"
         const val STAGED_UPLOADS_DIR_NAME = "uploads"
         const val STAGED_AT_FILE_NAME = "staged-at"
+        const val STAGED_OPERATION_ID_FILE_NAME = "operation-id"
+        const val STAGED_CONFIRMATION_TOKEN_FILE_NAME = "confirmation-token"
         private val PENDING_IMPORT_ABANDONED_AFTER = Duration.ofHours(24)
     }
 
@@ -166,6 +169,7 @@ class BackupService(
             validateSchemaCompatibility(importedManifest)
             writeStagedSecret(stagingTempRoot, importedManifest.secret)
             writeStagedAt(stagingTempRoot)
+            writeStagedOperationId(stagingTempRoot)
 
             deleteRecursivelyIfExists(importStagingRoot)
             Files.move(stagingTempRoot, importStagingRoot, StandardCopyOption.ATOMIC_MOVE)
@@ -177,6 +181,16 @@ class BackupService(
         }
     }
 
+    fun stagedOperationId(): String? {
+        val stagedOperationIdFile = importStagingRoot.resolve(STAGED_OPERATION_ID_FILE_NAME)
+        if (!Files.exists(stagedOperationIdFile)) return null
+        return Files.readString(stagedOperationIdFile)
+    }
+
+    fun writeConfirmationToken(confirmationToken: String) {
+        Files.writeString(importStagingRoot.resolve(STAGED_CONFIRMATION_TOKEN_FILE_NAME), confirmationToken)
+    }
+
     fun applyPendingImport(): Boolean {
         if (!Files.exists(importStagingRoot)) return false
 
@@ -185,6 +199,8 @@ class BackupService(
             deleteRecursivelyIfExists(importStagingRoot)
             return false
         }
+
+        if (!isPendingImportConfirmed()) return false
 
         val stagedSecret = Files.readString(importStagingRoot.resolve(STAGED_SECRET_FILE_NAME))
         val stagedDatabaseFile = importStagingRoot.resolve(STAGED_DATABASE_FILE_NAME)
@@ -229,6 +245,18 @@ class BackupService(
 
     private fun writeStagedAt(stagingTempRoot: Path) {
         Files.writeString(stagingTempRoot.resolve(STAGED_AT_FILE_NAME), Instant.now().toString())
+    }
+
+    private fun writeStagedOperationId(stagingTempRoot: Path) {
+        Files.writeString(stagingTempRoot.resolve(STAGED_OPERATION_ID_FILE_NAME), UUID.randomUUID().toString())
+    }
+
+    private fun isPendingImportConfirmed(): Boolean {
+        val operationId = stagedOperationId() ?: return false
+        val stagedConfirmationTokenFile = importStagingRoot.resolve(STAGED_CONFIRMATION_TOKEN_FILE_NAME)
+        if (!Files.exists(stagedConfirmationTokenFile)) return false
+        val stagedConfirmationToken = Files.readString(stagedConfirmationTokenFile)
+        return TokenService.isBackupConfirmationTokenValid(readSecret(), stagedConfirmationToken, operationId)
     }
 
     private fun readExactBytes(

--- a/server/app/src/main/kotlin/pos/ambrosia/services/TokenService.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/services/TokenService.kt
@@ -20,6 +20,31 @@ import java.util.concurrent.TimeUnit
 class TokenService(
     environment: ApplicationEnvironment,
 ) {
+    companion object {
+        const val JWT_ISSUER = "ambrosia-pos"
+        const val JWT_AUDIENCE = "ambrosia-pos-users"
+
+        fun isBackupConfirmationTokenValid(
+            secret: String,
+            token: String,
+            operationId: String,
+        ): Boolean =
+            try {
+                val verifier =
+                    JWT
+                        .require(Algorithm.HMAC256(secret))
+                        .withAudience(JWT_AUDIENCE)
+                        .withIssuer(JWT_ISSUER)
+                        .build()
+                val decodedJWT = verifier.verify(token)
+                val tokenScope = decodedJWT.getClaim("scope")?.asString()
+                val tokenOperationId = decodedJWT.getClaim("operationId")?.asString()
+                tokenScope == "backup_confirmation" && tokenOperationId == operationId
+            } catch (e: JWTVerificationException) {
+                false
+            }
+    }
+
     private val config = environment.config
     private val secret = config.property("secret").getString()
     private val issuer = config.property("jwt.issuer").getString()
@@ -105,9 +130,9 @@ class TokenService(
     ): String? =
         try {
             val decodedJWT = verifier.verify(token)
-            val scope = decodedJWT.getClaim("scope")?.asString()
+            val tokenScope = decodedJWT.getClaim("scope")?.asString()
             val tokenOperationId = decodedJWT.getClaim("operationId")?.asString()
-            if (scope == "backup_progress" && tokenOperationId == operationId) {
+            if (tokenScope == "backup_progress" && tokenOperationId == operationId) {
                 decodedJWT.getClaim("userId")?.asString()
             } else {
                 null
@@ -115,6 +140,17 @@ class TokenService(
         } catch (e: JWTVerificationException) {
             null
         }
+
+    fun generateBackupConfirmationToken(operationId: String): String =
+        JWT
+            .create()
+            .withAudience(audience)
+            .withIssuer(issuer)
+            .withClaim("scope", "backup_confirmation")
+            .withClaim("operationId", operationId)
+            .withClaim("realm", "Ambrosia-Server")
+            .withExpiresAt(Date(System.currentTimeMillis() + TimeUnit.HOURS.toMillis(4)))
+            .sign(algorithm)
 
     fun isWalletTokenValid(
         userId: String,

--- a/server/app/src/main/kotlin/pos/ambrosia/utils/DockerMode.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/utils/DockerMode.kt
@@ -1,0 +1,9 @@
+package pos.ambrosia.utils
+
+import io.ktor.server.application.ApplicationCall
+
+fun ApplicationCall.isDockerMode(): Boolean =
+    application.environment.config
+        .propertyOrNull("docker")
+        ?.getString()
+        ?.toBoolean() ?: false

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/BackupServiceTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/BackupServiceTest.kt
@@ -1,5 +1,8 @@
 package pos.ambrosia.utest
 
+import com.auth0.jwt.JWT
+import com.auth0.jwt.algorithms.Algorithm
+import io.ktor.server.engine.applicationEnvironment
 import kotlinx.serialization.json.Json
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.junit.After
@@ -7,8 +10,10 @@ import org.junit.Before
 import pos.ambrosia.models.BackupManifest
 import pos.ambrosia.models.BackupProgressPhase
 import pos.ambrosia.services.BackupService
+import pos.ambrosia.services.TokenService
 import pos.ambrosia.utils.ExposedTestDb
 import pos.ambrosia.utils.PendingImportAlreadyStagedException
+import pos.ambrosia.utils.confirmationTokenConfig
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.nio.file.Files
@@ -16,6 +21,7 @@ import java.nio.file.Path
 import java.security.SecureRandom
 import java.time.Instant
 import java.time.temporal.ChronoUnit
+import java.util.Date
 import java.util.zip.ZipEntry
 import java.util.zip.ZipInputStream
 import java.util.zip.ZipOutputStream
@@ -464,6 +470,21 @@ class BackupServiceTest {
     }
 
     @Test
+    fun `importBackup stages an operation id`() {
+        val backupService =
+            BackupService(uploadsRoot, databaseFile.absolutePath, configFile.absolutePath, importStagingRoot)
+        val exportedBackup = ByteArrayOutputStream()
+        backupService.exportBackup("My Test Store", "correct-password".toCharArray(), backupService.prepareExportSnapshot(), exportedBackup)
+
+        backupService.importBackup(
+            exportedBackup.toByteArray().inputStream(),
+            "correct-password".toCharArray(),
+        )
+
+        assertTrue(!backupService.stagedOperationId().isNullOrBlank())
+    }
+
+    @Test
     fun `importBackup throws when the password is wrong`() {
         val backupService =
             BackupService(uploadsRoot, databaseFile.absolutePath, configFile.absolutePath, importStagingRoot)
@@ -642,11 +663,36 @@ class BackupServiceTest {
         assertTrue(password.all { it == Char(0) })
     }
 
+    private fun confirmationTokenService(secret: String): TokenService =
+        TokenService(applicationEnvironment { config = confirmationTokenConfig(secret) })
+
+    private fun expiredConfirmationToken(
+        secret: String,
+        operationId: String,
+    ): String =
+        JWT
+            .create()
+            .withAudience(TokenService.JWT_AUDIENCE)
+            .withIssuer(TokenService.JWT_ISSUER)
+            .withClaim("scope", "backup_confirmation")
+            .withClaim("operationId", operationId)
+            .withExpiresAt(Date(System.currentTimeMillis() - 1000))
+            .sign(Algorithm.HMAC256(secret))
+
+    private fun confirmPendingImport(
+        backupService: BackupService,
+        secret: String,
+    ) {
+        val operationId = backupService.stagedOperationId() ?: return
+        backupService.writeConfirmationToken(confirmationTokenService(secret).generateBackupConfirmationToken(operationId))
+    }
+
     private fun prepareStagedImport(
         destinationUploadsRoot: Path,
         destinationDatabaseFile: Path,
         destinationConfigFile: File,
         destinationKeyStoreFile: Path = Files.createTempDirectory("backupServiceTestDestinationKeyStoreParent").resolve("keystore.jks"),
+        confirm: Boolean = true,
     ): BackupService {
         val exportingService =
             BackupService(uploadsRoot, databaseFile.absolutePath, configFile.absolutePath, importStagingRoot)
@@ -670,6 +716,10 @@ class BackupServiceTest {
             exportedBackup.toByteArray().inputStream(),
             "correct-password".toCharArray(),
         )
+        if (confirm) {
+            val destinationSecret = destinationConfigFile.readText().trim().removePrefix("secret=")
+            confirmPendingImport(destinationService, destinationSecret)
+        }
         return destinationService
     }
 
@@ -831,5 +881,77 @@ class BackupServiceTest {
         destinationService.applyPendingImport()
 
         assertFalse(Files.exists(importStagingRoot))
+    }
+
+    @Test
+    fun `applyPendingImport does not apply an unconfirmed pending import`() {
+        val destinationDatabaseFile = Files.createTempFile("backupServiceTestDestinationDb", ".db")
+        Files.writeString(destinationDatabaseFile, "old-destination-database-placeholder")
+        val originalDestinationDatabaseSize = Files.size(destinationDatabaseFile)
+        val destinationUploadsRoot = Files.createTempDirectory("backupServiceTestDestinationUploads")
+        val destinationConfigFile = Files.createTempFile("backupServiceTestDestinationConfig", ".conf").toFile()
+        destinationConfigFile.writeText("secret=old-destination-secret\n")
+        val destinationService =
+            prepareStagedImport(destinationUploadsRoot, destinationDatabaseFile, destinationConfigFile, confirm = false)
+
+        val pendingImportApplied = destinationService.applyPendingImport()
+
+        assertFalse(pendingImportApplied)
+        assertEquals(originalDestinationDatabaseSize, Files.size(destinationDatabaseFile))
+        assertEquals("secret=old-destination-secret", destinationConfigFile.readText().trim())
+    }
+
+    @Test
+    fun `applyPendingImport does not delete an unconfirmed pending import`() {
+        val destinationDatabaseFile = Files.createTempFile("backupServiceTestDestinationDb", ".db")
+        val destinationUploadsRoot = Files.createTempDirectory("backupServiceTestDestinationUploads")
+        val destinationConfigFile = Files.createTempFile("backupServiceTestDestinationConfig", ".conf").toFile()
+        destinationConfigFile.writeText("secret=old-destination-secret\n")
+        val destinationService =
+            prepareStagedImport(destinationUploadsRoot, destinationDatabaseFile, destinationConfigFile, confirm = false)
+
+        destinationService.applyPendingImport()
+
+        assertTrue(Files.exists(importStagingRoot))
+    }
+
+    @Test
+    fun `applyPendingImport does not apply a confirmation for a different operation id`() {
+        val destinationDatabaseFile = Files.createTempFile("backupServiceTestDestinationDb", ".db")
+        Files.writeString(destinationDatabaseFile, "old-destination-database-placeholder")
+        val originalDestinationDatabaseSize = Files.size(destinationDatabaseFile)
+        val destinationUploadsRoot = Files.createTempDirectory("backupServiceTestDestinationUploads")
+        val destinationConfigFile = Files.createTempFile("backupServiceTestDestinationConfig", ".conf").toFile()
+        destinationConfigFile.writeText("secret=old-destination-secret\n")
+        val destinationService =
+            prepareStagedImport(destinationUploadsRoot, destinationDatabaseFile, destinationConfigFile)
+        Files.writeString(
+            importStagingRoot.resolve(BackupService.STAGED_OPERATION_ID_FILE_NAME),
+            "a-newer-restaged-operation-id",
+        )
+
+        val pendingImportApplied = destinationService.applyPendingImport()
+
+        assertFalse(pendingImportApplied)
+        assertEquals(originalDestinationDatabaseSize, Files.size(destinationDatabaseFile))
+    }
+
+    @Test
+    fun `applyPendingImport does not apply an expired confirmation`() {
+        val destinationDatabaseFile = Files.createTempFile("backupServiceTestDestinationDb", ".db")
+        Files.writeString(destinationDatabaseFile, "old-destination-database-placeholder")
+        val originalDestinationDatabaseSize = Files.size(destinationDatabaseFile)
+        val destinationUploadsRoot = Files.createTempDirectory("backupServiceTestDestinationUploads")
+        val destinationConfigFile = Files.createTempFile("backupServiceTestDestinationConfig", ".conf").toFile()
+        destinationConfigFile.writeText("secret=old-destination-secret\n")
+        val destinationService =
+            prepareStagedImport(destinationUploadsRoot, destinationDatabaseFile, destinationConfigFile, confirm = false)
+        val operationId = destinationService.stagedOperationId()!!
+        destinationService.writeConfirmationToken(expiredConfirmationToken("old-destination-secret", operationId))
+
+        val pendingImportApplied = destinationService.applyPendingImport()
+
+        assertFalse(pendingImportApplied)
+        assertEquals(originalDestinationDatabaseSize, Files.size(destinationDatabaseFile))
     }
 }

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/InitialSetupRestoreRouteTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/InitialSetupRestoreRouteTest.kt
@@ -166,4 +166,33 @@ class InitialSetupRestoreRouteTest {
             val tokenService = TokenService(applicationEnvironment { config = testJwtConfig() })
             assertEquals("onboarding", tokenService.getUserIdFromBackupProgressToken(progressToken, operationId))
         }
+
+    @Test
+    fun `confirm-pending-restore returns conflict when initial setup is already completed`() =
+        testApplication {
+            ExposedTestDb.seedConfig("America/Mexico_City")
+            application {
+                install(ContentNegotiation) { json() }
+                handler()
+                configureInitialSetup()
+            }
+
+            val confirmResponse = client.post("/initial-setup/confirm-pending-restore")
+
+            assertEquals(HttpStatusCode.Conflict, confirmResponse.status)
+        }
+
+    @Test
+    fun `confirm-pending-restore returns ok when nothing is pending`() =
+        testApplication {
+            application {
+                install(ContentNegotiation) { json() }
+                handler()
+                configureInitialSetup()
+            }
+
+            val confirmResponse = client.post("/initial-setup/confirm-pending-restore")
+
+            assertEquals(HttpStatusCode.OK, confirmResponse.status)
+        }
 }

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/TokenServiceTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/TokenServiceTest.kt
@@ -8,6 +8,7 @@ import org.junit.Before
 import pos.ambrosia.db.tables.UserEntity
 import pos.ambrosia.services.TokenService
 import pos.ambrosia.utils.ExposedTestDb
+import pos.ambrosia.utils.confirmationTokenConfig
 import pos.ambrosia.utils.testJwtConfig
 import java.io.File
 import java.util.Date
@@ -26,6 +27,9 @@ class TokenServiceTest {
         }
     private val service = TokenService(environment)
     private lateinit var dbFile: File
+
+    private fun confirmationTokenService(secret: String): TokenService =
+        TokenService(applicationEnvironment { config = confirmationTokenConfig(secret) })
 
     @Before
     fun setUp() {
@@ -97,6 +101,55 @@ class TokenServiceTest {
         val resolvedUserId = service.getUserIdFromBackupProgressToken(walletAccessToken, "operation-1")
 
         assertNull(resolvedUserId)
+    }
+
+    @Test
+    fun `generateBackupConfirmationToken embeds scope and operationId and expires in about 4 hours`() {
+        val token = confirmationTokenService("confirmation-secret").generateBackupConfirmationToken("operation-1")
+
+        val decoded = JWT.decode(token)
+        assertTrue(decoded.getClaim("scope").asString() == "backup_confirmation")
+        assertTrue(decoded.getClaim("operationId").asString() == "operation-1")
+
+        val now = System.currentTimeMillis()
+        assertTrue(decoded.expiresAt.after(Date(now + TimeUnit.HOURS.toMillis(3))))
+        assertTrue(decoded.expiresAt.before(Date(now + TimeUnit.HOURS.toMillis(4) + TimeUnit.SECONDS.toMillis(1))))
+    }
+
+    @Test
+    fun `isBackupConfirmationTokenValid returns true when the token and operationId match`() {
+        val token = confirmationTokenService("confirmation-secret").generateBackupConfirmationToken("operation-1")
+
+        val isValid = TokenService.isBackupConfirmationTokenValid("confirmation-secret", token, "operation-1")
+
+        assertTrue(isValid)
+    }
+
+    @Test
+    fun `isBackupConfirmationTokenValid returns false when the operationId does not match`() {
+        val token = confirmationTokenService("confirmation-secret").generateBackupConfirmationToken("operation-1")
+
+        val isValid = TokenService.isBackupConfirmationTokenValid("confirmation-secret", token, "operation-2")
+
+        assertFalse(isValid)
+    }
+
+    @Test
+    fun `isBackupConfirmationTokenValid returns false for a token with a different scope`() {
+        val progressToken = confirmationTokenService("confirmation-secret").generateBackupProgressToken("user-1", "operation-1")
+
+        val isValid = TokenService.isBackupConfirmationTokenValid("confirmation-secret", progressToken, "operation-1")
+
+        assertFalse(isValid)
+    }
+
+    @Test
+    fun `isBackupConfirmationTokenValid returns false when the token was signed with a different secret`() {
+        val token = confirmationTokenService("confirmation-secret").generateBackupConfirmationToken("operation-1")
+
+        val isValid = TokenService.isBackupConfirmationTokenValid("a-different-secret", token, "operation-1")
+
+        assertFalse(isValid)
     }
 
     @Test

--- a/server/app/src/test/kotlin/pos/ambrosia/utils/TestJwtConfig.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utils/TestJwtConfig.kt
@@ -1,6 +1,7 @@
 package pos.ambrosia.utils
 
 import io.ktor.server.config.MapApplicationConfig
+import pos.ambrosia.services.TokenService
 
 private const val TEST_SECRET = "test-secret"
 private const val TEST_ISSUER = "test-issuer"
@@ -11,4 +12,11 @@ fun testJwtConfig(): MapApplicationConfig =
         "secret" to TEST_SECRET,
         "jwt.issuer" to TEST_ISSUER,
         "jwt.audience" to TEST_AUDIENCE,
+    )
+
+fun confirmationTokenConfig(secret: String): MapApplicationConfig =
+    MapApplicationConfig(
+        "secret" to secret,
+        "jwt.issuer" to TokenService.JWT_ISSUER,
+        "jwt.audience" to TokenService.JWT_AUDIENCE,
     )


### PR DESCRIPTION
## Changes:

- Add a signed confirmation token (`TokenService.generateBackupConfirmationToken`/`isBackupConfirmationTokenValid`) and require it in `BackupService.applyPendingImport` before a staged import/restore is ever applied, so a server restart no longer applies data that nobody explicitly confirmed.
- Expose the running `EmbeddedServer` and Docker mode in `Ambrosia.kt`/`DockerMode.kt` so a confirmed import can trigger a graceful, automatic restart when running in Docker.
- Add `POST /backup/confirm-pending-import` and `POST /initial-setup/confirm-pending-restore` endpoints that write the confirmation token and, in Docker, schedule the restart.
- Add `confirmPendingImport`/`confirmPendingRestore` to the client's `backupService`/`initialSetupService`.
- Call the new confirm functions before triggering a backend restart in both the Settings Import Data card and the onboarding restore step.