### PR TITLE
Feat(freelance-server): payout accounts api

### DIFF
--- a/server/app/src/main/kotlin/pos/ambrosia/Api.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/Api.kt
@@ -36,6 +36,7 @@ import pos.ambrosia.api.configureInitialSetup
 import pos.ambrosia.api.configureOrders
 import pos.ambrosia.api.configurePaymentWebsocket
 import pos.ambrosia.api.configurePayments
+import pos.ambrosia.api.configurePayoutAccounts
 import pos.ambrosia.api.configurePermissions
 import pos.ambrosia.api.configurePhoenixWebhook
 import pos.ambrosia.api.configurePrinters
@@ -118,6 +119,7 @@ class Api {
         configureCheckout()
         configureCategories()
         configureClients()
+        configurePayoutAccounts()
         configureProjects()
         configureCurrency()
         configureTimeEntries()

--- a/server/app/src/main/kotlin/pos/ambrosia/api/PayoutAccounts.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/api/PayoutAccounts.kt
@@ -1,0 +1,91 @@
+package pos.ambrosia.api
+
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.Application
+import io.ktor.server.request.receive
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.delete
+import io.ktor.server.routing.get
+import io.ktor.server.routing.post
+import io.ktor.server.routing.put
+import io.ktor.server.routing.route
+import io.ktor.server.routing.routing
+import pos.ambrosia.models.PayoutAccountUpsert
+import pos.ambrosia.services.PayoutAccountService
+import pos.ambrosia.utils.authorizePermission
+
+fun Application.configurePayoutAccounts() {
+    val payoutAccountService = PayoutAccountService()
+    routing { route("/payout-accounts") { payoutAccounts(payoutAccountService) } }
+}
+
+fun Route.payoutAccounts(payoutAccountService: PayoutAccountService) {
+    authorizePermission("payout_accounts_read") {
+        get("") {
+            val payoutAccounts = payoutAccountService.getPayoutAccounts()
+            if (payoutAccounts.isEmpty()) {
+                call.respond(HttpStatusCode.OK, "No payout accounts found")
+                return@get
+            }
+            call.respond(HttpStatusCode.OK, payoutAccounts)
+        }
+
+        get("/{id}") {
+            val payoutAccountId =
+                call.parameters["id"]
+                    ?: return@get call.respond(HttpStatusCode.BadRequest, "Missing or malformed ID")
+            val payoutAccount =
+                payoutAccountService.getPayoutAccountById(payoutAccountId)
+                    ?: return@get call.respond(HttpStatusCode.NotFound, "Payout account not found")
+            call.respond(HttpStatusCode.OK, payoutAccount)
+        }
+    }
+
+    authorizePermission("payout_accounts_create") {
+        post("") {
+            val payoutAccountRequest = call.receive<PayoutAccountUpsert>()
+            val createdPayoutAccountId = payoutAccountService.addPayoutAccount(payoutAccountRequest)
+            if (createdPayoutAccountId == null) {
+                call.respond(HttpStatusCode.BadRequest, "Invalid payout account data")
+                return@post
+            }
+            call.respond(
+                HttpStatusCode.Created,
+                mapOf("id" to createdPayoutAccountId, "message" to "Payout account added successfully"),
+            )
+        }
+    }
+
+    authorizePermission("payout_accounts_update") {
+        put("/{id}") {
+            val payoutAccountId =
+                call.parameters["id"]
+                    ?: return@put call.respond(HttpStatusCode.BadRequest, "Missing or malformed ID")
+            val payoutAccountRequest = call.receive<PayoutAccountUpsert>()
+            val payoutAccountWasUpdated = payoutAccountService.updatePayoutAccount(payoutAccountId, payoutAccountRequest)
+            if (!payoutAccountWasUpdated) {
+                call.respond(HttpStatusCode.NotFound, "Payout account with ID: $payoutAccountId not found or invalid")
+                return@put
+            }
+            call.respond(
+                HttpStatusCode.OK,
+                mapOf("id" to payoutAccountId, "message" to "Payout account updated successfully"),
+            )
+        }
+    }
+
+    authorizePermission("payout_accounts_delete") {
+        delete("/{id}") {
+            val payoutAccountId =
+                call.parameters["id"]
+                    ?: return@delete call.respond(HttpStatusCode.BadRequest, "Missing or malformed ID")
+            val payoutAccountWasDeleted = payoutAccountService.deletePayoutAccount(payoutAccountId)
+            if (!payoutAccountWasDeleted) {
+                call.respond(HttpStatusCode.NotFound, "Payout account not found")
+                return@delete
+            }
+            call.respond(HttpStatusCode.NoContent)
+        }
+    }
+}

--- a/server/app/src/main/kotlin/pos/ambrosia/models/AppModels.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/models/AppModels.kt
@@ -570,6 +570,35 @@ data class FreelanceProjectUpsert(
 )
 
 @Serializable
+data class PayoutAccount(
+    val id: String,
+    val type: String,
+    val accountHolder: String? = null,
+    val bankName: String? = null,
+    val accountNumber: String? = null,
+    val currencyId: String? = null,
+    val swift: String? = null,
+    val iban: String? = null,
+    val clabe: String? = null,
+    val lightningAddress: String? = null,
+    val isDeleted: Boolean = false,
+    val createdAt: String,
+)
+
+@Serializable
+data class PayoutAccountUpsert(
+    val type: String,
+    val accountHolder: String? = null,
+    val bankName: String? = null,
+    val accountNumber: String? = null,
+    val currencyId: String? = null,
+    val swift: String? = null,
+    val iban: String? = null,
+    val clabe: String? = null,
+    val lightningAddress: String? = null,
+)
+
+@Serializable
 data class ProductOptionValue(
     val id: String? = null,
     val optionTypeId: String? = null,

--- a/server/app/src/main/kotlin/pos/ambrosia/services/ActiveLightningBackend.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/services/ActiveLightningBackend.kt
@@ -32,6 +32,8 @@ object ActiveLightningBackend : LightningBackend, PaymentVerifier {
 
     fun isNwcActive(): Boolean = backendReference.get() is NwcService
 
+    fun isAvailable(): Boolean = backendReference.get() != null
+
     fun startPhoenixPaymentEventsListener(
         phoenixdUrl: String,
         phoenixdPassword: String,

--- a/server/app/src/main/kotlin/pos/ambrosia/services/PayoutAccountService.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/services/PayoutAccountService.kt
@@ -1,0 +1,155 @@
+package pos.ambrosia.services
+
+import org.jetbrains.exposed.v1.core.dao.id.EntityID
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import pos.ambrosia.db.tables.CurrencyTable
+import pos.ambrosia.db.tables.PayoutAccountEntity
+import pos.ambrosia.db.tables.PayoutAccountsTable
+import pos.ambrosia.logger
+import pos.ambrosia.models.PayoutAccount
+import pos.ambrosia.models.PayoutAccountUpsert
+import java.time.LocalDateTime
+import java.util.UUID
+
+class PayoutAccountService {
+    private fun parseUuid(value: String): UUID? =
+        try {
+            UUID.fromString(value)
+        } catch (_: IllegalArgumentException) {
+            null
+        }
+
+    private fun currencyExists(currencyId: String?): Boolean {
+        if (currencyId.isNullOrBlank()) return true
+        val currencyUuid = parseUuid(currencyId) ?: return false
+        return !CurrencyTable
+            .selectAll()
+            .where { CurrencyTable.id eq EntityID(currencyUuid, CurrencyTable) }
+            .empty()
+    }
+
+    private fun hasNoBankFields(payoutAccountRequest: PayoutAccountUpsert): Boolean =
+        payoutAccountRequest.accountHolder.isNullOrBlank() &&
+            payoutAccountRequest.bankName.isNullOrBlank() &&
+            payoutAccountRequest.accountNumber.isNullOrBlank() &&
+            payoutAccountRequest.swift.isNullOrBlank() &&
+            payoutAccountRequest.iban.isNullOrBlank() &&
+            payoutAccountRequest.clabe.isNullOrBlank()
+
+    private fun isValidBankAccount(payoutAccountRequest: PayoutAccountUpsert): Boolean =
+        !payoutAccountRequest.accountHolder.isNullOrBlank() &&
+            !payoutAccountRequest.bankName.isNullOrBlank() &&
+            !payoutAccountRequest.currencyId.isNullOrBlank() &&
+            currencyExists(payoutAccountRequest.currencyId) &&
+            (
+                !payoutAccountRequest.accountNumber.isNullOrBlank() ||
+                    !payoutAccountRequest.iban.isNullOrBlank() ||
+                    !payoutAccountRequest.clabe.isNullOrBlank()
+            ) &&
+            payoutAccountRequest.lightningAddress.isNullOrBlank()
+
+    private fun isValidLightningAccount(payoutAccountRequest: PayoutAccountUpsert): Boolean =
+        hasNoBankFields(payoutAccountRequest) &&
+            (!payoutAccountRequest.lightningAddress.isNullOrBlank() || ActiveLightningBackend.isAvailable())
+
+    private fun isValidPayoutAccountRequest(payoutAccountRequest: PayoutAccountUpsert): Boolean =
+        when (payoutAccountRequest.type) {
+            "bank" -> isValidBankAccount(payoutAccountRequest)
+            "lightning" -> isValidLightningAccount(payoutAccountRequest)
+            else -> false
+        }
+
+    private fun toPayoutAccountModel(payoutAccountEntity: PayoutAccountEntity): PayoutAccount =
+        PayoutAccount(
+            id = payoutAccountEntity.id.value.toString(),
+            type = payoutAccountEntity.type,
+            accountHolder = payoutAccountEntity.accountHolder,
+            bankName = payoutAccountEntity.bankName,
+            accountNumber = payoutAccountEntity.accountNumber,
+            currencyId = payoutAccountEntity.currencyId?.value?.toString(),
+            swift = payoutAccountEntity.swift,
+            iban = payoutAccountEntity.iban,
+            clabe = payoutAccountEntity.clabe,
+            lightningAddress = payoutAccountEntity.lightningAddress,
+            isDeleted = payoutAccountEntity.isDeleted,
+            createdAt = payoutAccountEntity.createdAt,
+        )
+
+    fun getPayoutAccounts(): List<PayoutAccount> =
+        transaction {
+            PayoutAccountEntity
+                .find { PayoutAccountsTable.isDeleted eq false }
+                .map { payoutAccountEntity -> toPayoutAccountModel(payoutAccountEntity) }
+        }
+
+    fun getPayoutAccountById(payoutAccountId: String): PayoutAccount? =
+        transaction {
+            val payoutAccountUuid = parseUuid(payoutAccountId) ?: return@transaction null
+            val payoutAccountEntity = PayoutAccountEntity.findById(payoutAccountUuid) ?: return@transaction null
+            if (payoutAccountEntity.isDeleted) return@transaction null
+            toPayoutAccountModel(payoutAccountEntity)
+        }
+
+    fun addPayoutAccount(payoutAccountRequest: PayoutAccountUpsert): String? =
+        transaction {
+            if (!isValidPayoutAccountRequest(payoutAccountRequest)) return@transaction null
+
+            val payoutAccountId =
+                PayoutAccountEntity
+                    .new(UUID.randomUUID()) {
+                        type = payoutAccountRequest.type
+                        accountHolder = payoutAccountRequest.accountHolder
+                        bankName = payoutAccountRequest.bankName
+                        accountNumber = payoutAccountRequest.accountNumber
+                        currencyId =
+                            payoutAccountRequest.currencyId?.let { EntityID(UUID.fromString(it), CurrencyTable) }
+                        swift = payoutAccountRequest.swift
+                        iban = payoutAccountRequest.iban
+                        clabe = payoutAccountRequest.clabe
+                        lightningAddress = payoutAccountRequest.lightningAddress
+                        isDeleted = false
+                        createdAt = LocalDateTime.now().toString()
+                    }.id.value
+                    .toString()
+            logger.info("Payout account created: $payoutAccountId")
+            payoutAccountId
+        }
+
+    fun updatePayoutAccount(
+        payoutAccountId: String,
+        payoutAccountRequest: PayoutAccountUpsert,
+    ): Boolean =
+        transaction {
+            val payoutAccountUuid = parseUuid(payoutAccountId) ?: return@transaction false
+            if (!isValidPayoutAccountRequest(payoutAccountRequest)) return@transaction false
+
+            val payoutAccountEntity = PayoutAccountEntity.findById(payoutAccountUuid) ?: return@transaction false
+            if (payoutAccountEntity.isDeleted) return@transaction false
+
+            payoutAccountEntity.type = payoutAccountRequest.type
+            payoutAccountEntity.accountHolder = payoutAccountRequest.accountHolder
+            payoutAccountEntity.bankName = payoutAccountRequest.bankName
+            payoutAccountEntity.accountNumber = payoutAccountRequest.accountNumber
+            payoutAccountEntity.currencyId =
+                payoutAccountRequest.currencyId?.let { EntityID(UUID.fromString(it), CurrencyTable) }
+            payoutAccountEntity.swift = payoutAccountRequest.swift
+            payoutAccountEntity.iban = payoutAccountRequest.iban
+            payoutAccountEntity.clabe = payoutAccountRequest.clabe
+            payoutAccountEntity.lightningAddress = payoutAccountRequest.lightningAddress
+            logger.info("Payout account updated: $payoutAccountId")
+            true
+        }
+
+    fun deletePayoutAccount(payoutAccountId: String): Boolean =
+        transaction {
+            val payoutAccountUuid = parseUuid(payoutAccountId) ?: return@transaction false
+            val payoutAccountEntity = PayoutAccountEntity.findById(payoutAccountUuid) ?: return@transaction false
+            if (payoutAccountEntity.isDeleted) return@transaction false
+
+            payoutAccountEntity.isDeleted = true
+            logger.info("Payout account soft deleted: $payoutAccountId")
+            true
+        }
+}

--- a/server/app/src/main/kotlin/pos/ambrosia/services/PayoutAccountService.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/services/PayoutAccountService.kt
@@ -14,9 +14,9 @@ import java.time.LocalDateTime
 import java.util.UUID
 
 class PayoutAccountService {
-    private fun parseUuid(value: String): UUID? =
+    private fun parseUuid(rawUuid: String): UUID? =
         try {
-            UUID.fromString(value)
+            UUID.fromString(rawUuid)
         } catch (_: IllegalArgumentException) {
             null
         }

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/FreelanceRoutesTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/FreelanceRoutesTest.kt
@@ -6,15 +6,20 @@ import io.ktor.client.request.header
 import io.ktor.client.request.post
 import io.ktor.client.request.put
 import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.server.application.install
 import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.server.testing.testApplication
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import org.junit.After
 import org.junit.Before
 import pos.ambrosia.api.configureClients
+import pos.ambrosia.api.configurePayoutAccounts
 import pos.ambrosia.api.configureProjects
 import pos.ambrosia.api.handler
 import pos.ambrosia.services.PermissionsService
@@ -164,6 +169,92 @@ class FreelanceRoutesTest {
         }
 
     @Test
+    fun `payout account routes create list get update and soft delete payout accounts`() =
+        testApplication {
+            val authCookies = installAdminAuth()
+            grantFreelancePermissions("admin-test-role", payoutAccountPermissions)
+            val currencyId = ExposedTestDb.seedCurrency("USD")
+            application {
+                install(ContentNegotiation) { json() }
+                handler()
+                configurePayoutAccounts()
+            }
+
+            val createPayoutAccountResponse =
+                client.post("/payout-accounts") {
+                    withAuthCookies(authCookies)
+                    header(HttpHeaders.ContentType, "application/json")
+                    setBody(
+                        """{
+                            "type":"bank",
+                            "accountHolder":"Jane Doe",
+                            "bankName":"Acme Bank",
+                            "accountNumber":"1234567890",
+                            "currencyId":"$currencyId"
+                        }""",
+                    )
+                }
+            val createdPayoutAccountId =
+                Json
+                    .parseToJsonElement(createPayoutAccountResponse.bodyAsText())
+                    .jsonObject["id"]!!
+                    .jsonPrimitive.content
+            val listPayoutAccountsResponse = client.get("/payout-accounts") { withAuthCookies(authCookies) }
+            val getPayoutAccountResponse =
+                client.get("/payout-accounts/$createdPayoutAccountId") { withAuthCookies(authCookies) }
+            val updatePayoutAccountResponse =
+                client.put("/payout-accounts/$createdPayoutAccountId") {
+                    withAuthCookies(authCookies)
+                    header(HttpHeaders.ContentType, "application/json")
+                    setBody(
+                        """{
+                            "type":"lightning",
+                            "lightningAddress":"freelancer@getalby.com"
+                        }""",
+                    )
+                }
+            val deletePayoutAccountResponse =
+                client.delete("/payout-accounts/$createdPayoutAccountId") { withAuthCookies(authCookies) }
+            val getDeletedPayoutAccountResponse =
+                client.get("/payout-accounts/$createdPayoutAccountId") { withAuthCookies(authCookies) }
+
+            assertEquals(HttpStatusCode.Created, createPayoutAccountResponse.status)
+            assertEquals(HttpStatusCode.OK, listPayoutAccountsResponse.status)
+            assertEquals(HttpStatusCode.OK, getPayoutAccountResponse.status)
+            assertEquals(HttpStatusCode.OK, updatePayoutAccountResponse.status)
+            assertEquals(HttpStatusCode.NoContent, deletePayoutAccountResponse.status)
+            assertEquals(HttpStatusCode.NotFound, getDeletedPayoutAccountResponse.status)
+        }
+
+    @Test
+    fun `payout account routes reject invalid bank and lightning payloads`() =
+        testApplication {
+            val authCookies = installAdminAuth()
+            grantFreelancePermissions("admin-test-role", payoutAccountPermissions)
+            application {
+                install(ContentNegotiation) { json() }
+                handler()
+                configurePayoutAccounts()
+            }
+
+            val invalidBankResponse =
+                client.post("/payout-accounts") {
+                    withAuthCookies(authCookies)
+                    header(HttpHeaders.ContentType, "application/json")
+                    setBody("""{"type":"bank","accountHolder":"Jane Doe"}""")
+                }
+            val invalidLightningResponse =
+                client.post("/payout-accounts") {
+                    withAuthCookies(authCookies)
+                    header(HttpHeaders.ContentType, "application/json")
+                    setBody("""{"type":"lightning","bankName":"Acme Bank","lightningAddress":"freelancer@getalby.com"}""")
+                }
+
+            assertEquals(HttpStatusCode.BadRequest, invalidBankResponse.status)
+            assertEquals(HttpStatusCode.BadRequest, invalidLightningResponse.status)
+        }
+
+    @Test
     fun `freelance routes require matching permissions`() =
         testApplication {
             val authCookies = installAdminAuth()
@@ -205,6 +296,13 @@ class FreelanceRoutesTest {
                 "projects_create",
                 "projects_update",
                 "projects_delete",
+            )
+        val payoutAccountPermissions =
+            listOf(
+                "payout_accounts_read",
+                "payout_accounts_create",
+                "payout_accounts_update",
+                "payout_accounts_delete",
             )
     }
 }

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/PayoutAccountServiceTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/PayoutAccountServiceTest.kt
@@ -18,7 +18,7 @@ import kotlin.test.assertTrue
 
 class PayoutAccountServiceTest {
     private lateinit var databaseFile: File
-    private val service = PayoutAccountService()
+    private val payoutAccountService = PayoutAccountService()
 
     private val validBankRequest =
         PayoutAccountUpsert(
@@ -45,10 +45,10 @@ class PayoutAccountServiceTest {
     fun `addPayoutAccount returns id for valid bank request`() {
         val currencyId = ExposedTestDb.seedCurrency("USD")
 
-        val payoutAccountId = service.addPayoutAccount(validBankRequest.copy(currencyId = currencyId))
+        val payoutAccountId = payoutAccountService.addPayoutAccount(validBankRequest.copy(currencyId = currencyId))
 
         assertNotNull(payoutAccountId)
-        val payoutAccount = service.getPayoutAccountById(payoutAccountId)
+        val payoutAccount = payoutAccountService.getPayoutAccountById(payoutAccountId)
         assertNotNull(payoutAccount)
         assertEquals("bank", payoutAccount.type)
         assertEquals("Jane Doe", payoutAccount.accountHolder)
@@ -60,16 +60,16 @@ class PayoutAccountServiceTest {
         val currencyId = ExposedTestDb.seedCurrency("USD")
         val validRequest = validBankRequest.copy(currencyId = currencyId)
 
-        assertNull(service.addPayoutAccount(validRequest.copy(accountHolder = "  ")))
-        assertNull(service.addPayoutAccount(validRequest.copy(bankName = "  ")))
-        assertNull(service.addPayoutAccount(validRequest.copy(currencyId = null)))
-        assertNull(service.addPayoutAccount(validRequest.copy(currencyId = UUID.randomUUID().toString())))
+        assertNull(payoutAccountService.addPayoutAccount(validRequest.copy(accountHolder = "  ")))
+        assertNull(payoutAccountService.addPayoutAccount(validRequest.copy(bankName = "  ")))
+        assertNull(payoutAccountService.addPayoutAccount(validRequest.copy(currencyId = null)))
+        assertNull(payoutAccountService.addPayoutAccount(validRequest.copy(currencyId = UUID.randomUUID().toString())))
         assertNull(
-            service.addPayoutAccount(
+            payoutAccountService.addPayoutAccount(
                 validRequest.copy(accountNumber = null, iban = null, clabe = null),
             ),
         )
-        assertNull(service.addPayoutAccount(validRequest.copy(lightningAddress = "user@getalby.com")))
+        assertNull(payoutAccountService.addPayoutAccount(validRequest.copy(lightningAddress = "user@getalby.com")))
     }
 
     @Test
@@ -80,19 +80,19 @@ class PayoutAccountServiceTest {
         val clabeRequest =
             validBankRequest.copy(currencyId = currencyId, accountNumber = null, clabe = "032180000118359719")
 
-        assertNotNull(service.addPayoutAccount(ibanRequest))
-        assertNotNull(service.addPayoutAccount(clabeRequest))
+        assertNotNull(payoutAccountService.addPayoutAccount(ibanRequest))
+        assertNotNull(payoutAccountService.addPayoutAccount(clabeRequest))
     }
 
     @Test
     fun `addPayoutAccount returns id for lightning request with lightning address`() {
         val payoutAccountId =
-            service.addPayoutAccount(
+            payoutAccountService.addPayoutAccount(
                 PayoutAccountUpsert(type = "lightning", lightningAddress = "freelancer@getalby.com"),
             )
 
         assertNotNull(payoutAccountId)
-        val payoutAccount = service.getPayoutAccountById(payoutAccountId)
+        val payoutAccount = payoutAccountService.getPayoutAccountById(payoutAccountId)
         assertNotNull(payoutAccount)
         assertEquals("lightning", payoutAccount.type)
         assertEquals("freelancer@getalby.com", payoutAccount.lightningAddress)
@@ -101,7 +101,7 @@ class PayoutAccountServiceTest {
     @Test
     fun `addPayoutAccount rejects blank lightning address without a local node fallback`() {
         val payoutAccountId =
-            service.addPayoutAccount(PayoutAccountUpsert(type = "lightning", lightningAddress = null))
+            payoutAccountService.addPayoutAccount(PayoutAccountUpsert(type = "lightning", lightningAddress = null))
 
         assertNull(payoutAccountId)
     }
@@ -111,7 +111,7 @@ class PayoutAccountServiceTest {
         ActiveLightningBackend.set(FakeLightningBackend("phoenixd"))
 
         val payoutAccountId =
-            service.addPayoutAccount(PayoutAccountUpsert(type = "lightning", lightningAddress = null))
+            payoutAccountService.addPayoutAccount(PayoutAccountUpsert(type = "lightning", lightningAddress = null))
 
         assertNotNull(payoutAccountId)
     }
@@ -119,7 +119,7 @@ class PayoutAccountServiceTest {
     @Test
     fun `addPayoutAccount rejects lightning request mixing bank fields`() {
         val payoutAccountId =
-            service.addPayoutAccount(
+            payoutAccountService.addPayoutAccount(
                 PayoutAccountUpsert(
                     type = "lightning",
                     lightningAddress = "freelancer@getalby.com",
@@ -132,7 +132,7 @@ class PayoutAccountServiceTest {
 
     @Test
     fun `addPayoutAccount rejects unknown type`() {
-        assertNull(service.addPayoutAccount(validBankRequest.copy(type = "cash")))
+        assertNull(payoutAccountService.addPayoutAccount(validBankRequest.copy(type = "cash")))
     }
 
     @Test
@@ -140,7 +140,7 @@ class PayoutAccountServiceTest {
         ExposedTestDb.seedPayoutAccount()
         ExposedTestDb.seedPayoutAccount(isDeleted = true)
 
-        val payoutAccounts = service.getPayoutAccounts()
+        val payoutAccounts = payoutAccountService.getPayoutAccounts()
 
         assertEquals(1, payoutAccounts.size)
         assertFalse(payoutAccounts[0].isDeleted)
@@ -150,9 +150,9 @@ class PayoutAccountServiceTest {
     fun `getPayoutAccountById returns null for invalid missing or deleted account`() {
         val deletedPayoutAccountId = ExposedTestDb.seedPayoutAccount(isDeleted = true)
 
-        assertNull(service.getPayoutAccountById("not-a-uuid"))
-        assertNull(service.getPayoutAccountById(UUID.randomUUID().toString()))
-        assertNull(service.getPayoutAccountById(deletedPayoutAccountId))
+        assertNull(payoutAccountService.getPayoutAccountById("not-a-uuid"))
+        assertNull(payoutAccountService.getPayoutAccountById(UUID.randomUUID().toString()))
+        assertNull(payoutAccountService.getPayoutAccountById(deletedPayoutAccountId))
     }
 
     @Test
@@ -161,13 +161,13 @@ class PayoutAccountServiceTest {
         val payoutAccountId = ExposedTestDb.seedPayoutAccount(currencyId = currencyId)
 
         val payoutAccountWasUpdated =
-            service.updatePayoutAccount(
+            payoutAccountService.updatePayoutAccount(
                 payoutAccountId,
                 validBankRequest.copy(currencyId = currencyId, accountHolder = "Updated Holder"),
             )
 
         assertTrue(payoutAccountWasUpdated)
-        val payoutAccount = service.getPayoutAccountById(payoutAccountId)
+        val payoutAccount = payoutAccountService.getPayoutAccountById(payoutAccountId)
         assertNotNull(payoutAccount)
         assertEquals("Updated Holder", payoutAccount.accountHolder)
     }
@@ -178,28 +178,28 @@ class PayoutAccountServiceTest {
         val deletedPayoutAccountId = ExposedTestDb.seedPayoutAccount(currencyId = currencyId, isDeleted = true)
         val validRequest = validBankRequest.copy(currencyId = currencyId)
 
-        assertFalse(service.updatePayoutAccount("not-a-uuid", validRequest))
-        assertFalse(service.updatePayoutAccount(UUID.randomUUID().toString(), validRequest))
-        assertFalse(service.updatePayoutAccount(deletedPayoutAccountId, validRequest))
-        assertFalse(service.updatePayoutAccount(deletedPayoutAccountId, validRequest.copy(accountHolder = " ")))
+        assertFalse(payoutAccountService.updatePayoutAccount("not-a-uuid", validRequest))
+        assertFalse(payoutAccountService.updatePayoutAccount(UUID.randomUUID().toString(), validRequest))
+        assertFalse(payoutAccountService.updatePayoutAccount(deletedPayoutAccountId, validRequest))
+        assertFalse(payoutAccountService.updatePayoutAccount(deletedPayoutAccountId, validRequest.copy(accountHolder = " ")))
     }
 
     @Test
     fun `deletePayoutAccount soft deletes account`() {
         val payoutAccountId = ExposedTestDb.seedPayoutAccount()
 
-        val payoutAccountWasDeleted = service.deletePayoutAccount(payoutAccountId)
+        val payoutAccountWasDeleted = payoutAccountService.deletePayoutAccount(payoutAccountId)
 
         assertTrue(payoutAccountWasDeleted)
-        assertNull(service.getPayoutAccountById(payoutAccountId))
+        assertNull(payoutAccountService.getPayoutAccountById(payoutAccountId))
     }
 
     @Test
     fun `deletePayoutAccount returns false for invalid missing or already deleted account`() {
         val deletedPayoutAccountId = ExposedTestDb.seedPayoutAccount(isDeleted = true)
 
-        assertFalse(service.deletePayoutAccount("not-a-uuid"))
-        assertFalse(service.deletePayoutAccount(UUID.randomUUID().toString()))
-        assertFalse(service.deletePayoutAccount(deletedPayoutAccountId))
+        assertFalse(payoutAccountService.deletePayoutAccount("not-a-uuid"))
+        assertFalse(payoutAccountService.deletePayoutAccount(UUID.randomUUID().toString()))
+        assertFalse(payoutAccountService.deletePayoutAccount(deletedPayoutAccountId))
     }
 }

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/PayoutAccountServiceTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/PayoutAccountServiceTest.kt
@@ -1,0 +1,205 @@
+package pos.ambrosia.utest
+
+import org.junit.After
+import org.junit.Before
+import pos.ambrosia.models.PayoutAccountUpsert
+import pos.ambrosia.services.ActiveLightningBackend
+import pos.ambrosia.services.PayoutAccountService
+import pos.ambrosia.utils.ExposedTestDb
+import pos.ambrosia.utils.FakeLightningBackend
+import java.io.File
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class PayoutAccountServiceTest {
+    private lateinit var databaseFile: File
+    private val service = PayoutAccountService()
+
+    private val validBankRequest =
+        PayoutAccountUpsert(
+            type = "bank",
+            accountHolder = "Jane Doe",
+            bankName = "Acme Bank",
+            accountNumber = "1234567890",
+            currencyId = null,
+        )
+
+    @Before
+    fun setUp() {
+        databaseFile = ExposedTestDb.connect()
+        ActiveLightningBackend.closeActive()
+    }
+
+    @After
+    fun tearDown() {
+        ActiveLightningBackend.closeActive()
+        ExposedTestDb.cleanup(databaseFile)
+    }
+
+    @Test
+    fun `addPayoutAccount returns id for valid bank request`() {
+        val currencyId = ExposedTestDb.seedCurrency("USD")
+
+        val payoutAccountId = service.addPayoutAccount(validBankRequest.copy(currencyId = currencyId))
+
+        assertNotNull(payoutAccountId)
+        val payoutAccount = service.getPayoutAccountById(payoutAccountId)
+        assertNotNull(payoutAccount)
+        assertEquals("bank", payoutAccount.type)
+        assertEquals("Jane Doe", payoutAccount.accountHolder)
+        assertEquals(currencyId, payoutAccount.currencyId)
+    }
+
+    @Test
+    fun `addPayoutAccount rejects bank request missing required fields`() {
+        val currencyId = ExposedTestDb.seedCurrency("USD")
+        val validRequest = validBankRequest.copy(currencyId = currencyId)
+
+        assertNull(service.addPayoutAccount(validRequest.copy(accountHolder = "  ")))
+        assertNull(service.addPayoutAccount(validRequest.copy(bankName = "  ")))
+        assertNull(service.addPayoutAccount(validRequest.copy(currencyId = null)))
+        assertNull(service.addPayoutAccount(validRequest.copy(currencyId = UUID.randomUUID().toString())))
+        assertNull(
+            service.addPayoutAccount(
+                validRequest.copy(accountNumber = null, iban = null, clabe = null),
+            ),
+        )
+        assertNull(service.addPayoutAccount(validRequest.copy(lightningAddress = "user@getalby.com")))
+    }
+
+    @Test
+    fun `addPayoutAccount accepts bank request identified by iban or clabe`() {
+        val currencyId = ExposedTestDb.seedCurrency("EUR")
+        val ibanRequest =
+            validBankRequest.copy(currencyId = currencyId, accountNumber = null, iban = "DE89370400440532013000")
+        val clabeRequest =
+            validBankRequest.copy(currencyId = currencyId, accountNumber = null, clabe = "032180000118359719")
+
+        assertNotNull(service.addPayoutAccount(ibanRequest))
+        assertNotNull(service.addPayoutAccount(clabeRequest))
+    }
+
+    @Test
+    fun `addPayoutAccount returns id for lightning request with lightning address`() {
+        val payoutAccountId =
+            service.addPayoutAccount(
+                PayoutAccountUpsert(type = "lightning", lightningAddress = "freelancer@getalby.com"),
+            )
+
+        assertNotNull(payoutAccountId)
+        val payoutAccount = service.getPayoutAccountById(payoutAccountId)
+        assertNotNull(payoutAccount)
+        assertEquals("lightning", payoutAccount.type)
+        assertEquals("freelancer@getalby.com", payoutAccount.lightningAddress)
+    }
+
+    @Test
+    fun `addPayoutAccount rejects blank lightning address without a local node fallback`() {
+        val payoutAccountId =
+            service.addPayoutAccount(PayoutAccountUpsert(type = "lightning", lightningAddress = null))
+
+        assertNull(payoutAccountId)
+    }
+
+    @Test
+    fun `addPayoutAccount accepts blank lightning address when a local node is available`() {
+        ActiveLightningBackend.set(FakeLightningBackend("phoenixd"))
+
+        val payoutAccountId =
+            service.addPayoutAccount(PayoutAccountUpsert(type = "lightning", lightningAddress = null))
+
+        assertNotNull(payoutAccountId)
+    }
+
+    @Test
+    fun `addPayoutAccount rejects lightning request mixing bank fields`() {
+        val payoutAccountId =
+            service.addPayoutAccount(
+                PayoutAccountUpsert(
+                    type = "lightning",
+                    lightningAddress = "freelancer@getalby.com",
+                    bankName = "Acme Bank",
+                ),
+            )
+
+        assertNull(payoutAccountId)
+    }
+
+    @Test
+    fun `addPayoutAccount rejects unknown type`() {
+        assertNull(service.addPayoutAccount(validBankRequest.copy(type = "cash")))
+    }
+
+    @Test
+    fun `getPayoutAccounts excludes deleted accounts`() {
+        ExposedTestDb.seedPayoutAccount()
+        ExposedTestDb.seedPayoutAccount(isDeleted = true)
+
+        val payoutAccounts = service.getPayoutAccounts()
+
+        assertEquals(1, payoutAccounts.size)
+        assertFalse(payoutAccounts[0].isDeleted)
+    }
+
+    @Test
+    fun `getPayoutAccountById returns null for invalid missing or deleted account`() {
+        val deletedPayoutAccountId = ExposedTestDb.seedPayoutAccount(isDeleted = true)
+
+        assertNull(service.getPayoutAccountById("not-a-uuid"))
+        assertNull(service.getPayoutAccountById(UUID.randomUUID().toString()))
+        assertNull(service.getPayoutAccountById(deletedPayoutAccountId))
+    }
+
+    @Test
+    fun `updatePayoutAccount updates active account`() {
+        val currencyId = ExposedTestDb.seedCurrency("USD")
+        val payoutAccountId = ExposedTestDb.seedPayoutAccount(currencyId = currencyId)
+
+        val payoutAccountWasUpdated =
+            service.updatePayoutAccount(
+                payoutAccountId,
+                validBankRequest.copy(currencyId = currencyId, accountHolder = "Updated Holder"),
+            )
+
+        assertTrue(payoutAccountWasUpdated)
+        val payoutAccount = service.getPayoutAccountById(payoutAccountId)
+        assertNotNull(payoutAccount)
+        assertEquals("Updated Holder", payoutAccount.accountHolder)
+    }
+
+    @Test
+    fun `updatePayoutAccount returns false for invalid missing or deleted account`() {
+        val currencyId = ExposedTestDb.seedCurrency("USD")
+        val deletedPayoutAccountId = ExposedTestDb.seedPayoutAccount(currencyId = currencyId, isDeleted = true)
+        val validRequest = validBankRequest.copy(currencyId = currencyId)
+
+        assertFalse(service.updatePayoutAccount("not-a-uuid", validRequest))
+        assertFalse(service.updatePayoutAccount(UUID.randomUUID().toString(), validRequest))
+        assertFalse(service.updatePayoutAccount(deletedPayoutAccountId, validRequest))
+        assertFalse(service.updatePayoutAccount(deletedPayoutAccountId, validRequest.copy(accountHolder = " ")))
+    }
+
+    @Test
+    fun `deletePayoutAccount soft deletes account`() {
+        val payoutAccountId = ExposedTestDb.seedPayoutAccount()
+
+        val payoutAccountWasDeleted = service.deletePayoutAccount(payoutAccountId)
+
+        assertTrue(payoutAccountWasDeleted)
+        assertNull(service.getPayoutAccountById(payoutAccountId))
+    }
+
+    @Test
+    fun `deletePayoutAccount returns false for invalid missing or already deleted account`() {
+        val deletedPayoutAccountId = ExposedTestDb.seedPayoutAccount(isDeleted = true)
+
+        assertFalse(service.deletePayoutAccount("not-a-uuid"))
+        assertFalse(service.deletePayoutAccount(UUID.randomUUID().toString()))
+        assertFalse(service.deletePayoutAccount(deletedPayoutAccountId))
+    }
+}


### PR DESCRIPTION
## Summary

Implements the PayoutAccountService + API for issue #654, built on top of the payout_accounts schema and permissions added by #651.

## Changes

- Adds PayoutAccount / PayoutAccountUpsert API models.
- Adds ActiveLightningBackend.isAvailable() to detect whether a Lightning backend (local phoenixd or NWC) is currently active.
- Adds PayoutAccountService for listing, creating, updating, reading, and soft-deleting payout accounts, with server-side validation per type:
  - bank: requires account_holder, bank_name, a valid currency_id, and at least one of account_number / iban / clabe; rejects bank rows that also carry a lightning_address.
  - lightning: requires a lightning_address or an active Lightning backend as a node fallback (so a blank address is never silently accepted with nothing to fall back on); rejects lightning rows that carry any bank field.
- Registers the new API module with configurePayoutAccounts().
- Adds payout account routes:
  - GET /payout-accounts
  - POST /payout-accounts
  - GET /payout-accounts/{id}
  - PUT /payout-accounts/{id}
  - DELETE /payout-accounts/{id}
- Uses the freelance permissions added by #651 (payout_accounts_read/create/update/delete).
- Keeps delete behavior as soft delete only, so invoices.payout_snapshot keeps rendering after the source account is deleted.

## Testing

- Added focused service tests covering both sub-shapes and the node-fallback validation (PayoutAccountServiceTest).
- Added route tests covering the full CRUD flow and invalid-payload rejection (FreelanceRoutesTest).
- Verified focused suites locally with:
  - ./gradlew :app:test --tests pos.ambrosia.utest.PayoutAccountServiceTest
  - ./gradlew :app:test --tests pos.ambrosia.utest.FreelanceRoutesTest
- Manually exercised the full CRUD flow with curl against a running server (login, create bank/lightning accounts, update, soft-delete, permission checks).
