### PR TITLE
Feat/native(chore): restart controls

### DIFF
--- a/client/src/components/pages/Store/Settings/Settings.jsx
+++ b/client/src/components/pages/Store/Settings/Settings.jsx
@@ -21,6 +21,7 @@ import { QRUrl } from "./QRUrl";
 import { SecureConnection } from "./SecureConnection/SecureConnection";
 import { Seed } from "./Seed";
 import { StoreInfo } from "./StoreInfo";
+import { SystemCard } from "./System/SystemCard";
 import { TicketTemplates } from "./TicketTemplates";
 import { Tips } from "./Tips";
 import { Tutorials } from "./Tutorials";
@@ -47,6 +48,7 @@ export function Settings() {
               <ImportData />
               <NwcConnectionCard />
               <PhoenixdRemoteCard />
+              <SystemCard />
               <Tutorials />
             </>
           )}

--- a/client/src/components/pages/Store/Settings/System/RestartConfirmModal.jsx
+++ b/client/src/components/pages/Store/Settings/System/RestartConfirmModal.jsx
@@ -15,7 +15,12 @@ export function RestartConfirmModal({ isOpen, title, description, isRestarting, 
           </div>
         </ModalBody>
         <ModalFooter>
-          <Button variant="bordered" onPress={onCancel} isDisabled={isRestarting}>
+          <Button
+            variant="bordered"
+            className="px-6 py-2 border border-border text-foreground hover:bg-muted disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            onPress={onCancel}
+            isDisabled={isRestarting}
+          >
             {systemCardTranslations("cardSystem.cancelButton")}
           </Button>
           <Button color="danger" onPress={onConfirm} isLoading={isRestarting}>

--- a/client/src/components/pages/Store/Settings/System/RestartConfirmModal.jsx
+++ b/client/src/components/pages/Store/Settings/System/RestartConfirmModal.jsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { Button, Modal, ModalBody, ModalContent, ModalFooter, ModalHeader } from "@heroui/react";
+import { AlertTriangle } from "lucide-react";
+
+export function RestartConfirmModal({ isOpen, title, description, isRestarting, onCancel, onConfirm, systemCardTranslations }) {
+  return (
+    <Modal isOpen={isOpen} onOpenChange={onCancel} isDismissable={!isRestarting} hideCloseButton={isRestarting}>
+      <ModalContent>
+        <ModalHeader>{title}</ModalHeader>
+        <ModalBody>
+          <div className="flex items-start gap-3 border border-red-400 rounded-lg p-4">
+            <AlertTriangle className="w-5 h-5 text-red-600 mt-0.5 shrink-0" />
+            <p className="text-red-700 text-sm">{description}</p>
+          </div>
+        </ModalBody>
+        <ModalFooter>
+          <Button variant="bordered" onPress={onCancel} isDisabled={isRestarting}>
+            {systemCardTranslations("cardSystem.cancelButton")}
+          </Button>
+          <Button color="danger" onPress={onConfirm} isLoading={isRestarting}>
+            {systemCardTranslations("cardSystem.confirmButton")}
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/client/src/components/pages/Store/Settings/System/SystemCard.jsx
+++ b/client/src/components/pages/Store/Settings/System/SystemCard.jsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { addToast, Button, Card, CardBody, CardHeader } from "@heroui/react";
+import { useTranslations } from "next-intl";
+
+import { useSystemRestart } from "@/hooks/useSystemRestart";
+
+import { RestartConfirmModal } from "./RestartConfirmModal";
+
+export function SystemCard() {
+  const systemCardTranslations = useTranslations("settings");
+  const {
+    serverRestartSupported,
+    phoenixdRestartSupported,
+    restartingTarget,
+    loadRestartCapabilities,
+    restartServer,
+    restartPhoenixd,
+  } = useSystemRestart();
+  const [confirmTarget, setConfirmTarget] = useState(null);
+
+  useEffect(() => {
+    loadRestartCapabilities();
+  }, [loadRestartCapabilities]);
+
+  const restartTargets = {
+    server: {
+      buttonLabelKey: "cardSystem.restartServerButton",
+      confirmTitleKey: "cardSystem.confirmServerTitle",
+      confirmDescriptionKey: "cardSystem.confirmServerDescription",
+      successMessageKey: "cardSystem.restartServerSuccess",
+      errorMessageKey: "cardSystem.restartServerError",
+      isSupported: serverRestartSupported,
+      restart: restartServer,
+    },
+    phoenixd: {
+      buttonLabelKey: "cardSystem.restartPhoenixdButton",
+      confirmTitleKey: "cardSystem.confirmPhoenixdTitle",
+      confirmDescriptionKey: "cardSystem.confirmPhoenixdDescription",
+      successMessageKey: "cardSystem.restartPhoenixdSuccess",
+      errorMessageKey: "cardSystem.restartPhoenixdError",
+      isSupported: phoenixdRestartSupported,
+      restart: restartPhoenixd,
+    },
+  };
+
+  const activeConfirmTarget = confirmTarget ? restartTargets[confirmTarget] : null;
+  const supportedTargetEntries = Object.entries(restartTargets).filter(([, target]) => target.isSupported);
+
+  const handleConfirmRestart = async () => {
+    const succeeded = await activeConfirmTarget.restart();
+    const resultMessageKey = succeeded ? activeConfirmTarget.successMessageKey : activeConfirmTarget.errorMessageKey;
+    setConfirmTarget(null);
+    addToast({ color: succeeded ? "success" : "danger", description: systemCardTranslations(resultMessageKey) });
+  };
+
+  return (
+    <Card shadow="none" className="rounded-lg mb-6 p-6 shadow-lg">
+      <CardHeader className="flex flex-col items-start pb-0">
+        <h2 className="text-lg sm:text-xl xl:text-2xl font-semibold text-green-900">
+          {systemCardTranslations("cardSystem.title")}
+        </h2>
+      </CardHeader>
+
+      <CardBody className="gap-4">
+        <p className="text-sm text-gray-500">{systemCardTranslations("cardSystem.description")}</p>
+
+        {supportedTargetEntries.length === 0 ? (
+          <p className="text-sm text-gray-500">{systemCardTranslations("cardSystem.unsupportedNotice")}</p>
+        ) : (
+          <div className="flex flex-wrap gap-3">
+            {supportedTargetEntries.map(([targetName, target]) => (
+              <Button
+                key={targetName}
+                variant="bordered"
+                className="border border-red-600 text-red-600"
+                onPress={() => setConfirmTarget(targetName)}
+                isLoading={restartingTarget === targetName}
+              >
+                {systemCardTranslations(target.buttonLabelKey)}
+              </Button>
+            ))}
+          </div>
+        )}
+      </CardBody>
+
+      {activeConfirmTarget && (
+        <RestartConfirmModal
+          isOpen
+          isRestarting={restartingTarget !== null}
+          onCancel={() => setConfirmTarget(null)}
+          onConfirm={handleConfirmRestart}
+          systemCardTranslations={systemCardTranslations}
+          title={systemCardTranslations(activeConfirmTarget.confirmTitleKey)}
+          description={systemCardTranslations(activeConfirmTarget.confirmDescriptionKey)}
+        />
+      )}
+    </Card>
+  );
+}

--- a/client/src/components/pages/Store/Settings/System/SystemCard.jsx
+++ b/client/src/components/pages/Store/Settings/System/SystemCard.jsx
@@ -74,8 +74,7 @@ export function SystemCard() {
             {supportedTargetEntries.map(([targetName, target]) => (
               <Button
                 key={targetName}
-                variant="bordered"
-                className="border border-red-600 text-red-600"
+                color="danger"
                 onPress={() => setConfirmTarget(targetName)}
                 isLoading={restartingTarget === targetName}
               >

--- a/client/src/components/pages/Store/Settings/System/__tests__/SystemCard.test.jsx
+++ b/client/src/components/pages/Store/Settings/System/__tests__/SystemCard.test.jsx
@@ -1,0 +1,165 @@
+import { render, screen, fireEvent, act } from "@testing-library/react";
+
+import * as useSystemRestartHook from "@/hooks/useSystemRestart";
+
+import { SystemCard } from "../SystemCard";
+
+jest.mock("@/hooks/useSystemRestart");
+
+jest.mock("@heroui/react", () => ({
+  addToast: jest.fn(),
+  Button: ({ onPress, children, isLoading, ...props }) => (
+    <button type="button" disabled={isLoading} onClick={onPress} {...props}>{children}</button>
+  ),
+  Card: ({ children }) => <div>{children}</div>,
+  CardHeader: ({ children }) => <div>{children}</div>,
+  CardBody: ({ children }) => <div>{children}</div>,
+}));
+
+jest.mock("../RestartConfirmModal", () => ({
+  RestartConfirmModal: ({ isOpen, title, description, onConfirm, onCancel }) => (
+    isOpen ? (
+      <div data-testid="restart-confirm-modal">
+        <span>{title}</span>
+        <span>{description}</span>
+        <button type="button" onClick={onConfirm}>confirm</button>
+        <button type="button" onClick={onCancel}>cancel</button>
+      </div>
+    ) : null
+  ),
+}));
+
+function mockUseSystemRestart(overrides = {}) {
+  const defaults = {
+    serverRestartSupported: false,
+    phoenixdRestartSupported: false,
+    restartingTarget: null,
+    loadRestartCapabilities: jest.fn(),
+    restartServer: jest.fn().mockResolvedValue(true),
+    restartPhoenixd: jest.fn().mockResolvedValue(true),
+  };
+  const state = { ...defaults, ...overrides };
+  jest.spyOn(useSystemRestartHook, "useSystemRestart").mockReturnValue(state);
+  return state;
+}
+
+describe("SystemCard", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("Rendering", () => {
+    it("renders the title and description", () => {
+      mockUseSystemRestart();
+      render(<SystemCard />);
+
+      expect(screen.getByText("cardSystem.title")).toBeInTheDocument();
+      expect(screen.getByText("cardSystem.description")).toBeInTheDocument();
+    });
+
+    it("shows the unsupported notice when neither target can be restarted", () => {
+      mockUseSystemRestart();
+      render(<SystemCard />);
+
+      expect(screen.getByText("cardSystem.unsupportedNotice")).toBeInTheDocument();
+      expect(screen.queryByText("cardSystem.restartServerButton")).not.toBeInTheDocument();
+      expect(screen.queryByText("cardSystem.restartPhoenixdButton")).not.toBeInTheDocument();
+    });
+
+    it("shows only the server button when only server restart is supported", () => {
+      mockUseSystemRestart({ serverRestartSupported: true });
+      render(<SystemCard />);
+
+      expect(screen.getByText("cardSystem.restartServerButton")).toBeInTheDocument();
+      expect(screen.queryByText("cardSystem.restartPhoenixdButton")).not.toBeInTheDocument();
+    });
+
+    it("shows both buttons when both targets are supported", () => {
+      mockUseSystemRestart({ serverRestartSupported: true, phoenixdRestartSupported: true });
+      render(<SystemCard />);
+
+      expect(screen.getByText("cardSystem.restartServerButton")).toBeInTheDocument();
+      expect(screen.getByText("cardSystem.restartPhoenixdButton")).toBeInTheDocument();
+    });
+
+    it("loads restart capabilities on mount", () => {
+      const state = mockUseSystemRestart();
+      render(<SystemCard />);
+
+      expect(state.loadRestartCapabilities).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("Restarting the server", () => {
+    it("opens the confirmation modal when the restart server button is pressed", () => {
+      mockUseSystemRestart({ serverRestartSupported: true });
+      render(<SystemCard />);
+
+      fireEvent.click(screen.getByText("cardSystem.restartServerButton"));
+
+      expect(screen.getByTestId("restart-confirm-modal")).toBeInTheDocument();
+      expect(screen.getByText("cardSystem.confirmServerTitle")).toBeInTheDocument();
+    });
+
+    it("calls restartServer and shows a success toast on confirm", async () => {
+      const state = mockUseSystemRestart({ serverRestartSupported: true });
+      const { addToast } = require("@heroui/react");
+      render(<SystemCard />);
+
+      fireEvent.click(screen.getByText("cardSystem.restartServerButton"));
+      await act(async () => {
+        fireEvent.click(screen.getByText("confirm"));
+      });
+
+      expect(state.restartServer).toHaveBeenCalledTimes(1);
+      expect(addToast).toHaveBeenCalledWith(
+        expect.objectContaining({ color: "success", description: "cardSystem.restartServerSuccess" }),
+      );
+      expect(screen.queryByTestId("restart-confirm-modal")).not.toBeInTheDocument();
+    });
+
+    it("shows a danger toast when the restart fails", async () => {
+      const state = mockUseSystemRestart({
+        serverRestartSupported: true,
+        restartServer: jest.fn().mockResolvedValue(false),
+      });
+      const { addToast } = require("@heroui/react");
+      render(<SystemCard />);
+
+      fireEvent.click(screen.getByText("cardSystem.restartServerButton"));
+      await act(async () => {
+        fireEvent.click(screen.getByText("confirm"));
+      });
+
+      expect(state.restartServer).toHaveBeenCalledTimes(1);
+      expect(addToast).toHaveBeenCalledWith(
+        expect.objectContaining({ color: "danger", description: "cardSystem.restartServerError" }),
+      );
+    });
+
+    it("closes the modal without restarting when cancelled", () => {
+      const state = mockUseSystemRestart({ serverRestartSupported: true });
+      render(<SystemCard />);
+
+      fireEvent.click(screen.getByText("cardSystem.restartServerButton"));
+      fireEvent.click(screen.getByText("cancel"));
+
+      expect(state.restartServer).not.toHaveBeenCalled();
+      expect(screen.queryByTestId("restart-confirm-modal")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Restarting phoenixd", () => {
+    it("calls restartPhoenixd on confirm", async () => {
+      const state = mockUseSystemRestart({ phoenixdRestartSupported: true });
+      render(<SystemCard />);
+
+      fireEvent.click(screen.getByText("cardSystem.restartPhoenixdButton"));
+      await act(async () => {
+        fireEvent.click(screen.getByText("confirm"));
+      });
+
+      expect(state.restartPhoenixd).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/client/src/components/pages/Store/Settings/System/__tests__/SystemCard.test.jsx
+++ b/client/src/components/pages/Store/Settings/System/__tests__/SystemCard.test.jsx
@@ -38,9 +38,9 @@ function mockUseSystemRestart(overrides = {}) {
     restartServer: jest.fn().mockResolvedValue(true),
     restartPhoenixd: jest.fn().mockResolvedValue(true),
   };
-  const state = { ...defaults, ...overrides };
-  jest.spyOn(useSystemRestartHook, "useSystemRestart").mockReturnValue(state);
-  return state;
+  const restartState = { ...defaults, ...overrides };
+  jest.spyOn(useSystemRestartHook, "useSystemRestart").mockReturnValue(restartState);
+  return restartState;
 }
 
 describe("SystemCard", () => {
@@ -83,10 +83,10 @@ describe("SystemCard", () => {
     });
 
     it("loads restart capabilities on mount", () => {
-      const state = mockUseSystemRestart();
+      const restartState = mockUseSystemRestart();
       render(<SystemCard />);
 
-      expect(state.loadRestartCapabilities).toHaveBeenCalledTimes(1);
+      expect(restartState.loadRestartCapabilities).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -102,7 +102,7 @@ describe("SystemCard", () => {
     });
 
     it("calls restartServer and shows a success toast on confirm", async () => {
-      const state = mockUseSystemRestart({ serverRestartSupported: true });
+      const restartState = mockUseSystemRestart({ serverRestartSupported: true });
       const { addToast } = require("@heroui/react");
       render(<SystemCard />);
 
@@ -111,7 +111,7 @@ describe("SystemCard", () => {
         fireEvent.click(screen.getByText("confirm"));
       });
 
-      expect(state.restartServer).toHaveBeenCalledTimes(1);
+      expect(restartState.restartServer).toHaveBeenCalledTimes(1);
       expect(addToast).toHaveBeenCalledWith(
         expect.objectContaining({ color: "success", description: "cardSystem.restartServerSuccess" }),
       );
@@ -119,7 +119,7 @@ describe("SystemCard", () => {
     });
 
     it("shows a danger toast when the restart fails", async () => {
-      const state = mockUseSystemRestart({
+      const restartState = mockUseSystemRestart({
         serverRestartSupported: true,
         restartServer: jest.fn().mockResolvedValue(false),
       });
@@ -131,27 +131,27 @@ describe("SystemCard", () => {
         fireEvent.click(screen.getByText("confirm"));
       });
 
-      expect(state.restartServer).toHaveBeenCalledTimes(1);
+      expect(restartState.restartServer).toHaveBeenCalledTimes(1);
       expect(addToast).toHaveBeenCalledWith(
         expect.objectContaining({ color: "danger", description: "cardSystem.restartServerError" }),
       );
     });
 
     it("closes the modal without restarting when cancelled", () => {
-      const state = mockUseSystemRestart({ serverRestartSupported: true });
+      const restartState = mockUseSystemRestart({ serverRestartSupported: true });
       render(<SystemCard />);
 
       fireEvent.click(screen.getByText("cardSystem.restartServerButton"));
       fireEvent.click(screen.getByText("cancel"));
 
-      expect(state.restartServer).not.toHaveBeenCalled();
+      expect(restartState.restartServer).not.toHaveBeenCalled();
       expect(screen.queryByTestId("restart-confirm-modal")).not.toBeInTheDocument();
     });
   });
 
   describe("Restarting phoenixd", () => {
     it("calls restartPhoenixd on confirm", async () => {
-      const state = mockUseSystemRestart({ phoenixdRestartSupported: true });
+      const restartState = mockUseSystemRestart({ phoenixdRestartSupported: true });
       render(<SystemCard />);
 
       fireEvent.click(screen.getByText("cardSystem.restartPhoenixdButton"));
@@ -159,7 +159,7 @@ describe("SystemCard", () => {
         fireEvent.click(screen.getByText("confirm"));
       });
 
-      expect(state.restartPhoenixd).toHaveBeenCalledTimes(1);
+      expect(restartState.restartPhoenixd).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/client/src/components/pages/Store/Settings/System/locales/en.js
+++ b/client/src/components/pages/Store/Settings/System/locales/en.js
@@ -1,0 +1,21 @@
+const systemEn = {
+  cardSystem: {
+    title: "System",
+    description: "Restart the Ambrosia server or the Lightning node when they need to pick up a change.",
+    restartServerButton: "Restart server",
+    restartPhoenixdButton: "Restart phoenixd",
+    unsupportedNotice: "Restart is not available for this installation.",
+    confirmServerTitle: "Restart the server?",
+    confirmServerDescription: "The Ambrosia server will restart. Open sessions will be briefly interrupted.",
+    confirmPhoenixdTitle: "Restart phoenixd?",
+    confirmPhoenixdDescription: "The Lightning node will restart. Wallet operations will be briefly unavailable.",
+    cancelButton: "Cancel",
+    confirmButton: "Restart",
+    restartServerSuccess: "The server is restarting.",
+    restartServerError: "Could not restart the server.",
+    restartPhoenixdSuccess: "phoenixd is restarting.",
+    restartPhoenixdError: "Could not restart phoenixd.",
+  },
+};
+
+export default systemEn;

--- a/client/src/components/pages/Store/Settings/System/locales/es.js
+++ b/client/src/components/pages/Store/Settings/System/locales/es.js
@@ -1,0 +1,21 @@
+const systemEs = {
+  cardSystem: {
+    title: "Sistema",
+    description: "Reinicia el servidor de Ambrosia o el nodo Lightning cuando necesiten aplicar un cambio.",
+    restartServerButton: "Reiniciar servidor",
+    restartPhoenixdButton: "Reiniciar phoenixd",
+    unsupportedNotice: "El reinicio no está disponible para esta instalación.",
+    confirmServerTitle: "¿Reiniciar el servidor?",
+    confirmServerDescription: "El servidor de Ambrosia se reiniciará. Las sesiones abiertas se interrumpirán brevemente.",
+    confirmPhoenixdTitle: "¿Reiniciar phoenixd?",
+    confirmPhoenixdDescription: "El nodo Lightning se reiniciará. Las operaciones de la billetera no estarán disponibles brevemente.",
+    cancelButton: "Cancelar",
+    confirmButton: "Reiniciar",
+    restartServerSuccess: "El servidor se está reiniciando.",
+    restartServerError: "No se pudo reiniciar el servidor.",
+    restartPhoenixdSuccess: "phoenixd se está reiniciando.",
+    restartPhoenixdError: "No se pudo reiniciar phoenixd.",
+  },
+};
+
+export default systemEs;

--- a/client/src/components/pages/Store/Settings/locales/en.js
+++ b/client/src/components/pages/Store/Settings/locales/en.js
@@ -6,6 +6,7 @@ import phoenixdRemoteCardEn from "../PhoenixdRemote/locales/en";
 import printersEn from "../Printers/locales/en";
 import seedEn from "../Seed/locales/en";
 import storeInfoEn from "../StoreInfo/locales/en";
+import systemEn from "../System/locales/en";
 import ticketTemplatesEn from "../TicketTemplates/locales/en";
 import tutorialsEn from "../Tutorials/locales/en";
 
@@ -94,6 +95,7 @@ const settingsEn = {
       errorMessage: "Failed to save tip settings",
     },
     ...storeInfoEn,
+    ...systemEn,
     ...printersEn,
     ...ticketTemplatesEn,
     ...seedEn,

--- a/client/src/components/pages/Store/Settings/locales/es.js
+++ b/client/src/components/pages/Store/Settings/locales/es.js
@@ -6,6 +6,7 @@ import phoenixdRemoteCardEs from "../PhoenixdRemote/locales/es";
 import printersEs from "../Printers/locales/es";
 import seedEs from "../Seed/locales/es";
 import storeInfoEs from "../StoreInfo/locales/es";
+import systemEs from "../System/locales/es";
 import ticketTemplatesEs from "../TicketTemplates/locales/es";
 import tutorialsEs from "../Tutorials/locales/es";
 
@@ -94,6 +95,7 @@ const settingsEs = {
       errorMessage: "No se pudo guardar la configuración de propinas",
     },
     ...storeInfoEs,
+    ...systemEs,
     ...printersEs,
     ...ticketTemplatesEs,
     ...seedEs,

--- a/client/src/hooks/__tests__/useSystemRestart.test.js
+++ b/client/src/hooks/__tests__/useSystemRestart.test.js
@@ -19,10 +19,10 @@ describe("useSystemRestart", () => {
 
   describe("initial state", () => {
     it("starts with both capabilities unsupported", () => {
-      const { result } = renderHook(() => useSystemRestart());
+      const { result: hookResult } = renderHook(() => useSystemRestart());
 
-      expect(result.current.serverRestartSupported).toBe(false);
-      expect(result.current.phoenixdRestartSupported).toBe(false);
+      expect(hookResult.current.serverRestartSupported).toBe(false);
+      expect(hookResult.current.phoenixdRestartSupported).toBe(false);
     });
   });
 
@@ -32,69 +32,69 @@ describe("useSystemRestart", () => {
         serverRestartSupported: true,
         phoenixdRestartSupported: false,
       });
-      const { result } = renderHook(() => useSystemRestart());
+      const { result: hookResult } = renderHook(() => useSystemRestart());
 
       await act(async () => {
-        await result.current.loadRestartCapabilities();
+        await hookResult.current.loadRestartCapabilities();
       });
 
-      expect(result.current.serverRestartSupported).toBe(true);
-      expect(result.current.phoenixdRestartSupported).toBe(false);
+      expect(hookResult.current.serverRestartSupported).toBe(true);
+      expect(hookResult.current.phoenixdRestartSupported).toBe(false);
     });
 
     it("sets an error when the request fails", async () => {
       getRestartCapabilities.mockRejectedValue(new Error("network error"));
-      const { result } = renderHook(() => useSystemRestart());
+      const { result: hookResult } = renderHook(() => useSystemRestart());
 
       await act(async () => {
-        await result.current.loadRestartCapabilities();
+        await hookResult.current.loadRestartCapabilities();
       });
 
-      expect(result.current.error).toBe("network error");
+      expect(hookResult.current.error).toBe("network error");
     });
   });
 
   describe("restartServer", () => {
     it("calls the server restart endpoint and returns true on success", async () => {
       restartServer.mockResolvedValue({ message: "Server restarting" });
-      const { result } = renderHook(() => useSystemRestart());
+      const { result: hookResult } = renderHook(() => useSystemRestart());
 
-      let returnValue;
+      let restartSucceeded;
       await act(async () => {
-        returnValue = await result.current.restartServer();
+        restartSucceeded = await hookResult.current.restartServer();
       });
 
       expect(restartServer).toHaveBeenCalledTimes(1);
-      expect(returnValue).toBe(true);
-      expect(result.current.restartingTarget).toBeNull();
+      expect(restartSucceeded).toBe(true);
+      expect(hookResult.current.restartingTarget).toBeNull();
     });
 
     it("sets an error and returns false when the request fails", async () => {
       restartServer.mockRejectedValue(new Error("restart failed"));
-      const { result } = renderHook(() => useSystemRestart());
+      const { result: hookResult } = renderHook(() => useSystemRestart());
 
-      let returnValue;
+      let restartSucceeded;
       await act(async () => {
-        returnValue = await result.current.restartServer();
+        restartSucceeded = await hookResult.current.restartServer();
       });
 
-      expect(returnValue).toBe(false);
-      expect(result.current.error).toBe("restart failed");
+      expect(restartSucceeded).toBe(false);
+      expect(hookResult.current.error).toBe("restart failed");
     });
   });
 
   describe("restartPhoenixd", () => {
     it("calls the phoenixd restart endpoint and returns true on success", async () => {
       restartPhoenixd.mockResolvedValue({ message: "phoenixd restarting" });
-      const { result } = renderHook(() => useSystemRestart());
+      const { result: hookResult } = renderHook(() => useSystemRestart());
 
-      let returnValue;
+      let restartSucceeded;
       await act(async () => {
-        returnValue = await result.current.restartPhoenixd();
+        restartSucceeded = await hookResult.current.restartPhoenixd();
       });
 
       expect(restartPhoenixd).toHaveBeenCalledTimes(1);
-      expect(returnValue).toBe(true);
+      expect(restartSucceeded).toBe(true);
     });
   });
 });

--- a/client/src/hooks/__tests__/useSystemRestart.test.js
+++ b/client/src/hooks/__tests__/useSystemRestart.test.js
@@ -1,0 +1,100 @@
+import { act, renderHook } from "@testing-library/react";
+
+import { getRestartCapabilities, restartPhoenixd, restartServer } from "@/services/systemService";
+
+import { useSystemRestart } from "../useSystemRestart";
+
+jest.mock("@/services/systemService", () => ({
+  getRestartCapabilities: jest.fn(),
+  restartServer: jest.fn(),
+  restartPhoenixd: jest.fn(),
+}));
+
+jest.mock("@lib/isElectron", () => ({ isElectron: false }));
+
+describe("useSystemRestart", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("initial state", () => {
+    it("starts with both capabilities unsupported", () => {
+      const { result } = renderHook(() => useSystemRestart());
+
+      expect(result.current.serverRestartSupported).toBe(false);
+      expect(result.current.phoenixdRestartSupported).toBe(false);
+    });
+  });
+
+  describe("loadRestartCapabilities", () => {
+    it("applies the capabilities returned by the server", async () => {
+      getRestartCapabilities.mockResolvedValue({
+        serverRestartSupported: true,
+        phoenixdRestartSupported: false,
+      });
+      const { result } = renderHook(() => useSystemRestart());
+
+      await act(async () => {
+        await result.current.loadRestartCapabilities();
+      });
+
+      expect(result.current.serverRestartSupported).toBe(true);
+      expect(result.current.phoenixdRestartSupported).toBe(false);
+    });
+
+    it("sets an error when the request fails", async () => {
+      getRestartCapabilities.mockRejectedValue(new Error("network error"));
+      const { result } = renderHook(() => useSystemRestart());
+
+      await act(async () => {
+        await result.current.loadRestartCapabilities();
+      });
+
+      expect(result.current.error).toBe("network error");
+    });
+  });
+
+  describe("restartServer", () => {
+    it("calls the server restart endpoint and returns true on success", async () => {
+      restartServer.mockResolvedValue({ message: "Server restarting" });
+      const { result } = renderHook(() => useSystemRestart());
+
+      let returnValue;
+      await act(async () => {
+        returnValue = await result.current.restartServer();
+      });
+
+      expect(restartServer).toHaveBeenCalledTimes(1);
+      expect(returnValue).toBe(true);
+      expect(result.current.restartingTarget).toBeNull();
+    });
+
+    it("sets an error and returns false when the request fails", async () => {
+      restartServer.mockRejectedValue(new Error("restart failed"));
+      const { result } = renderHook(() => useSystemRestart());
+
+      let returnValue;
+      await act(async () => {
+        returnValue = await result.current.restartServer();
+      });
+
+      expect(returnValue).toBe(false);
+      expect(result.current.error).toBe("restart failed");
+    });
+  });
+
+  describe("restartPhoenixd", () => {
+    it("calls the phoenixd restart endpoint and returns true on success", async () => {
+      restartPhoenixd.mockResolvedValue({ message: "phoenixd restarting" });
+      const { result } = renderHook(() => useSystemRestart());
+
+      let returnValue;
+      await act(async () => {
+        returnValue = await result.current.restartPhoenixd();
+      });
+
+      expect(restartPhoenixd).toHaveBeenCalledTimes(1);
+      expect(returnValue).toBe(true);
+    });
+  });
+});

--- a/client/src/hooks/useSystemRestart.js
+++ b/client/src/hooks/useSystemRestart.js
@@ -1,0 +1,75 @@
+"use client";
+
+import { useCallback, useState } from "react";
+
+import {
+  getRestartCapabilities,
+  restartPhoenixd as requestPhoenixdRestart,
+  restartServer as requestServerRestart,
+} from "@/services/systemService";
+import { isElectron } from "@lib/isElectron";
+
+export function useSystemRestart() {
+  const [serverRestartSupported, setServerRestartSupported] = useState(isElectron);
+  const [phoenixdRestartSupported, setPhoenixdRestartSupported] = useState(isElectron);
+  const [loadingCapabilities, setLoadingCapabilities] = useState(false);
+  const [restartingTarget, setRestartingTarget] = useState(null);
+  const [error, setError] = useState(null);
+
+  const loadRestartCapabilities = useCallback(async () => {
+    if (isElectron) {
+      return;
+    }
+
+    setLoadingCapabilities(true);
+    setError(null);
+    try {
+      const capabilities = await getRestartCapabilities();
+      setServerRestartSupported(Boolean(capabilities?.serverRestartSupported));
+      setPhoenixdRestartSupported(Boolean(capabilities?.phoenixdRestartSupported));
+    } catch (loadError) {
+      setError(loadError.message);
+    } finally {
+      setLoadingCapabilities(false);
+    }
+  }, []);
+
+  const restartService = useCallback(async (serviceName, requestRestart) => {
+    setRestartingTarget(serviceName);
+    setError(null);
+    try {
+      if (isElectron) {
+        await window.electron.ipc.invoke("services:restart", serviceName);
+      } else {
+        await requestRestart();
+      }
+      return true;
+    } catch (restartError) {
+      setError(restartError.message);
+      return false;
+    } finally {
+      setRestartingTarget(null);
+    }
+  }, []);
+
+  const restartServer = useCallback(
+    () => restartService("backend", requestServerRestart),
+    [restartService],
+  );
+
+  const restartPhoenixd = useCallback(
+    () => restartService("phoenixd", requestPhoenixdRestart),
+    [restartService],
+  );
+
+  return {
+    serverRestartSupported,
+    phoenixdRestartSupported,
+    loadingCapabilities,
+    restartingTarget,
+    error,
+    loadRestartCapabilities,
+    restartServer,
+    restartPhoenixd,
+  };
+}

--- a/client/src/services/systemService.js
+++ b/client/src/services/systemService.js
@@ -1,0 +1,26 @@
+import { buildParsedHttpError } from "@/components/pages/Store/utils/buildHttpError";
+import { httpClient, parseJsonResponse } from "@/lib/http";
+
+export async function getRestartCapabilities() {
+  const capabilitiesResponse = await httpClient("/system/restart-capabilities");
+  if (!capabilitiesResponse.ok) {
+    throw await buildParsedHttpError(capabilitiesResponse, "Failed to get restart capabilities");
+  }
+  return await parseJsonResponse(capabilitiesResponse, null);
+}
+
+export async function restartServer() {
+  const restartServerResponse = await httpClient("/system/restart-server", { method: "POST" });
+  if (!restartServerResponse.ok) {
+    throw await buildParsedHttpError(restartServerResponse, "Failed to restart server");
+  }
+  return await parseJsonResponse(restartServerResponse, null);
+}
+
+export async function restartPhoenixd() {
+  const restartPhoenixdResponse = await httpClient("/system/restart-phoenixd", { method: "POST" });
+  if (!restartPhoenixdResponse.ok) {
+    throw await buildParsedHttpError(restartPhoenixdResponse, "Failed to restart phoenixd");
+  }
+  return await parseJsonResponse(restartPhoenixdResponse, null);
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,8 @@ services:
     environment:
       NEXT_PUBLIC_API_URL: http://ambrosia:9154
       NEXT_PUBLIC_PORT_API: "9154"
+      HOSTNAME: "0.0.0.0"
+      PORT: "3000"
 
 volumes:
   phoenixd_datadir: 

--- a/hardware/image/build/assemble-image.sh
+++ b/hardware/image/build/assemble-image.sh
@@ -546,6 +546,7 @@ install_repo_assets() {
 
   install -m 0755 "$IMAGE_ROOT/common/portal/ambrosia-wifi-portal" "$ROOTFS_MNT/opt/ambrosia/bin/ambrosia-wifi-portal"
   install -m 0755 "$IMAGE_ROOT/common/firstboot/ambrosia-firstboot" "$ROOTFS_MNT/opt/ambrosia/bin/ambrosia-firstboot"
+  install -m 0755 "$REPO_ROOT/scripts/run-phoenixd.sh" "$ROOTFS_MNT/opt/ambrosia/bin/run-phoenixd.sh"
 
   install -m 0644 "$IMAGE_ROOT/common/portal/ambrosia-wifi-portal.service" "$ROOTFS_MNT/etc/systemd/system/ambrosia-wifi-portal.service"
   install -m 0644 "$IMAGE_ROOT/common/firstboot/ambrosia-firstboot.service" "$ROOTFS_MNT/etc/systemd/system/ambrosia-firstboot.service"
@@ -654,6 +655,7 @@ verify_mounted_image() {
   require_nonempty_file "$ROOTFS_MNT/opt/ambrosia/bin/ambrosia-client"
   require_nonempty_file "$ROOTFS_MNT/opt/ambrosia/bin/ambrosia-firstboot"
   require_nonempty_file "$ROOTFS_MNT/opt/ambrosia/bin/ambrosia-wifi-portal"
+  require_nonempty_file "$ROOTFS_MNT/opt/ambrosia/bin/run-phoenixd.sh"
   require_nonempty_file "$ROOTFS_MNT/opt/ambrosia/client/server.js"
   require_sane_javascript_text_file "$ROOTFS_MNT/opt/ambrosia/client/server.js"
   require_sane_json_text_file "$ROOTFS_MNT/opt/ambrosia/client/package.json"

--- a/hardware/image/common/systemd/ambrosia.service
+++ b/hardware/image/common/systemd/ambrosia.service
@@ -14,6 +14,7 @@ WorkingDirectory=/opt/ambrosia/server
 Environment=HOME=/home/__RUNTIME_USER__
 Environment=AMBROSIA_DATADIR=/home/__RUNTIME_USER__/.Ambrosia-POS
 Environment=PHOENIX_DATADIR=/home/__RUNTIME_USER__/.phoenix
+Environment=AMBROSIA_SERVICE_MANAGED=true
 ExecStart=/opt/ambrosia/bin/ambrosia-server
 Restart=always
 RestartSec=5

--- a/hardware/image/common/systemd/phoenixd.service
+++ b/hardware/image/common/systemd/phoenixd.service
@@ -14,7 +14,7 @@ Group=__RUNTIME_GROUP__
 WorkingDirectory=/home/__RUNTIME_USER__
 Environment=HOME=/home/__RUNTIME_USER__
 ExecStartPre=/bin/sh -c 'if [ -f /home/__RUNTIME_USER__/.phoenix/seed.dat ] && [ ! -s /home/__RUNTIME_USER__/.phoenix/seed.dat ]; then rm -f /home/__RUNTIME_USER__/.phoenix/seed.dat; fi'
-ExecStart=/usr/local/bin/phoenixd --agree-to-terms-of-service
+ExecStart=/opt/ambrosia/bin/run-phoenixd.sh
 Restart=always
 RestartSec=5
 LimitNOFILE=4096

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -11,6 +11,7 @@ IFS=$'\n\t'
 AUTO_YES=false
 INSTALL_SYSTEMD=true
 EXPOSE_LAN=false
+LOCAL_INSTALL=false
 
 for arg in "$@"; do
   case $arg in
@@ -24,6 +25,10 @@ for arg in "$@"; do
       ;;
     --expose-lan)
       EXPOSE_LAN=true
+      shift
+      ;;
+    --local)
+      LOCAL_INSTALL=true
       shift
       ;;
     *)
@@ -76,6 +81,27 @@ print_header() {
   echo "----------------------------------------"
   echo " 🚀 Unified Ambrosia & Phoenixd Installer"
   echo "----------------------------------------"
+}
+
+resolve_repo_root() {
+  local script_path="${BASH_SOURCE[0]}"
+  while [ -L "$script_path" ]; do
+    local script_dir
+    script_dir=$(cd -- "$(dirname -- "$script_path")" &> /dev/null && pwd)
+    script_path=$(readlink "$script_path")
+    [[ $script_path != /* ]] && script_path="$script_dir/$script_path"
+  done
+  local script_dir
+  script_dir=$(cd -- "$(dirname -- "$script_path")" &> /dev/null && pwd)
+  dirname "$script_dir"
+}
+
+require_local_repo_root() {
+  REPO_ROOT=$(resolve_repo_root)
+  if [[ ! -d "$REPO_ROOT/server" || ! -d "$REPO_ROOT/client" ]]; then
+    log_error "--local requires running install.sh from within a cloned ambrosia checkout"
+    exit 1
+  fi
 }
 
 # --- Phoenixd Installation Logic ---
@@ -203,9 +229,13 @@ phoenixd_install() {
 }
 
 phoenixd_install_restart_wrapper() {
-  local wrapper_url="https://raw.githubusercontent.com/${AMBROSIA_REPO}/v${AMBROSIA_TAG}/scripts/run-phoenixd.sh"
-  download_file "$wrapper_url" "$GLOBAL_TEMP_DIR/run-phoenixd.sh"
-  sudo cp "$GLOBAL_TEMP_DIR/run-phoenixd.sh" "$PHOENIXD_INSTALL_DIR/run-phoenixd.sh"
+  if [[ "$LOCAL_INSTALL" == "true" ]]; then
+    sudo cp "$REPO_ROOT/scripts/run-phoenixd.sh" "$PHOENIXD_INSTALL_DIR/run-phoenixd.sh"
+  else
+    local wrapper_url="https://raw.githubusercontent.com/${AMBROSIA_REPO}/v${AMBROSIA_TAG}/scripts/run-phoenixd.sh"
+    download_file "$wrapper_url" "$GLOBAL_TEMP_DIR/run-phoenixd.sh"
+    sudo cp "$GLOBAL_TEMP_DIR/run-phoenixd.sh" "$PHOENIXD_INSTALL_DIR/run-phoenixd.sh"
+  fi
   sudo chmod +x "$PHOENIXD_INSTALL_DIR/run-phoenixd.sh"
   echo "✅ phoenixd restart wrapper installed to $PHOENIXD_INSTALL_DIR/run-phoenixd.sh"
 }
@@ -311,9 +341,20 @@ ambrosia_install() {
   mkdir -p "$AMBROSIA_BIN_DIR" "$AMBROSIA_INSTALL_DIR"
   ambrosia_write_initial_config
 
-  local ambrosia_url="https://github.com/${AMBROSIA_REPO}/releases/download/v${AMBROSIA_TAG}"
-  download_file "${ambrosia_url}/ambrosia-${AMBROSIA_TAG}.jar" "$AMBROSIA_INSTALL_DIR/ambrosia.jar"
-  download_file "https://raw.githubusercontent.com/${AMBROSIA_REPO}/v${AMBROSIA_TAG}/scripts/run-server.sh" "$AMBROSIA_INSTALL_DIR/run-server.sh"
+  if [[ "$LOCAL_INSTALL" == "true" ]]; then
+    local local_jar
+    local_jar=$(ls "$REPO_ROOT"/server/app/build/libs/*.jar 2>/dev/null | head -1)
+    if [[ -z "$local_jar" ]]; then
+      log_error "No local JAR found under $REPO_ROOT/server/app/build/libs/ — run './gradlew jar' in server/ first"
+      exit 1
+    fi
+    cp "$local_jar" "$AMBROSIA_INSTALL_DIR/ambrosia.jar"
+    cp "$REPO_ROOT/scripts/run-server.sh" "$AMBROSIA_INSTALL_DIR/run-server.sh"
+  else
+    local ambrosia_url="https://github.com/${AMBROSIA_REPO}/releases/download/v${AMBROSIA_TAG}"
+    download_file "${ambrosia_url}/ambrosia-${AMBROSIA_TAG}.jar" "$AMBROSIA_INSTALL_DIR/ambrosia.jar"
+    download_file "https://raw.githubusercontent.com/${AMBROSIA_REPO}/v${AMBROSIA_TAG}/scripts/run-server.sh" "$AMBROSIA_INSTALL_DIR/run-server.sh"
+  fi
 
   chmod +x "$AMBROSIA_INSTALL_DIR/ambrosia.jar" "$AMBROSIA_INSTALL_DIR/run-server.sh"
   ln -sf "$AMBROSIA_INSTALL_DIR/run-server.sh" "$AMBROSIA_BIN_DIR/ambrosia"
@@ -370,6 +411,7 @@ EOF
 # --- Client Installation ---
 
 CLIENT_INSTALL_DIR="$HOME/.local/ambrosia/client"
+CLIENT_DIST_DIR="/tmp/ambrosia-client-dist"
 
 client_install() {
   echo "➡️  Starting Ambrosia POS Client installation..."
@@ -385,10 +427,18 @@ client_install() {
 
   mkdir -p "$CLIENT_INSTALL_DIR"
 
-  local client_dist_file="ambrosia-client-${AMBROSIA_TAG}.tar.gz"
-  local client_dist_url="https://github.com/${AMBROSIA_REPO}/releases/download/v${AMBROSIA_TAG}/${client_dist_file}"
-  download_file "$client_dist_url" "$GLOBAL_TEMP_DIR/$client_dist_file"
-  tar -xzf "$GLOBAL_TEMP_DIR/$client_dist_file" -C "$CLIENT_INSTALL_DIR" --strip-components=1
+  if [[ "$LOCAL_INSTALL" == "true" ]]; then
+    if [[ ! -d "$CLIENT_DIST_DIR" ]]; then
+      log_error "No local client build found at $CLIENT_DIST_DIR — run 'make build-client' first"
+      exit 1
+    fi
+    cp -r "$CLIENT_DIST_DIR/." "$CLIENT_INSTALL_DIR/"
+  else
+    local client_dist_file="ambrosia-client-${AMBROSIA_TAG}.tar.gz"
+    local client_dist_url="https://github.com/${AMBROSIA_REPO}/releases/download/v${AMBROSIA_TAG}/${client_dist_file}"
+    download_file "$client_dist_url" "$GLOBAL_TEMP_DIR/$client_dist_file"
+    tar -xzf "$GLOBAL_TEMP_DIR/$client_dist_file" -C "$CLIENT_INSTALL_DIR" --strip-components=1
+  fi
 
   echo "   Installing Node.js dependencies..."
   pushd "$CLIENT_INSTALL_DIR" > /dev/null
@@ -458,7 +508,11 @@ EOF
 # --- Main execution flow ---
 check_dependencies
 print_header
-ambrosia_resolve_tag
+if [[ "$LOCAL_INSTALL" == "true" ]]; then
+  require_local_repo_root
+else
+  ambrosia_resolve_tag
+fi
 phoenixd_install
 ambrosia_install
 client_install

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -249,7 +249,10 @@ phoenixd_install_restart_wrapper() {
     sudo cp "$REPO_ROOT/scripts/run-phoenixd.sh" "$PHOENIXD_INSTALL_DIR/run-phoenixd.sh"
   else
     local wrapper_url="https://raw.githubusercontent.com/${AMBROSIA_REPO}/v${AMBROSIA_TAG}/scripts/run-phoenixd.sh"
-    download_file "$wrapper_url" "$GLOBAL_TEMP_DIR/run-phoenixd.sh"
+    if ! curl -fsSL -o "$GLOBAL_TEMP_DIR/run-phoenixd.sh" "$wrapper_url" 2>/dev/null; then
+      log_info "phoenixd restart wrapper not published at v$AMBROSIA_TAG yet, phoenixd will run directly."
+      return 0
+    fi
     sudo cp "$GLOBAL_TEMP_DIR/run-phoenixd.sh" "$PHOENIXD_INSTALL_DIR/run-phoenixd.sh"
   fi
   sudo chmod +x "$PHOENIXD_INSTALL_DIR/run-phoenixd.sh"
@@ -265,13 +268,17 @@ phoenixd_setup_systemd() {
   fi
 
   if [[ $reply =~ ^[Yy]$ ]]; then
+    local exec_start="$PHOENIXD_INSTALL_DIR/phoenixd --agree-to-terms-of-service"
+    if [[ -f "$PHOENIXD_INSTALL_DIR/run-phoenixd.sh" ]]; then
+      exec_start="/bin/bash $PHOENIXD_INSTALL_DIR/run-phoenixd.sh"
+    fi
     sudo tee /etc/systemd/system/phoenixd.service > /dev/null << EOF
 [Unit]
 Description=Phoenix Daemon
 After=network.target
 
 [Service]
-ExecStart=/bin/bash $PHOENIXD_INSTALL_DIR/run-phoenixd.sh
+ExecStart=$exec_start
 User=$USER
 Restart=always
 RestartSec=5

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -506,7 +506,8 @@ client_setup_systemd() {
     sudo tee "/etc/systemd/system/ambrosia-client.service" > /dev/null << EOF
 [Unit]
 Description=Ambrosia POS Client (Next.js)
-After=network.target
+After=network.target ambrosia.service
+Wants=ambrosia.service
 
 [Service]
 User=$USER

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -104,6 +104,22 @@ require_local_repo_root() {
   fi
 }
 
+build_local_artifacts() {
+  local build_dependencies=("java" "node" "npm")
+  for cmd in "${build_dependencies[@]}"; do
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+      log_error "Missing required dependency for --local: $cmd (see doc/dependencies.md)"
+      exit 1
+    fi
+  done
+
+  log_info "Building server JAR from local source..."
+  (cd "$REPO_ROOT/server" && ./gradlew jar)
+
+  log_info "Building client from local source..."
+  (cd "$REPO_ROOT/client" && chmod +x package-client.sh && NO_ZIP=1 ./package-client.sh)
+}
+
 # --- Phoenixd Installation Logic ---
 
 PHOENIXD_TAG="0.9.0"
@@ -510,6 +526,7 @@ check_dependencies
 print_header
 if [[ "$LOCAL_INSTALL" == "true" ]]; then
   require_local_repo_root
+  build_local_artifacts
 else
   ambrosia_resolve_tag
 fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -359,7 +359,7 @@ ambrosia_install() {
 
   if [[ "$LOCAL_INSTALL" == "true" ]]; then
     local local_jar
-    local_jar=$(ls "$REPO_ROOT"/server/app/build/libs/*.jar 2>/dev/null | head -1)
+    local_jar=$(find "$REPO_ROOT/server/app/build/libs" -maxdepth 1 -name '*.jar' 2>/dev/null | head -1)
     if [[ -z "$local_jar" ]]; then
       log_error "No local JAR found under $REPO_ROOT/server/app/build/libs/ — run './gradlew jar' in server/ first"
       exit 1

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -143,10 +143,10 @@ phoenixd_check_existing() {
 phoenixd_verify_signature() {
   echo "🔐 Verifying package signature and integrity..."
   pushd "$GLOBAL_TEMP_DIR" > /dev/null
-  
+
   local acinq_key_url="https://acinq.co/pgp/padioupm.asc"
   local sig_url="${PHOENIXD_RELEASE_BASE_URL}/SHA256SUMS.asc"
-  
+
   download_file "$acinq_key_url" "padioupm.asc"
   download_file "$sig_url" "SHA256SUMS.asc"
 
@@ -160,7 +160,7 @@ phoenixd_verify_signature() {
     popd > /dev/null
     exit 1
   fi
-  
+
   local sha_cmd="sha256sum"
   if ! command -v sha256sum >/dev/null; then sha_cmd="shasum -a 256"; fi
 
@@ -177,18 +177,20 @@ phoenixd_verify_signature() {
 phoenixd_install() {
   phoenixd_detect_os_arch
   phoenixd_check_existing
-  
+
   echo "Installing phoenixd ${PHOENIXD_TAG}"
   sudo mkdir -p "$PHOENIXD_INSTALL_DIR"
-  
+
   # Download to global temp
   download_file "${PHOENIXD_RELEASE_BASE_URL}/${PHOENIXD_ZIP_FILENAME}" "$GLOBAL_TEMP_DIR/$PHOENIXD_ZIP_FILENAME"
-  
+
   phoenixd_verify_signature
-  
+
   sudo unzip -j -o "$GLOBAL_TEMP_DIR/$PHOENIXD_ZIP_FILENAME" -d "$PHOENIXD_INSTALL_DIR"
   echo "✅ phoenixd installed to $PHOENIXD_INSTALL_DIR"
-  
+
+  phoenixd_install_restart_wrapper
+
   if [[ "$OSTYPE" == "darwin"* ]]; then
     echo "MacOS: Ensure $PHOENIXD_INSTALL_DIR is in your PATH."
     return
@@ -200,6 +202,14 @@ phoenixd_install() {
   fi
 }
 
+phoenixd_install_restart_wrapper() {
+  local wrapper_url="https://raw.githubusercontent.com/${AMBROSIA_REPO}/v${AMBROSIA_TAG}/scripts/run-phoenixd.sh"
+  download_file "$wrapper_url" "$GLOBAL_TEMP_DIR/run-phoenixd.sh"
+  sudo cp "$GLOBAL_TEMP_DIR/run-phoenixd.sh" "$PHOENIXD_INSTALL_DIR/run-phoenixd.sh"
+  sudo chmod +x "$PHOENIXD_INSTALL_DIR/run-phoenixd.sh"
+  echo "✅ phoenixd restart wrapper installed to $PHOENIXD_INSTALL_DIR/run-phoenixd.sh"
+}
+
 phoenixd_setup_systemd() {
   local reply="n"
   if [[ "$AUTO_YES" == true ]]; then reply="y";
@@ -207,7 +217,7 @@ phoenixd_setup_systemd() {
     echo "Do you want to setup a systemd service (requires sudo permission)? (y/n): "
     read -r reply
   fi
-  
+
   if [[ $reply =~ ^[Yy]$ ]]; then
     sudo tee /etc/systemd/system/phoenixd.service > /dev/null << EOF
 [Unit]
@@ -215,7 +225,7 @@ Description=Phoenix Daemon
 After=network.target
 
 [Service]
-ExecStart=$PHOENIXD_INSTALL_DIR/phoenixd --agree-to-terms-of-service
+ExecStart=/bin/bash $PHOENIXD_INSTALL_DIR/run-phoenixd.sh
 User=$USER
 Restart=always
 RestartSec=5
@@ -304,12 +314,12 @@ ambrosia_install() {
   local ambrosia_url="https://github.com/${AMBROSIA_REPO}/releases/download/v${AMBROSIA_TAG}"
   download_file "${ambrosia_url}/ambrosia-${AMBROSIA_TAG}.jar" "$AMBROSIA_INSTALL_DIR/ambrosia.jar"
   download_file "https://raw.githubusercontent.com/${AMBROSIA_REPO}/v${AMBROSIA_TAG}/scripts/run-server.sh" "$AMBROSIA_INSTALL_DIR/run-server.sh"
-  
+
   chmod +x "$AMBROSIA_INSTALL_DIR/ambrosia.jar" "$AMBROSIA_INSTALL_DIR/run-server.sh"
   ln -sf "$AMBROSIA_INSTALL_DIR/run-server.sh" "$AMBROSIA_BIN_DIR/ambrosia"
-  
+
   echo "✅ Ambrosia POS Server installed."
-  
+
   # Setup Path logic (simplified)
   local rc_file=""
   [[ $SHELL == *"zsh"* ]] && rc_file="$HOME/.zshrc"
@@ -327,7 +337,7 @@ ambrosia_install() {
 ambrosia_setup_systemd() {
     local reply="n"
     if [[ "$AUTO_YES" == true ]]; then reply="y";
-    elif [[ -t 0 ]]; then 
+    elif [[ -t 0 ]]; then
         echo "Setup systemd service for Ambrosia Server? (y/n): "
         read -r reply
     fi
@@ -342,6 +352,7 @@ After=network.target
 ExecStart=$AMBROSIA_INSTALL_DIR/run-server.sh
 WorkingDirectory=$AMBROSIA_INSTALL_DIR
 User=$USER
+Environment=AMBROSIA_SERVICE_MANAGED=true
 Restart=always
 RestartSec=5
 LimitNOFILE=4096
@@ -378,12 +389,12 @@ client_install() {
   local client_dist_url="https://github.com/${AMBROSIA_REPO}/releases/download/v${AMBROSIA_TAG}/${client_dist_file}"
   download_file "$client_dist_url" "$GLOBAL_TEMP_DIR/$client_dist_file"
   tar -xzf "$GLOBAL_TEMP_DIR/$client_dist_file" -C "$CLIENT_INSTALL_DIR" --strip-components=1
-  
+
   echo "   Installing Node.js dependencies..."
   pushd "$CLIENT_INSTALL_DIR" > /dev/null
   npm install --production --silent
   popd > /dev/null
-  
+
   echo "✅ Client installed."
 
   # Create wrapper for easier execution
@@ -403,7 +414,7 @@ EOF
 client_setup_systemd() {
     local reply="n"
     if [[ "$AUTO_YES" == true ]]; then reply="y";
-    elif [[ -t 0 ]]; then 
+    elif [[ -t 0 ]]; then
       echo "Setup systemd service for Ambrosia Client? (y/n): "
       read -r reply
     fi
@@ -447,8 +458,8 @@ EOF
 # --- Main execution flow ---
 check_dependencies
 print_header
-phoenixd_install
 ambrosia_resolve_tag
+phoenixd_install
 ambrosia_install
 client_install
 

--- a/scripts/run-phoenixd.sh
+++ b/scripts/run-phoenixd.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+PHOENIX_DATADIR="${PHOENIX_DATADIR:-$HOME/.phoenix}"
+PID_FILE="$PHOENIX_DATADIR/phoenixd.pid"
+
+mkdir -p "$PHOENIX_DATADIR"
+
+SHOULD_STOP=0
+trap 'SHOULD_STOP=1; [ -n "$CHILD_PID" ] && kill -TERM "$CHILD_PID" 2>/dev/null' TERM INT
+
+while true; do
+    phoenixd --agree-to-terms-of-service &
+    CHILD_PID=$!
+    echo "$CHILD_PID" > "$PID_FILE"
+    wait "$CHILD_PID"
+    rm -f "$PID_FILE"
+    [ "$SHOULD_STOP" -eq 1 ] && break
+    sleep 1
+done

--- a/scripts/run-server.sh
+++ b/scripts/run-server.sh
@@ -46,4 +46,13 @@ else
     echo "Using embedded logback configuration"
 fi
 
-java $JVM_OPTS -jar "$JAR_PATH" "$@"
+SHOULD_STOP=0
+trap 'SHOULD_STOP=1; [ -n "$CHILD_PID" ] && kill -TERM "$CHILD_PID" 2>/dev/null' TERM INT
+
+while true; do
+    java $JVM_OPTS -jar "$JAR_PATH" "$@" &
+    CHILD_PID=$!
+    wait "$CHILD_PID"
+    [ "$SHOULD_STOP" -eq 1 ] && break
+    sleep 1
+done

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -163,6 +163,11 @@ if [ -f "$PHOENIXD_BIN_DIR/phoenix-cli" ]; then
   echo "✅ phoenix-cli binary removed"
 fi
 
+if [ -f "$PHOENIXD_BIN_DIR/run-phoenixd.sh" ]; then
+  sudo rm -f "$PHOENIXD_BIN_DIR/run-phoenixd.sh"
+  echo "✅ phoenixd restart wrapper removed"
+fi
+
 echo ""
 echo "✅ phoenixd has been uninstalled successfully!"
 echo ""

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -265,6 +265,45 @@ systemd_start_if_was_active() {
   fi
 }
 
+# --- Restart-wrapper retrofit (for installs that predate this feature) ---
+
+ensure_phoenixd_restart_wrapper() {
+  if [[ -f "$PHOENIXD_INSTALL_DIR/run-phoenixd.sh" ]]; then
+    return 0
+  fi
+  local wrapper_url="https://raw.githubusercontent.com/${AMBROSIA_REPO}/v${AMBROSIA_TAG}/scripts/run-phoenixd.sh"
+  if ! curl -fsSL -o "$GLOBAL_TEMP_DIR/run-phoenixd.sh" "$wrapper_url" 2>/dev/null; then
+    log_info "Restart wrapper not published at v$AMBROSIA_TAG yet, skipping."
+    return 0
+  fi
+  log_info "Installing the phoenixd restart wrapper..."
+  sudo cp "$GLOBAL_TEMP_DIR/run-phoenixd.sh" "$PHOENIXD_INSTALL_DIR/run-phoenixd.sh"
+  sudo chmod +x "$PHOENIXD_INSTALL_DIR/run-phoenixd.sh"
+}
+
+retrofit_phoenixd_service() {
+  local service_file="/etc/systemd/system/phoenixd.service"
+  [[ -f "$service_file" ]] || return 0
+  [[ -f "$PHOENIXD_INSTALL_DIR/run-phoenixd.sh" ]] || return 0
+  if grep -q "run-phoenixd.sh" "$service_file"; then
+    return 0
+  fi
+  log_info "Updating phoenixd.service to restart through the wrapper..."
+  sudo sed -i "s#^ExecStart=.*#ExecStart=/bin/bash ${PHOENIXD_INSTALL_DIR}/run-phoenixd.sh#" "$service_file"
+  sudo systemctl daemon-reload
+}
+
+retrofit_ambrosia_service() {
+  local service_file="/etc/systemd/system/ambrosia.service"
+  [[ -f "$service_file" ]] || return 0
+  if grep -q "AMBROSIA_SERVICE_MANAGED" "$service_file"; then
+    return 0
+  fi
+  log_info "Flagging ambrosia.service as service-managed..."
+  sudo sed -i "/^ExecStart=/i Environment=AMBROSIA_SERVICE_MANAGED=true" "$service_file"
+  sudo systemctl daemon-reload
+}
+
 # --- phoenixd update ---
 
 phoenixd_update() {
@@ -275,6 +314,9 @@ phoenixd_update() {
     log_info "phoenixd is not installed here, skipping. Run install.sh first."
     return
   fi
+
+  ensure_phoenixd_restart_wrapper
+  retrofit_phoenixd_service
 
   local installed_version
   installed_version=$(get_installed_phoenixd_version)
@@ -325,6 +367,8 @@ server_update() {
     log_info "Ambrosia Server is not installed here (no ambrosia.jar found), skipping. Run install.sh first."
     return
   fi
+
+  retrofit_ambrosia_service
 
   local installed_version
   installed_version=$(get_installed_server_version)
@@ -433,6 +477,7 @@ EOF
 check_dependencies
 print_header
 
+ambrosia_resolve_tag
 phoenixd_resolve_tag
 phoenixd_update
 
@@ -442,7 +487,6 @@ if [[ ! -d "$AMBROSIA_INSTALL_DIR" ]]; then
   exit 1
 fi
 
-ambrosia_resolve_tag
 server_update
 client_update
 

--- a/server/app/src/main/kotlin/pos/ambrosia/Ambrosia.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/Ambrosia.kt
@@ -67,7 +67,7 @@ fun main(args: Array<String>) {
     Ambrosia().main(args)
 }
 
-fun scheduleDockerRestart() {
+fun scheduleProcessRestart() {
     CoroutineScope(Dispatchers.IO).launch {
         delay(500)
         runningEmbeddedServer?.stopSuspend()

--- a/server/app/src/main/kotlin/pos/ambrosia/Ambrosia.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/Ambrosia.kt
@@ -45,6 +45,7 @@ import pos.ambrosia.services.VapidKeyService
 import pos.ambrosia.services.VapidKeys
 import java.io.File
 import java.security.KeyStore
+import kotlin.system.exitProcess
 
 val userHome = System.getProperty("user.home")
 
@@ -71,6 +72,7 @@ fun scheduleProcessRestart() {
     CoroutineScope(Dispatchers.IO).launch {
         delay(500)
         runningEmbeddedServer?.stopSuspend()
+        exitProcess(0)
     }
 }
 

--- a/server/app/src/main/kotlin/pos/ambrosia/Api.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/Api.kt
@@ -49,6 +49,7 @@ import pos.ambrosia.api.configureShifts
 import pos.ambrosia.api.configureSpaces
 import pos.ambrosia.api.configureStoreOrders
 import pos.ambrosia.api.configureSuppliers
+import pos.ambrosia.api.configureSystem
 import pos.ambrosia.api.configureTables
 import pos.ambrosia.api.configureTicketTemplates
 import pos.ambrosia.api.configureTickets
@@ -127,6 +128,7 @@ class Api {
         }
         configurePaymentWebsocket()
         configureHealth()
+        configureSystem()
     }
 }
 

--- a/server/app/src/main/kotlin/pos/ambrosia/api/Backup.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/api/Backup.kt
@@ -27,13 +27,13 @@ import kotlinx.coroutines.runBlocking
 import pos.ambrosia.logger
 import pos.ambrosia.models.BackupProgressPhase
 import pos.ambrosia.models.RolePassword
-import pos.ambrosia.scheduleDockerRestart
+import pos.ambrosia.scheduleProcessRestart
 import pos.ambrosia.services.AuthService
 import pos.ambrosia.services.BackupService
 import pos.ambrosia.services.ConfigService
 import pos.ambrosia.services.TokenService
 import pos.ambrosia.utils.InvalidCredentialsException
-import pos.ambrosia.utils.isDockerMode
+import pos.ambrosia.utils.canRestartSelf
 import java.nio.file.Files
 import java.nio.file.Path
 import java.time.LocalDate
@@ -73,7 +73,7 @@ fun Route.backup(
             call.backupActorUserId() ?: throw InvalidCredentialsException()
             backupService.stagedOperationId()?.let { operationId ->
                 backupService.writeConfirmationToken(tokenService.generateBackupConfirmationToken(operationId))
-                if (call.isDockerMode()) scheduleDockerRestart()
+                if (call.canRestartSelf()) scheduleProcessRestart()
             }
             call.respond(HttpStatusCode.OK)
         }

--- a/server/app/src/main/kotlin/pos/ambrosia/api/InitialSetup.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/api/InitialSetup.kt
@@ -25,7 +25,7 @@ import pos.ambrosia.models.InitialSetupStatus
 import pos.ambrosia.models.Role
 import pos.ambrosia.models.TestPhoenixdConnectionRequest
 import pos.ambrosia.models.User
-import pos.ambrosia.scheduleDockerRestart
+import pos.ambrosia.scheduleProcessRestart
 import pos.ambrosia.services.ActiveLightningBackend
 import pos.ambrosia.services.BackupService
 import pos.ambrosia.services.ConfigService
@@ -37,7 +37,7 @@ import pos.ambrosia.services.TokenService
 import pos.ambrosia.services.UsersService
 import pos.ambrosia.services.WalletAdminNotificationService
 import pos.ambrosia.utils.InitialSetupException
-import pos.ambrosia.utils.isDockerMode
+import pos.ambrosia.utils.canRestartSelf
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.Path
@@ -325,7 +325,7 @@ private fun Route.initialSetupRoutes() {
         backupService.stagedOperationId()?.let { operationId ->
             val tokenService = TokenService(call.application.environment)
             backupService.writeConfirmationToken(tokenService.generateBackupConfirmationToken(operationId))
-            if (call.isDockerMode()) scheduleDockerRestart()
+            if (call.canRestartSelf()) scheduleProcessRestart()
         }
         call.respond(HttpStatusCode.OK)
     }

--- a/server/app/src/main/kotlin/pos/ambrosia/api/System.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/api/System.kt
@@ -1,0 +1,66 @@
+package pos.ambrosia.api
+
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.Application
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
+import io.ktor.server.routing.post
+import io.ktor.server.routing.route
+import io.ktor.server.routing.routing
+import pos.ambrosia.models.Message
+import pos.ambrosia.models.RestartCapabilitiesResponse
+import pos.ambrosia.scheduleProcessRestart
+import pos.ambrosia.services.PhoenixdProcessService
+import pos.ambrosia.services.PhoenixdRestartResult
+import pos.ambrosia.utils.authenticateAdmin
+import pos.ambrosia.utils.canRestartSelf
+import pos.ambrosia.utils.isLocalPhoenixd
+
+fun Application.configureSystem() {
+    val phoenixdProcessService = PhoenixdProcessService()
+    routing { route("/system") { systemRoutes(phoenixdProcessService) } }
+}
+
+fun Route.systemRoutes(phoenixdProcessService: PhoenixdProcessService) {
+    authenticateAdmin {
+        get("/restart-capabilities") {
+            val serverRestartSupported = call.canRestartSelf()
+            val phoenixdRestartSupported =
+                serverRestartSupported && call.isLocalPhoenixd() && phoenixdProcessService.isRunning()
+            call.respond(
+                HttpStatusCode.OK,
+                RestartCapabilitiesResponse(serverRestartSupported, phoenixdRestartSupported),
+            )
+        }
+
+        post("/restart-server") {
+            if (!call.canRestartSelf()) {
+                call.respond(HttpStatusCode.Conflict, Message("Restarting the server is not supported on this deployment"))
+                return@post
+            }
+            scheduleProcessRestart()
+            call.respond(HttpStatusCode.OK, Message("Server restarting"))
+        }
+
+        post("/restart-phoenixd") {
+            if (!call.canRestartSelf() || !call.isLocalPhoenixd()) {
+                call.respond(HttpStatusCode.Conflict, Message("Restarting phoenixd is not supported on this deployment"))
+                return@post
+            }
+            when (phoenixdProcessService.requestRestart()) {
+                PhoenixdRestartResult.Requested -> {
+                    call.respond(HttpStatusCode.OK, Message("phoenixd restarting"))
+                }
+
+                PhoenixdRestartResult.NotRunning -> {
+                    call.respond(HttpStatusCode.Conflict, Message("phoenixd is not running"))
+                }
+
+                PhoenixdRestartResult.NoPidFile -> {
+                    call.respond(HttpStatusCode.Conflict, Message("phoenixd is not managed by the restart wrapper"))
+                }
+            }
+        }
+    }
+}

--- a/server/app/src/main/kotlin/pos/ambrosia/config/SeedGenerator.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/config/SeedGenerator.kt
@@ -18,9 +18,7 @@ import java.security.SecureRandom
 object SeedGenerator {
     val NUM_WORDS: Int = 12
     private const val FALLBACK_WORDLIST_URL =
-        """
-            https://raw.githubusercontent.com/olympus-btc/Ambrosia-POS/main/scripts/eff_large_wordlist.txt
-        """
+        "https://raw.githubusercontent.com/olympus-btc/Ambrosia-POS/main/scripts/eff_large_wordlist.txt"
 
     /**
      * Downloads the wordlist from the fallback URL

--- a/server/app/src/main/kotlin/pos/ambrosia/config/SeedGenerator.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/config/SeedGenerator.kt
@@ -24,15 +24,15 @@ object SeedGenerator {
      * Downloads the wordlist from the fallback URL
      */
     private suspend fun downloadWordlist(): List<String> {
-        val client = HttpClient(CIO)
+        val httpClient = HttpClient(CIO)
         return try {
-            val response: HttpResponse = client.get(FALLBACK_WORDLIST_URL)
-            val content = response.bodyAsText()
-            client.close()
-            content.lines().filter { it.isNotBlank() }
-        } catch (e: Exception) {
-            client.close()
-            throw IllegalStateException("Failed to download wordlist from fallback URL: ${e.message}", e)
+            val wordlistResponse: HttpResponse = httpClient.get(FALLBACK_WORDLIST_URL)
+            val wordlistText = wordlistResponse.bodyAsText()
+            httpClient.close()
+            wordlistText.lines().filter { it.isNotBlank() }
+        } catch (error: Exception) {
+            httpClient.close()
+            throw IllegalStateException("Failed to download wordlist from fallback URL: ${error.message}", error)
         }
     }
 
@@ -62,8 +62,8 @@ object SeedGenerator {
      * Generates a dice roll (5 digits, each 1-6) for Diceware
      */
     private fun generateDiceRoll(): String {
-        val random = SecureRandom()
-        return (1..5).map { (random.nextInt(6) + 1).toString() }.joinToString("")
+        val secureRandom = SecureRandom()
+        return (1..5).map { (secureRandom.nextInt(6) + 1).toString() }.joinToString("")
     }
 
     /**

--- a/server/app/src/main/kotlin/pos/ambrosia/models/AppModels.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/models/AppModels.kt
@@ -96,6 +96,12 @@ data class PhoenixdRemoteStatusResponse(
 )
 
 @Serializable
+data class RestartCapabilitiesResponse(
+    val serverRestartSupported: Boolean,
+    val phoenixdRestartSupported: Boolean,
+)
+
+@Serializable
 data class User(
     val id: String? = null,
     val name: String,

--- a/server/app/src/main/kotlin/pos/ambrosia/services/PhoenixdProcessService.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/services/PhoenixdProcessService.kt
@@ -1,0 +1,37 @@
+package pos.ambrosia.services
+
+import pos.ambrosia.phoenixDatadir
+import java.io.File
+
+sealed interface PhoenixdRestartResult {
+    data object Requested : PhoenixdRestartResult
+
+    data object NotRunning : PhoenixdRestartResult
+
+    data object NoPidFile : PhoenixdRestartResult
+}
+
+class PhoenixdProcessService(
+    private val pidFile: File = File(phoenixDatadir.toString(), "phoenixd.pid"),
+) {
+    fun isRunning(): Boolean = findAlivePhoenixdProcess() != null
+
+    fun requestRestart(): PhoenixdRestartResult {
+        val alivePhoenixdProcess = findAlivePhoenixdProcess()
+        if (alivePhoenixdProcess == null) {
+            return if (pidFile.exists()) PhoenixdRestartResult.NotRunning else PhoenixdRestartResult.NoPidFile
+        }
+        alivePhoenixdProcess.destroy()
+        return PhoenixdRestartResult.Requested
+    }
+
+    private fun findAlivePhoenixdProcess(): ProcessHandle? {
+        val phoenixdPid =
+            pidFile
+                .takeIf { it.exists() }
+                ?.readText()
+                ?.trim()
+                ?.toLongOrNull() ?: return null
+        return ProcessHandle.of(phoenixdPid).orElse(null)?.takeIf { it.isAlive }
+    }
+}

--- a/server/app/src/main/kotlin/pos/ambrosia/utils/ServiceSupervision.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/utils/ServiceSupervision.kt
@@ -1,0 +1,21 @@
+package pos.ambrosia.utils
+
+import io.ktor.server.application.ApplicationCall
+
+fun ApplicationCall.isSystemdManaged(): Boolean = System.getenv("AMBROSIA_SERVICE_MANAGED") == "true"
+
+fun ApplicationCall.canRestartSelf(): Boolean = isDockerMode() || isSystemdManaged()
+
+fun ApplicationCall.isPhoenixdRemote(): Boolean =
+    application.environment.config
+        .propertyOrNull("phoenixd-remote")
+        ?.getString()
+        ?.toBoolean() ?: false
+
+fun ApplicationCall.isNwcMode(): Boolean =
+    application.environment.config
+        .propertyOrNull("nwc-uri")
+        ?.getString()
+        ?.isNotBlank() ?: false
+
+fun ApplicationCall.isLocalPhoenixd(): Boolean = !isPhoenixdRemote() && !isNwcMode()

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/PhoenixdProcessServiceTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/PhoenixdProcessServiceTest.kt
@@ -1,0 +1,45 @@
+package pos.ambrosia.utest
+
+import pos.ambrosia.services.PhoenixdProcessService
+import pos.ambrosia.services.PhoenixdRestartResult
+import java.io.File
+import java.nio.file.Files
+import java.util.concurrent.TimeUnit
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class PhoenixdProcessServiceTest {
+    private fun newPidFile(): File = Files.createTempDirectory("phoenixdProcessServiceTest").resolve("phoenixd.pid").toFile()
+
+    @Test
+    fun `requestRestart returns NoPidFile when the pidfile does not exist`() {
+        val service = PhoenixdProcessService(pidFile = newPidFile())
+
+        assertEquals(PhoenixdRestartResult.NoPidFile, service.requestRestart())
+        assertFalse(service.isRunning())
+    }
+
+    @Test
+    fun `requestRestart returns NotRunning when the pidfile references a dead process`() {
+        val deadProcess = ProcessBuilder("true").start()
+        deadProcess.waitFor()
+        val pidFile = newPidFile().apply { writeText(deadProcess.pid().toString()) }
+        val service = PhoenixdProcessService(pidFile = pidFile)
+
+        assertEquals(PhoenixdRestartResult.NotRunning, service.requestRestart())
+        assertFalse(service.isRunning())
+    }
+
+    @Test
+    fun `requestRestart signals the live process referenced by the pidfile`() {
+        val longRunningProcess = ProcessBuilder("sleep", "30").start()
+        val pidFile = newPidFile().apply { writeText(longRunningProcess.pid().toString()) }
+        val service = PhoenixdProcessService(pidFile = pidFile)
+
+        assertTrue(service.isRunning())
+        assertEquals(PhoenixdRestartResult.Requested, service.requestRestart())
+        assertTrue(longRunningProcess.waitFor(5, TimeUnit.SECONDS))
+    }
+}

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/PhoenixdProcessServiceTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/PhoenixdProcessServiceTest.kt
@@ -15,10 +15,10 @@ class PhoenixdProcessServiceTest {
 
     @Test
     fun `requestRestart returns NoPidFile when the pidfile does not exist`() {
-        val service = PhoenixdProcessService(pidFile = newPidFile())
+        val phoenixdProcessService = PhoenixdProcessService(pidFile = newPidFile())
 
-        assertEquals(PhoenixdRestartResult.NoPidFile, service.requestRestart())
-        assertFalse(service.isRunning())
+        assertEquals(PhoenixdRestartResult.NoPidFile, phoenixdProcessService.requestRestart())
+        assertFalse(phoenixdProcessService.isRunning())
     }
 
     @Test
@@ -26,20 +26,20 @@ class PhoenixdProcessServiceTest {
         val deadProcess = ProcessBuilder("true").start()
         deadProcess.waitFor()
         val pidFile = newPidFile().apply { writeText(deadProcess.pid().toString()) }
-        val service = PhoenixdProcessService(pidFile = pidFile)
+        val phoenixdProcessService = PhoenixdProcessService(pidFile = pidFile)
 
-        assertEquals(PhoenixdRestartResult.NotRunning, service.requestRestart())
-        assertFalse(service.isRunning())
+        assertEquals(PhoenixdRestartResult.NotRunning, phoenixdProcessService.requestRestart())
+        assertFalse(phoenixdProcessService.isRunning())
     }
 
     @Test
     fun `requestRestart signals the live process referenced by the pidfile`() {
         val longRunningProcess = ProcessBuilder("sleep", "30").start()
         val pidFile = newPidFile().apply { writeText(longRunningProcess.pid().toString()) }
-        val service = PhoenixdProcessService(pidFile = pidFile)
+        val phoenixdProcessService = PhoenixdProcessService(pidFile = pidFile)
 
-        assertTrue(service.isRunning())
-        assertEquals(PhoenixdRestartResult.Requested, service.requestRestart())
+        assertTrue(phoenixdProcessService.isRunning())
+        assertEquals(PhoenixdRestartResult.Requested, phoenixdProcessService.requestRestart())
         assertTrue(longRunningProcess.waitFor(5, TimeUnit.SECONDS))
     }
 }

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/ServiceSupervisionTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/ServiceSupervisionTest.kt
@@ -1,0 +1,59 @@
+package pos.ambrosia.utest
+
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.server.application.call
+import io.ktor.server.config.MapApplicationConfig
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.get
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.testApplication
+import pos.ambrosia.utils.canRestartSelf
+import pos.ambrosia.utils.isLocalPhoenixd
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ServiceSupervisionTest {
+    @Test
+    fun `isLocalPhoenixd is true when neither phoenixd-remote nor nwc-uri are configured`() =
+        testApplication {
+            application { routing { get("/probe") { call.respondText(call.isLocalPhoenixd().toString()) } } }
+
+            assertEquals("true", client.get("/probe").bodyAsText())
+        }
+
+    @Test
+    fun `isLocalPhoenixd is false when phoenixd-remote is enabled`() =
+        testApplication {
+            environment { config = MapApplicationConfig("phoenixd-remote" to "true") }
+            application { routing { get("/probe") { call.respondText(call.isLocalPhoenixd().toString()) } } }
+
+            assertEquals("false", client.get("/probe").bodyAsText())
+        }
+
+    @Test
+    fun `isLocalPhoenixd is false when an nwc-uri is configured`() =
+        testApplication {
+            environment { config = MapApplicationConfig("nwc-uri" to "nostr+walletconnect://pubkey?relay=wss://relay") }
+            application { routing { get("/probe") { call.respondText(call.isLocalPhoenixd().toString()) } } }
+
+            assertEquals("false", client.get("/probe").bodyAsText())
+        }
+
+    @Test
+    fun `canRestartSelf is true when the docker config flag is set`() =
+        testApplication {
+            environment { config = MapApplicationConfig("docker" to "true") }
+            application { routing { get("/probe") { call.respondText(call.canRestartSelf().toString()) } } }
+
+            assertEquals("true", client.get("/probe").bodyAsText())
+        }
+
+    @Test
+    fun `canRestartSelf is false without the docker flag or a systemd invocation id`() =
+        testApplication {
+            application { routing { get("/probe") { call.respondText(call.canRestartSelf().toString()) } } }
+
+            assertEquals("false", client.get("/probe").bodyAsText())
+        }
+}


### PR DESCRIPTION
## Problem

Ambrosia had no way to restart the server or phoenixd from the app itself. If either process needed to pick up a config change, recover from a stuck state, or apply a pending settings change, the only options were a manual terminal/systemctl command (native installs), physically rebooting the device (hardware), or restarting containers by hand (Docker) — with zero in-app control. Electron already had the plumbing for this internally (`services:restart` IPC), but it was never exposed as an actual button, and no other deployment mode had anything at all.

## Fix

Added "Restart server" / "Restart phoenixd" controls to Settings, working across every deployment mode — native (systemd), the Raspberry Pi/OrangePi hardware image, Docker, and Electron — by reusing each mode's own existing process supervisor (systemd `Restart=always`, Docker `restart: unless-stopped`, Electron's `ServiceManager`) instead of introducing new privileges like passwordless sudo or polkit rules. phoenixd is signalled directly via a pidfile since it runs as the same OS user as the server on native/hardware installs; on Docker it correctly has no way to be reached (separate container, separate PID namespace) so only the server button is shown there.

## What Changed

- Added `canRestartSelf()`/`isSystemdManaged()`/`isLocalPhoenixd()` server helpers to detect when a self-restart is safe.
- Generalized the existing Docker-only restart (`scheduleDockerRestart`) into `scheduleProcessRestart`, now also used for systemd-managed native/hardware installs.
- Forced the process to `exitProcess` after stopping the embedded server — a leaked non-daemon thread from the Web Push async HTTP client was silently keeping the JVM alive after `stopSuspend()`, so the process never actually restarted.
- Added `PhoenixdProcessService`, which signals phoenixd through a pidfile.
- Added admin-only `/system/restart-capabilities`, `/system/restart-server`, `/system/restart-phoenixd` endpoints.
- Added `run-server.sh` / `run-phoenixd.sh` self-restart wrappers with signal forwarding, so `systemctl stop` still stops the process cleanly instead of fighting the restart loop.
- Wired the phoenixd wrapper and an `AMBROSIA_SERVICE_MANAGED` flag into `install.sh` and the hardware image's systemd units.
- Added an `install.sh --local` flag that builds and installs from the current checkout instead of downloading a GitHub release; updated `uninstall.sh` to remove the new wrapper too.
- Added a "System" Settings card with a confirmation modal for each restart action, styled to match the Close Channel danger buttons.
- Fixed two unrelated pre-existing bugs found while testing this end-to-end: a malformed fallback wordlist URL in `SeedGenerator` (a stray triple-quoted string embedded newlines into the URL) that broke server boot on any fresh install without the local wordlist file, and the Docker client not binding to `0.0.0.0`, which made its own middleware unable to reach itself for the onboarding check.

## How to Test

1. **Native**: ` ./scripts/install.sh --local --yes`, log in as admin, go to Settings → System, click "Restart server" and confirm — the service should actually come back. Same for "Restart phoenixd".
2. **Hardware**: build and flash the OrangePi/RPi image, boot the device, repeat the same two checks.
3. **Docker**: `docker compose up --build -d`, confirm only "Restart server" is shown (not phoenixd), and that clicking it restarts the `ambrosia` container.
4. **Electron**: confirm both buttons work via the existing `services:restart` IPC channel.
5. Confirm neither button appears on a deployment with no supervisor (e.g. a `--no-service` install).

## Verification

- Server: `./gradlew test ktlintCheck` passed.
- Client: full Jest suite passed (306 suites, 2905 tests), ESLint clean.
- All new/modified shell scripts pass `bash -n`.
- Manually verified end-to-end on native, hardware (real device flash + boot), Docker, and Electron.

## Screenshots

<img width="729" height="199" alt="image" src="https://github.com/user-attachments/assets/f1e49645-0b01-473b-801c-c41156a12224" />