### PR TITLE
Chore/secrets encryption

### DIFF
--- a/client/src/components/locales/en.js
+++ b/client/src/components/locales/en.js
@@ -136,6 +136,8 @@ const componentsEn = {
   secretsUnlockPassword: {
     passwordLabel: "Unlock password",
     passwordDescription: "This is the password you'll use to unlock your encrypted secrets later. Any password works — it doesn't need to follow a specific format.",
+    confirmPasswordLabel: "Confirm unlock password",
+    passwordsDoNotMatch: "Passwords do not match",
     passwordWarning: "Write it down or save it somewhere safe — you may need to enter it again if the app restarts. If you forget this password, there's no way to recover it or the secrets it protects.",
   },
 };

--- a/client/src/components/locales/en.js
+++ b/client/src/components/locales/en.js
@@ -133,6 +133,11 @@ const componentsEn = {
     testSuccess: "Successfully connected to the remote node",
     testError: "Could not connect to the remote node — check the URL and password",
   },
+  secretsUnlockPassword: {
+    passwordLabel: "Unlock password",
+    passwordDescription: "This is the password you'll use to unlock your encrypted secrets later. Any password works — it doesn't need to follow a specific format.",
+    passwordWarning: "Write it down or save it somewhere safe — you may need to enter it again if the app restarts. If you forget this password, there's no way to recover it or the secrets it protects.",
+  },
 };
 
 export default componentsEn;

--- a/client/src/components/locales/es.js
+++ b/client/src/components/locales/es.js
@@ -136,6 +136,8 @@ const componentsEs = {
   secretsUnlockPassword: {
     passwordLabel: "Contraseña de desbloqueo",
     passwordDescription: "Esta es la contraseña que vas a usar para desbloquear tus secretos cifrados más adelante. Puede ser cualquier contraseña — no necesita seguir un formato específico.",
+    confirmPasswordLabel: "Confirmar contraseña de desbloqueo",
+    passwordsDoNotMatch: "Las contraseñas no coinciden",
     passwordWarning: "Anótala o guárdala en un lugar seguro — es posible que te la pida de nuevo si la app se reinicia. Si olvidas esta contraseña, no hay forma de recuperarla ni de recuperar los secretos que protege.",
   },
 };

--- a/client/src/components/locales/es.js
+++ b/client/src/components/locales/es.js
@@ -133,6 +133,11 @@ const componentsEs = {
     testSuccess: "Conexión exitosa con el nodo remoto",
     testError: "No se pudo conectar con el nodo remoto — revisa la URL y el password",
   },
+  secretsUnlockPassword: {
+    passwordLabel: "Contraseña de desbloqueo",
+    passwordDescription: "Esta es la contraseña que vas a usar para desbloquear tus secretos cifrados más adelante. Puede ser cualquier contraseña — no necesita seguir un formato específico.",
+    passwordWarning: "Anótala o guárdala en un lugar seguro — es posible que te la pida de nuevo si la app se reinicia. Si olvidas esta contraseña, no hay forma de recuperarla ni de recuperar los secretos que protege.",
+  },
 };
 
 export default componentsEs;

--- a/client/src/components/pages/Onboarding/Onboarding.jsx
+++ b/client/src/components/pages/Onboarding/Onboarding.jsx
@@ -45,7 +45,11 @@ const STEP_VALIDATORS = {
     onboardingData.walletBackend !== "nwc" ||
     (Boolean(onboardingData.nwcUri) && NWC_URI_REGEX.test(onboardingData.nwcUri))
   ),
-  5: (onboardingData) => !onboardingData.activateSecretsEncryption || Boolean(onboardingData.secretsUnlockPassword),
+  5: (onboardingData) => (
+    !onboardingData.activateSecretsEncryption ||
+    (Boolean(onboardingData.secretsUnlockPassword) &&
+      onboardingData.secretsUnlockPassword === onboardingData.secretsUnlockPasswordConfirmation)
+  ),
 };
 
 export function Onboarding() {
@@ -62,6 +66,7 @@ export function Onboarding() {
     phoenixdPassword: "",
     activateSecretsEncryption: false,
     secretsUnlockPassword: "",
+    secretsUnlockPasswordConfirmation: "",
     userName: "",
     userPassword: "",
     userPasswordConfirmation: "",
@@ -222,6 +227,7 @@ export function Onboarding() {
                 secretsEncryptionData={{
                   activateSecretsEncryption: onboardingData.activateSecretsEncryption,
                   secretsUnlockPassword: onboardingData.secretsUnlockPassword,
+                  secretsUnlockPasswordConfirmation: onboardingData.secretsUnlockPasswordConfirmation,
                 }}
                 onChange={(updatedSecretsEncryptionFields) => handleOnboardingDataChange(updatedSecretsEncryptionFields)}
               />

--- a/client/src/components/pages/Onboarding/Onboarding.jsx
+++ b/client/src/components/pages/Onboarding/Onboarding.jsx
@@ -1,39 +1,58 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 
-import { Button, Divider, addToast } from "@heroui/react";
+import { Button, Divider } from "@heroui/react";
 import { useTranslations } from "next-intl";
 
 import { parseJsonResponse } from "@/lib/http";
-import { useUpload } from "@components/hooks/useUpload";
 import { LanguageSwitcher } from "@i18n/I18nProvider";
-import { getInitialSetupStatus, submitInitialSetup } from "@services/initialSetupService";
+import { getInitialSetupStatus } from "@services/initialSetupService";
 
 import { BusinessDetailsStep } from "./AddBusinessData";
 import { UserAccountStep } from "./AddUserAccount";
+import { useOnboardingSubmit } from "./hooks/useOnboardingSubmit";
 import { RestoreFromBackupStep } from "./RestoreFromBackup";
+import { SecretsEncryptionStep } from "./SecretsEncryptionStep";
 import { BusinessTypeStep } from "./SelectBusiness";
 import { WizardSummary } from "./StepsSummary";
 import { WalletBackendStep } from "./WalletBackendStep";
 
-const TOAST_REDIRECT_TIMEOUT_MS = 3000;
+const NWC_URI_REGEX = /^nostr\+walletconnect:\/\/[0-9a-f]{64}\?/;
 
-function addRedirectToast(toastProps) {
-  addToast({
-    ...toastProps,
-    timeout: TOAST_REDIRECT_TIMEOUT_MS,
-    shouldShowTimeoutProgress: true,
-  });
+function isPasswordStrong(password) {
+  return /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[\W_]).{8,}$/.test(password);
 }
+
+function isPinValid(pin) {
+  return /^\d{4}$/.test(pin);
+}
+
+const STEP_VALIDATORS = {
+  1: (onboardingData) => Boolean(onboardingData.businessType),
+  2: (onboardingData) => (
+    Boolean(onboardingData.userName) &&
+    Boolean(onboardingData.userPassword) &&
+    Boolean(onboardingData.userPasswordConfirmation) &&
+    onboardingData.userPassword === onboardingData.userPasswordConfirmation &&
+    isPasswordStrong(onboardingData.userPassword) &&
+    isPinValid(onboardingData.userPin)
+  ),
+  3: (onboardingData) => (
+    Boolean(onboardingData.businessName) && Boolean(onboardingData.businessCurrency) && Boolean(onboardingData.timezone)
+  ),
+  4: (onboardingData) => (
+    onboardingData.walletBackend !== "nwc" ||
+    (Boolean(onboardingData.nwcUri) && NWC_URI_REGEX.test(onboardingData.nwcUri))
+  ),
+  5: (onboardingData) => !onboardingData.activateSecretsEncryption || Boolean(onboardingData.secretsUnlockPassword),
+};
 
 export function Onboarding() {
   const onboardingTranslations = useTranslations();
   const [step, setStep] = useState(1);
   const [activeView, setActiveView] = useState("setup");
   const [setupStatus, setSetupStatus] = useState(null);
-  const [isSubmittingSetup, setIsSubmittingSetup] = useState(false);
-  const isSubmittingSetupRef = useRef(false);
   const [onboardingData, setOnboardingData] = useState({
     businessType: "store",
     walletBackend: "phoenixd",
@@ -41,6 +60,8 @@ export function Onboarding() {
     phoenixdRemote: false,
     phoenixdUrl: "",
     phoenixdPassword: "",
+    activateSecretsEncryption: false,
+    secretsUnlockPassword: "",
     userName: "",
     userPassword: "",
     userPasswordConfirmation: "",
@@ -54,8 +75,8 @@ export function Onboarding() {
     timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
     businessLogo: null,
   });
-  const { upload } = useUpload();
   const needsBusinessType = setupStatus?.needsBusinessType === true;
+  const { handleComplete, isSubmittingSetup } = useOnboardingSubmit({ onboardingData, needsBusinessType });
 
   useEffect(() => {
     let isMounted = true;
@@ -80,18 +101,8 @@ export function Onboarding() {
     };
   }, []);
 
-  function isPasswordStrong(password) {
-    return /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[\W_]).{8,}$/.test(password);
-  }
-
-  function isPinValid(pin) {
-    return /^\d{4}$/.test(pin);
-  }
-
-  const NWC_URI_REGEX = /^nostr\+walletconnect:\/\/[0-9a-f]{64}\?/;
-
   const handleNext = () => {
-    if (step < 5) {
+    if (step < 6) {
       setStep(step + 1);
     }
   };
@@ -106,104 +117,9 @@ export function Onboarding() {
     setOnboardingData((previousOnboardingData) => ({ ...previousOnboardingData, ...updatedOnboardingFields }));
   };
 
-  const handleComplete = async () => {
-    if (isSubmittingSetupRef.current) return;
-    isSubmittingSetupRef.current = true;
-    setIsSubmittingSetup(true);
-
-    try {
-      if (needsBusinessType) {
-        await submitInitialSetup({
-          businessType: onboardingData.businessType,
-        });
-        addRedirectToast({
-          title: onboardingTranslations("submitOnboardingToast.title"),
-          description: onboardingTranslations("submitOnboardingToast.description"),
-          color: "success",
-          onClose: () => window.location.reload(),
-        });
-        return;
-      }
-
-      let logoUrl = null;
-      if (onboardingData.businessLogo) {
-        const [uploaded] = await upload([onboardingData.businessLogo]);
-        logoUrl = uploaded?.url ?? uploaded?.path;
-      }
-
-      const isPhoenixdRemoteAttempt = onboardingData.walletBackend === "phoenixd" && Boolean(onboardingData.phoenixdRemote);
-
-      const setupResponse = await submitInitialSetup({
-        ...onboardingData,
-        businessLogoUrl: logoUrl,
-        businessLogo: undefined,
-        userPasswordConfirmation: undefined,
-        walletBackend: undefined,
-        nwcUri: onboardingData.walletBackend === "nwc" && onboardingData.nwcUri ? onboardingData.nwcUri : undefined,
-        phoenixdRemote: isPhoenixdRemoteAttempt ? true : undefined,
-        phoenixdUrl: isPhoenixdRemoteAttempt ? onboardingData.phoenixdUrl : undefined,
-        phoenixdPassword: isPhoenixdRemoteAttempt ? onboardingData.phoenixdPassword : undefined,
-      });
-
-      const isNwcAttempt = onboardingData.walletBackend === "nwc";
-      let nwcSaved = false;
-      let phoenixdRemoteSaved = false;
-      try {
-        const setupResponseBody = await setupResponse.json();
-        nwcSaved = Boolean(setupResponseBody?.nwcSaved);
-        phoenixdRemoteSaved = Boolean(setupResponseBody?.phoenixdRemoteSaved);
-      } catch {}
-
-      addRedirectToast({
-        title: onboardingTranslations("submitOnboardingToast.title"),
-        description: onboardingTranslations("submitOnboardingToast.description"),
-        color: "success",
-        onClose: (isNwcAttempt || isPhoenixdRemoteAttempt) ? undefined : () => window.location.reload(),
-      });
-
-      if (nwcSaved) {
-        addRedirectToast({
-          title: onboardingTranslations("submitOnboardingToast.nwcSavedTitle"),
-          description: onboardingTranslations("submitOnboardingToast.nwcSavedDescription"),
-          color: "primary",
-          onClose: () => window.location.reload(),
-        });
-      } else if (isNwcAttempt) {
-        addRedirectToast({
-          title: onboardingTranslations("submitOnboardingToast.nwcErrorTitle"),
-          description: onboardingTranslations("submitOnboardingToast.nwcErrorDescription"),
-          color: "danger",
-          onClose: () => window.location.reload(),
-        });
-      } else if (phoenixdRemoteSaved) {
-        addRedirectToast({
-          title: onboardingTranslations("submitOnboardingToast.phoenixdRemoteSavedTitle"),
-          description: onboardingTranslations("submitOnboardingToast.phoenixdRemoteSavedDescription"),
-          color: "primary",
-          onClose: () => window.location.reload(),
-        });
-      } else if (isPhoenixdRemoteAttempt) {
-        addRedirectToast({
-          title: onboardingTranslations("submitOnboardingToast.phoenixdRemoteErrorTitle"),
-          description: onboardingTranslations("submitOnboardingToast.phoenixdRemoteErrorDescription"),
-          color: "danger",
-          onClose: () => window.location.reload(),
-        });
-      }
-    } catch (setupSubmissionError) {
-      addToast({
-        title: onboardingTranslations("submitOnboardingToast.errorTitle"),
-        description: setupSubmissionError.message,
-        color: "danger",
-      });
-    } finally {
-      isSubmittingSetupRef.current = false;
-      setIsSubmittingSetup(false);
-    }
-  };
-
-  const totalSteps = needsBusinessType ? 1 : 5;
+  const totalSteps = needsBusinessType ? 1 : 6;
   const progressValue = totalSteps === 1 ? 100 : ((step - 1) / (totalSteps - 1)) * 100;
+  const isCurrentStepValid = STEP_VALIDATORS[step]?.(onboardingData) ?? true;
 
   return (
     <div className="flex flex-col items-center justify-start min-h-screen gradient-fresh px-4 pb-4 pt-4">
@@ -227,7 +143,7 @@ export function Onboarding() {
                   className="absolute top-1/2 -translate-y-1/2 h-2 md:h-3 rounded-full bg-green-800 z-0 transition-all duration-300 left-0"
                   style={{ width: `${progressValue}%` }}
                 />
-                {[1, 2, 3, 4, 5].map((stepNumber) => (
+                {[1, 2, 3, 4, 5, 6].map((stepNumber) => (
                   <div
                     key={stepNumber}
                     className={`relative z-10 flex items-center justify-center w-8 h-8 md:w-10 md:h-10 rounded-full text-sm md:text-base font-semibold transition-all ${stepNumber <= step ? "bg-green-800 text-white" : "bg-gray-300 text-gray-500"}`}
@@ -301,7 +217,17 @@ export function Onboarding() {
               />
               )}
 
-              {step === 5 && <WizardSummary onboardingData={onboardingData} onEdit={(stepNum) => setStep(stepNum)} />}
+              {step === 5 && (
+              <SecretsEncryptionStep
+                secretsEncryptionData={{
+                  activateSecretsEncryption: onboardingData.activateSecretsEncryption,
+                  secretsUnlockPassword: onboardingData.secretsUnlockPassword,
+                }}
+                onChange={(updatedSecretsEncryptionFields) => handleOnboardingDataChange(updatedSecretsEncryptionFields)}
+              />
+              )}
+
+              {step === 6 && <WizardSummary onboardingData={onboardingData} onEdit={(stepNum) => setStep(stepNum)} />}
 
               <Divider className="hidden md:block my-8 bg-gray-400" />
 
@@ -327,23 +253,11 @@ export function Onboarding() {
                     >
                       {onboardingTranslations("buttons.finish")}
                     </Button>
-                  ) : step < 5 ? (
+                  ) : step < 6 ? (
                     <Button
                       color="primary"
                       onPress={handleNext}
-                      isDisabled={
-                    (step === 1 && !onboardingData.businessType) ||
-                    (step === 2 && (
-                      !onboardingData.userName ||
-                      !onboardingData.userPassword ||
-                      !onboardingData.userPasswordConfirmation ||
-                      onboardingData.userPassword !== onboardingData.userPasswordConfirmation ||
-                      !isPasswordStrong(onboardingData.userPassword) ||
-                      !isPinValid(onboardingData.userPin)
-                    )) ||
-                    (step === 3 && (!onboardingData.businessName || !onboardingData.businessCurrency || !onboardingData.timezone)) ||
-                    (step === 4 && onboardingData.walletBackend === "nwc" && (!onboardingData.nwcUri || !NWC_URI_REGEX.test(onboardingData.nwcUri)))
-                  }
+                      isDisabled={!isCurrentStepValid}
                       className="bg-green-800"
                     >
                       {onboardingTranslations("buttons.next")}

--- a/client/src/components/pages/Onboarding/SecretsEncryptionStep.jsx
+++ b/client/src/components/pages/Onboarding/SecretsEncryptionStep.jsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { Checkbox } from "@heroui/react";
+import { useTranslations } from "next-intl";
+
+import { SecretsUnlockPasswordField } from "@components/shared/SecretsUnlockPasswordField";
+
+export function SecretsEncryptionStep({ secretsEncryptionData, onChange }) {
+  const secretsEncryptionTranslations = useTranslations();
+
+  const handleActivateToggle = (activateSecretsEncryption) => {
+    onChange({
+      activateSecretsEncryption,
+      secretsUnlockPassword: activateSecretsEncryption ? secretsEncryptionData.secretsUnlockPassword : "",
+    });
+  };
+
+  return (
+    <div>
+      <h2 className="text-xl md:text-2xl font-bold text-green-900 mb-2">
+        {secretsEncryptionTranslations("stepSecretsEncryption.title")}
+      </h2>
+      <p className="text-gray-500 mb-4 md:mb-8">{secretsEncryptionTranslations("stepSecretsEncryption.subtitle")}</p>
+
+      <Checkbox isSelected={Boolean(secretsEncryptionData.activateSecretsEncryption)} onValueChange={handleActivateToggle}>
+        {secretsEncryptionTranslations("stepSecretsEncryption.activateLabel")}
+      </Checkbox>
+
+      {secretsEncryptionData.activateSecretsEncryption && (
+        <div className="mt-4 space-y-2">
+          <SecretsUnlockPasswordField
+            unlockPassword={secretsEncryptionData.secretsUnlockPassword || ""}
+            onUnlockPasswordChange={(secretsUnlockPassword) => onChange({ secretsUnlockPassword })}
+          />
+          <p className="text-xs text-gray-400">{secretsEncryptionTranslations("stepSecretsEncryption.laterHint")}</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/pages/Onboarding/SecretsEncryptionStep.jsx
+++ b/client/src/components/pages/Onboarding/SecretsEncryptionStep.jsx
@@ -12,6 +12,9 @@ export function SecretsEncryptionStep({ secretsEncryptionData, onChange }) {
     onChange({
       activateSecretsEncryption,
       secretsUnlockPassword: activateSecretsEncryption ? secretsEncryptionData.secretsUnlockPassword : "",
+      secretsUnlockPasswordConfirmation: activateSecretsEncryption
+        ? secretsEncryptionData.secretsUnlockPasswordConfirmation
+        : "",
     });
   };
 
@@ -31,6 +34,10 @@ export function SecretsEncryptionStep({ secretsEncryptionData, onChange }) {
           <SecretsUnlockPasswordField
             unlockPassword={secretsEncryptionData.secretsUnlockPassword || ""}
             onUnlockPasswordChange={(secretsUnlockPassword) => onChange({ secretsUnlockPassword })}
+            unlockPasswordConfirmation={secretsEncryptionData.secretsUnlockPasswordConfirmation || ""}
+            onUnlockPasswordConfirmationChange={(secretsUnlockPasswordConfirmation) => (
+              onChange({ secretsUnlockPasswordConfirmation })
+            )}
           />
           <p className="text-xs text-gray-400">{secretsEncryptionTranslations("stepSecretsEncryption.laterHint")}</p>
         </div>

--- a/client/src/components/pages/Onboarding/StepsSummary.jsx
+++ b/client/src/components/pages/Onboarding/StepsSummary.jsx
@@ -68,6 +68,20 @@ export function WizardSummary({ onboardingData, onEdit }) {
         <Card>
           <CardHeader className="flex justify-between items-start">
             <div className="flex flex-col">
+              <p className="text-xs font-medium text-muted-foreground uppercase">{summaryTranslations("step4.sections.secretsEncryption.title")}</p>
+              <p className="text-md font-semibold text-foreground mt-1">
+                {onboardingData.activateSecretsEncryption
+                  ? summaryTranslations("step4.sections.secretsEncryption.active")
+                  : summaryTranslations("step4.sections.secretsEncryption.inactive")}
+              </p>
+            </div>
+            <EditButton onPress={() => onEdit(5)}>{summaryTranslations("buttons.edit")}</EditButton>
+          </CardHeader>
+        </Card>
+
+        <Card>
+          <CardHeader className="flex justify-between items-start">
+            <div className="flex flex-col">
               <p className="text-xs font-medium text-muted-foreground uppercase">{summaryTranslations("step4.sections.businessDetails.title")}</p>
               <div className="mt-3 space-y-2">
                 <div>

--- a/client/src/components/pages/Onboarding/__tests__/Onboarding.test.jsx
+++ b/client/src/components/pages/Onboarding/__tests__/Onboarding.test.jsx
@@ -1,9 +1,8 @@
-import { addToast } from "@heroui/react";
 import { render, screen, fireEvent, act, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { I18nProvider } from "@/i18n/I18nProvider";
-import { submitInitialSetup } from "@services/initialSetupService";
+import { getInitialSetupStatus } from "@services/initialSetupService";
 
 import { Onboarding } from "../Onboarding";
 
@@ -13,10 +12,25 @@ jest.mock("@heroui/react", () => ({
 }));
 
 jest.mock("@services/initialSetupService", () => ({
-  getInitialSetupStatus: jest.fn(() => Promise.resolve({ initialized: false, needsBusinessType: false })),
-  submitInitialSetup: jest.fn(() => Promise.resolve({})),
+  getInitialSetupStatus: jest.fn(() => (
+    Promise.resolve({ status: 200, text: () => Promise.resolve(JSON.stringify({ initialized: false, needsBusinessType: false })) })
+  )),
   restoreFromBackup: jest.fn(),
 }));
+
+const mockHandleComplete = jest.fn();
+let mockIsSubmittingSetup = false;
+
+jest.mock("../hooks/useOnboardingSubmit", () => ({
+  useOnboardingSubmit: () => ({
+    handleComplete: mockHandleComplete,
+    isSubmittingSetup: mockIsSubmittingSetup,
+  }),
+}));
+
+function makeStatusResponse(statusBody) {
+  return { status: 200, text: () => Promise.resolve(JSON.stringify(statusBody)) };
+}
 
 function renderOnboarding() {
   return render(
@@ -34,9 +48,7 @@ async function navigateToStep(button, targetStep) {
   }
 }
 
-const validNwcUri = `nostr+walletconnect://${"a".repeat(64)}?relay=wss://relay.test&secret=${"b".repeat(64)}`;
-
-async function completeOnboardingWithNwcUri(user, nwcUri) {
+async function navigateToWalletBackendStep() {
   await act(async () => {
     fireEvent.click(screen.getByText("buttons.next"));
   });
@@ -53,85 +65,25 @@ async function completeOnboardingWithNwcUri(user, nwcUri) {
 
   await act(async () => {
     fireEvent.change(screen.getByPlaceholderText("step3.fields.businessNamePlaceholder"), { target: { value: "My Business" } });
-  });
-  await act(async () => {
-    fireEvent.click(screen.getByText("buttons.next"));
-  });
-
-  await user.click(screen.getByText("stepWallet.nwcName"));
-  await act(async () => {
-    fireEvent.change(screen.getByPlaceholderText("nostr+walletconnect://..."), {
-      target: { value: nwcUri },
-    });
-  });
-  await act(async () => {
-    fireEvent.click(screen.getByText("buttons.next"));
-  });
-
-  await act(async () => {
-    fireEvent.click(screen.getByText("buttons.finish"));
-  });
-}
-
-async function completeOnboardingWithPhoenixd() {
-  await act(async () => {
-    fireEvent.click(screen.getByText("buttons.next"));
-  });
-
-  await act(async () => {
-    fireEvent.change(screen.getByPlaceholderText("step2.fields.userNamePlaceholder"), { target: { value: "testuser" } });
-    fireEvent.change(screen.getByPlaceholderText("step2.fields.userPinPlaceholder"), { target: { value: "0000" } });
-    fireEvent.change(screen.getByPlaceholderText("step2.fields.passwordPlaceholder"), { target: { value: "Abcd123$" } });
-    fireEvent.change(screen.getByPlaceholderText("step2.fields.confirmPasswordPlaceholder"), { target: { value: "Abcd123$" } });
-  });
-  await act(async () => {
-    fireEvent.click(screen.getByText("buttons.next"));
-  });
-
-  await act(async () => {
-    fireEvent.change(screen.getByPlaceholderText("step3.fields.businessNamePlaceholder"), { target: { value: "My Business" } });
-  });
-  await act(async () => {
-    fireEvent.click(screen.getByText("buttons.next"));
   });
   await act(async () => {
     fireEvent.click(screen.getByText("buttons.next"));
   });
 }
 
-async function completeOnboardingWithPhoenixdRemote(user, phoenixdUrl, phoenixdPassword) {
+async function navigateToSecretsEncryptionStep() {
+  await navigateToWalletBackendStep();
+
   await act(async () => {
     fireEvent.click(screen.getByText("buttons.next"));
   });
+}
 
-  await act(async () => {
-    fireEvent.change(screen.getByPlaceholderText("step2.fields.userNamePlaceholder"), { target: { value: "testuser" } });
-    fireEvent.change(screen.getByPlaceholderText("step2.fields.userPinPlaceholder"), { target: { value: "0000" } });
-    fireEvent.change(screen.getByPlaceholderText("step2.fields.passwordPlaceholder"), { target: { value: "Abcd123$" } });
-    fireEvent.change(screen.getByPlaceholderText("step2.fields.confirmPasswordPlaceholder"), { target: { value: "Abcd123$" } });
-  });
+async function navigateToSummary() {
+  await navigateToSecretsEncryptionStep();
+
   await act(async () => {
     fireEvent.click(screen.getByText("buttons.next"));
-  });
-
-  await act(async () => {
-    fireEvent.change(screen.getByPlaceholderText("step3.fields.businessNamePlaceholder"), { target: { value: "My Business" } });
-  });
-  await act(async () => {
-    fireEvent.click(screen.getByText("buttons.next"));
-  });
-
-  await user.click(screen.getByLabelText("remoteToggleLabel"));
-  await act(async () => {
-    fireEvent.change(screen.getByPlaceholderText("http://100.x.x.x:9740"), { target: { value: phoenixdUrl } });
-    fireEvent.change(screen.getByLabelText("passwordLabel"), { target: { value: phoenixdPassword } });
-  });
-  await act(async () => {
-    fireEvent.click(screen.getByText("buttons.next"));
-  });
-
-  await act(async () => {
-    fireEvent.click(screen.getByText("buttons.finish"));
   });
 }
 
@@ -158,6 +110,11 @@ beforeAll(() => {
     }
     originalWarn.call(console, ...args);
   };
+});
+
+afterEach(() => {
+  mockHandleComplete.mockClear();
+  mockIsSubmittingSetup = false;
 });
 
 describe("Onboarding Wizard", () => {
@@ -416,125 +373,6 @@ describe("Onboarding Wizard", () => {
     expect(nextButton).not.toBeDisabled();
   });
 
-  describe("NWC onboarding result toast", () => {
-    it("shows the NWC activated toast when the backend connects successfully", async () => {
-      submitInitialSetup.mockResolvedValueOnce({
-        json: () => Promise.resolve({ nwcSaved: true }),
-      });
-      const user = userEvent.setup();
-
-      await act(async () => {
-        renderOnboarding();
-      });
-
-      await completeOnboardingWithNwcUri(user, validNwcUri);
-
-      await waitFor(() => {
-        expect(addToast).toHaveBeenCalledWith(
-          expect.objectContaining({ title: "submitOnboardingToast.nwcSavedTitle", color: "primary" }),
-        );
-      });
-    });
-
-    it("shows an error toast when the NWC backend could not be connected", async () => {
-      submitInitialSetup.mockResolvedValueOnce({
-        json: () => Promise.resolve({ nwcSaved: false }),
-      });
-      const user = userEvent.setup();
-
-      await act(async () => {
-        renderOnboarding();
-      });
-
-      await completeOnboardingWithNwcUri(user, validNwcUri);
-
-      await waitFor(() => {
-        expect(addToast).toHaveBeenCalledWith(
-          expect.objectContaining({ title: "submitOnboardingToast.nwcErrorTitle", color: "danger" }),
-        );
-      });
-    });
-  });
-
-  describe("phoenixd remote onboarding result toast", () => {
-    it("shows the phoenixd remote activated toast when the backend connects successfully", async () => {
-      submitInitialSetup.mockResolvedValueOnce({
-        json: () => Promise.resolve({ phoenixdRemoteSaved: true }),
-      });
-      const user = userEvent.setup();
-
-      await act(async () => {
-        renderOnboarding();
-      });
-
-      await completeOnboardingWithPhoenixdRemote(user, "http://100.1.1.1:9740", "remote-password");
-
-      await waitFor(() => {
-        expect(addToast).toHaveBeenCalledWith(
-          expect.objectContaining({ title: "submitOnboardingToast.phoenixdRemoteSavedTitle", color: "primary" }),
-        );
-      });
-    });
-
-    it("shows an error toast when the remote phoenixd node could not be connected", async () => {
-      submitInitialSetup.mockResolvedValueOnce({
-        json: () => Promise.resolve({ phoenixdRemoteSaved: false }),
-      });
-      const user = userEvent.setup();
-
-      await act(async () => {
-        renderOnboarding();
-      });
-
-      await completeOnboardingWithPhoenixdRemote(user, "http://100.1.1.1:9740", "remote-password");
-
-      await waitFor(() => {
-        expect(addToast).toHaveBeenCalledWith(
-          expect.objectContaining({ title: "submitOnboardingToast.phoenixdRemoteErrorTitle", color: "danger" }),
-        );
-      });
-    });
-
-    it("sends the phoenixd remote fields in the setup payload", async () => {
-      const user = userEvent.setup();
-
-      await act(async () => {
-        renderOnboarding();
-      });
-
-      await completeOnboardingWithPhoenixdRemote(user, "http://100.1.1.1:9740", "remote-password");
-
-      await waitFor(() => {
-        expect(submitInitialSetup).toHaveBeenCalledWith(
-          expect.objectContaining({
-            phoenixdRemote: true,
-            phoenixdUrl: "http://100.1.1.1:9740",
-            phoenixdPassword: "remote-password",
-          }),
-        );
-      });
-    });
-  });
-
-  describe("timezone", () => {
-    it("sends the browser-detected timezone in the setup payload", async () => {
-      await act(async () => {
-        renderOnboarding();
-      });
-      await completeOnboardingWithPhoenixd();
-
-      await act(async () => {
-        fireEvent.click(screen.getByText("buttons.finish"));
-      });
-
-      await waitFor(() => {
-        expect(submitInitialSetup).toHaveBeenCalledWith(
-          expect.objectContaining({ timezone: Intl.DateTimeFormat().resolvedOptions().timeZone }),
-        );
-      });
-    });
-  });
-
   describe("Restore from backup", () => {
     it("shows the restore toggle link on the first step when setup is not initialized", async () => {
       await act(async () => {
@@ -574,51 +412,81 @@ describe("Onboarding Wizard", () => {
     });
   });
 
-  describe("setup submit feedback", () => {
-    it("shows a localized error toast when setup submission fails", async () => {
-      submitInitialSetup.mockRejectedValueOnce(new Error("Server unavailable"));
-
+  describe("submitting the wizard", () => {
+    it("calls handleComplete when Finish is pressed", async () => {
       await act(async () => {
         renderOnboarding();
       });
-      await completeOnboardingWithPhoenixd();
+      await navigateToSummary();
 
       await act(async () => {
         fireEvent.click(screen.getByText("buttons.finish"));
       });
 
-      expect(addToast).toHaveBeenCalledWith(
-        expect.objectContaining({
-          title: "submitOnboardingToast.errorTitle",
-          description: "Server unavailable",
-          color: "danger",
-        }),
-      );
+      expect(mockHandleComplete).toHaveBeenCalledTimes(1);
     });
 
-    it("prevents duplicate setup submissions while finish is pending", async () => {
-      let resolveSetupSubmission;
-      submitInitialSetup.mockImplementationOnce(() => new Promise((resolveSetup) => {
-        resolveSetupSubmission = resolveSetup;
-      }));
+    it("disables and shows loading on Finish while isSubmittingSetup is true", async () => {
+      mockIsSubmittingSetup = true;
 
       await act(async () => {
         renderOnboarding();
       });
-      await completeOnboardingWithPhoenixd();
-      submitInitialSetup.mockClear();
+      await navigateToSummary();
 
-      const finishButton = screen.getByText("buttons.finish");
-      await act(async () => {
-        fireEvent.click(finishButton);
-        fireEvent.click(finishButton);
-      });
+      expect(screen.getByText("buttons.finish").closest("button")).toBeDisabled();
+    });
 
-      expect(submitInitialSetup).toHaveBeenCalledTimes(1);
+    it("calls handleComplete when Finish is pressed for a business-type-only setup", async () => {
+      getInitialSetupStatus.mockResolvedValueOnce(makeStatusResponse({ initialized: false, needsBusinessType: true }));
 
       await act(async () => {
-        resolveSetupSubmission({});
+        renderOnboarding();
       });
+
+      await act(async () => {
+        fireEvent.click(screen.getByLabelText("store"));
+      });
+      await act(async () => {
+        fireEvent.click(screen.getByText("buttons.finish"));
+      });
+
+      expect(mockHandleComplete).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("secrets encryption onboarding step", () => {
+    it("shows the secrets encryption step between the wallet backend step and the summary", async () => {
+      await act(async () => {
+        renderOnboarding();
+      });
+
+      await navigateToSecretsEncryptionStep();
+
+      expect(screen.getByText("stepSecretsEncryption.title")).toBeInTheDocument();
+    });
+
+    it("reaches the summary as not activated when the admin leaves the checkbox unchecked", async () => {
+      await act(async () => {
+        renderOnboarding();
+      });
+
+      await navigateToSummary();
+
+      expect(screen.getByText("step4.sections.secretsEncryption.inactive")).toBeInTheDocument();
+    });
+
+    it("disables the Next button when the checkbox is checked but no password was entered", async () => {
+      const user = userEvent.setup();
+
+      await act(async () => {
+        renderOnboarding();
+      });
+
+      await navigateToSecretsEncryptionStep();
+      await user.click(screen.getByRole("checkbox"));
+
+      expect(screen.getByText("buttons.next")).toBeDisabled();
     });
   });
 });

--- a/client/src/components/pages/Onboarding/__tests__/Onboarding.test.jsx
+++ b/client/src/components/pages/Onboarding/__tests__/Onboarding.test.jsx
@@ -488,5 +488,41 @@ describe("Onboarding Wizard", () => {
 
       expect(screen.getByText("buttons.next")).toBeDisabled();
     });
+
+    it("keeps the Next button disabled when the passwords don't match", async () => {
+      const user = userEvent.setup();
+
+      await act(async () => {
+        renderOnboarding();
+      });
+
+      await navigateToSecretsEncryptionStep();
+      await user.click(screen.getByRole("checkbox"));
+
+      await act(async () => {
+        fireEvent.change(screen.getByLabelText("passwordLabel"), { target: { value: "correct-unlock-password" } });
+        fireEvent.change(screen.getByLabelText("confirmPasswordLabel"), { target: { value: "different-password" } });
+      });
+
+      expect(screen.getByText("buttons.next")).toBeDisabled();
+    });
+
+    it("enables the Next button when both passwords match", async () => {
+      const user = userEvent.setup();
+
+      await act(async () => {
+        renderOnboarding();
+      });
+
+      await navigateToSecretsEncryptionStep();
+      await user.click(screen.getByRole("checkbox"));
+
+      await act(async () => {
+        fireEvent.change(screen.getByLabelText("passwordLabel"), { target: { value: "correct-unlock-password" } });
+        fireEvent.change(screen.getByLabelText("confirmPasswordLabel"), { target: { value: "correct-unlock-password" } });
+      });
+
+      expect(screen.getByText("buttons.next")).not.toBeDisabled();
+    });
   });
 });

--- a/client/src/components/pages/Onboarding/__tests__/SecretsEncryptionStep.test.jsx
+++ b/client/src/components/pages/Onboarding/__tests__/SecretsEncryptionStep.test.jsx
@@ -20,18 +20,24 @@ let mockSecretsUnlockPasswordFieldProps = null;
 jest.mock("@components/shared/SecretsUnlockPasswordField", () => ({
   SecretsUnlockPasswordField: (props) => {
     mockSecretsUnlockPasswordFieldProps = props;
-    const { unlockPassword, onUnlockPasswordChange } = props;
+    const { unlockPassword, onUnlockPasswordChange, unlockPasswordConfirmation, onUnlockPasswordConfirmationChange } = props;
     return (
       <div data-testid="secrets-unlock-password-field">
         <span data-testid="unlock-password-value">{unlockPassword}</span>
+        <span data-testid="confirm-unlock-password-value">{unlockPasswordConfirmation}</span>
         <button type="button" onClick={() => onUnlockPasswordChange("new-unlock-password")}>set-unlock-password</button>
+        <button type="button" onClick={() => onUnlockPasswordConfirmationChange("new-unlock-password")}>set-confirm-unlock-password</button>
       </div>
     );
   },
 }));
 
 function renderStep(secretsEncryptionData = {}, onChange = jest.fn()) {
-  const defaultSecretsEncryptionData = { activateSecretsEncryption: false, secretsUnlockPassword: "" };
+  const defaultSecretsEncryptionData = {
+    activateSecretsEncryption: false,
+    secretsUnlockPassword: "",
+    secretsUnlockPasswordConfirmation: "",
+  };
   return {
     onChange,
     ...render(
@@ -68,20 +74,32 @@ describe("SecretsEncryptionStep", () => {
     expect(screen.getByText("stepSecretsEncryption.laterHint")).toBeInTheDocument();
   });
 
-  it("checking the checkbox with no prior password calls onChange with an empty password", () => {
+  it("checking the checkbox with no prior password calls onChange with empty passwords", () => {
     const { onChange } = renderStep({ activateSecretsEncryption: false, secretsUnlockPassword: "" });
 
     fireEvent.click(screen.getByRole("checkbox"));
 
-    expect(onChange).toHaveBeenCalledWith({ activateSecretsEncryption: true, secretsUnlockPassword: "" });
+    expect(onChange).toHaveBeenCalledWith({
+      activateSecretsEncryption: true,
+      secretsUnlockPassword: "",
+      secretsUnlockPasswordConfirmation: "",
+    });
   });
 
-  it("unchecking the checkbox clears the password", () => {
-    const { onChange } = renderStep({ activateSecretsEncryption: true, secretsUnlockPassword: "correct-unlock-password" });
+  it("unchecking the checkbox clears both passwords", () => {
+    const { onChange } = renderStep({
+      activateSecretsEncryption: true,
+      secretsUnlockPassword: "correct-unlock-password",
+      secretsUnlockPasswordConfirmation: "correct-unlock-password",
+    });
 
     fireEvent.click(screen.getByRole("checkbox"));
 
-    expect(onChange).toHaveBeenCalledWith({ activateSecretsEncryption: false, secretsUnlockPassword: "" });
+    expect(onChange).toHaveBeenCalledWith({
+      activateSecretsEncryption: false,
+      secretsUnlockPassword: "",
+      secretsUnlockPasswordConfirmation: "",
+    });
   });
 
   it("forwards the shared field's onUnlockPasswordChange as only the password change", () => {
@@ -92,9 +110,23 @@ describe("SecretsEncryptionStep", () => {
     expect(onChange).toHaveBeenCalledWith({ secretsUnlockPassword: "new-unlock-password" });
   });
 
+  it("forwards the shared field's onUnlockPasswordConfirmationChange as only the confirmation change", () => {
+    const { onChange } = renderStep({ activateSecretsEncryption: true, secretsUnlockPasswordConfirmation: "" });
+
+    fireEvent.click(screen.getByText("set-confirm-unlock-password"));
+
+    expect(onChange).toHaveBeenCalledWith({ secretsUnlockPasswordConfirmation: "new-unlock-password" });
+  });
+
   it("passes the current password down to the shared field via unlockPassword", () => {
     renderStep({ activateSecretsEncryption: true, secretsUnlockPassword: "correct-unlock-password" });
 
     expect(mockSecretsUnlockPasswordFieldProps.unlockPassword).toBe("correct-unlock-password");
+  });
+
+  it("passes the current confirmation down to the shared field via unlockPasswordConfirmation", () => {
+    renderStep({ activateSecretsEncryption: true, secretsUnlockPasswordConfirmation: "correct-unlock-password" });
+
+    expect(mockSecretsUnlockPasswordFieldProps.unlockPasswordConfirmation).toBe("correct-unlock-password");
   });
 });

--- a/client/src/components/pages/Onboarding/__tests__/SecretsEncryptionStep.test.jsx
+++ b/client/src/components/pages/Onboarding/__tests__/SecretsEncryptionStep.test.jsx
@@ -1,0 +1,100 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+
+import { SecretsEncryptionStep } from "../SecretsEncryptionStep";
+
+jest.mock("@heroui/react", () => ({
+  Checkbox: ({ children, isSelected, onValueChange }) => (
+    <label>
+      <input
+        type="checkbox"
+        checked={isSelected}
+        onChange={(event) => onValueChange(event.target.checked)}
+      />
+      {children}
+    </label>
+  ),
+}));
+
+let mockSecretsUnlockPasswordFieldProps = null;
+
+jest.mock("@components/shared/SecretsUnlockPasswordField", () => ({
+  SecretsUnlockPasswordField: (props) => {
+    mockSecretsUnlockPasswordFieldProps = props;
+    const { unlockPassword, onUnlockPasswordChange } = props;
+    return (
+      <div data-testid="secrets-unlock-password-field">
+        <span data-testid="unlock-password-value">{unlockPassword}</span>
+        <button type="button" onClick={() => onUnlockPasswordChange("new-unlock-password")}>set-unlock-password</button>
+      </div>
+    );
+  },
+}));
+
+function renderStep(secretsEncryptionData = {}, onChange = jest.fn()) {
+  const defaultSecretsEncryptionData = { activateSecretsEncryption: false, secretsUnlockPassword: "" };
+  return {
+    onChange,
+    ...render(
+      <SecretsEncryptionStep
+        secretsEncryptionData={{ ...defaultSecretsEncryptionData, ...secretsEncryptionData }}
+        onChange={onChange}
+      />,
+    ),
+  };
+}
+
+describe("SecretsEncryptionStep", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    mockSecretsUnlockPasswordFieldProps = null;
+  });
+
+  it("renders unchecked and without the password field by default", () => {
+    renderStep();
+
+    expect(screen.getByRole("checkbox")).not.toBeChecked();
+    expect(screen.queryByTestId("secrets-unlock-password-field")).not.toBeInTheDocument();
+  });
+
+  it("shows the shared password field with the current value when already checked", () => {
+    renderStep({ activateSecretsEncryption: true, secretsUnlockPassword: "correct-unlock-password" });
+
+    expect(screen.getByTestId("unlock-password-value").textContent).toBe("correct-unlock-password");
+  });
+
+  it("shows the later-hint text when already checked", () => {
+    renderStep({ activateSecretsEncryption: true, secretsUnlockPassword: "" });
+
+    expect(screen.getByText("stepSecretsEncryption.laterHint")).toBeInTheDocument();
+  });
+
+  it("checking the checkbox with no prior password calls onChange with an empty password", () => {
+    const { onChange } = renderStep({ activateSecretsEncryption: false, secretsUnlockPassword: "" });
+
+    fireEvent.click(screen.getByRole("checkbox"));
+
+    expect(onChange).toHaveBeenCalledWith({ activateSecretsEncryption: true, secretsUnlockPassword: "" });
+  });
+
+  it("unchecking the checkbox clears the password", () => {
+    const { onChange } = renderStep({ activateSecretsEncryption: true, secretsUnlockPassword: "correct-unlock-password" });
+
+    fireEvent.click(screen.getByRole("checkbox"));
+
+    expect(onChange).toHaveBeenCalledWith({ activateSecretsEncryption: false, secretsUnlockPassword: "" });
+  });
+
+  it("forwards the shared field's onUnlockPasswordChange as only the password change", () => {
+    const { onChange } = renderStep({ activateSecretsEncryption: true, secretsUnlockPassword: "" });
+
+    fireEvent.click(screen.getByText("set-unlock-password"));
+
+    expect(onChange).toHaveBeenCalledWith({ secretsUnlockPassword: "new-unlock-password" });
+  });
+
+  it("passes the current password down to the shared field via unlockPassword", () => {
+    renderStep({ activateSecretsEncryption: true, secretsUnlockPassword: "correct-unlock-password" });
+
+    expect(mockSecretsUnlockPasswordFieldProps.unlockPassword).toBe("correct-unlock-password");
+  });
+});

--- a/client/src/components/pages/Onboarding/__tests__/StepsSummary.test.jsx
+++ b/client/src/components/pages/Onboarding/__tests__/StepsSummary.test.jsx
@@ -56,6 +56,9 @@ describe("Step 4 Summary", () => {
 
     await act(async () => fireEvent.click(buttons[2]));
     expect(mockOnEdit).toHaveBeenCalledWith(3);
+
+    await act(async () => fireEvent.click(buttons[3]));
+    expect(mockOnEdit).toHaveBeenCalledWith(5);
   });
 
   it("shows masked password correctly", async () => {
@@ -91,6 +94,26 @@ describe("Step 4 Summary", () => {
     });
 
     expect(screen.queryByText("step4.sections.walletBackend.phoenixdRemote")).not.toBeInTheDocument();
+  });
+
+  it("shows secrets encryption as active when the admin chose to activate it", async () => {
+    const dataWithSecretsEncryption = { ...baseData, activateSecretsEncryption: true };
+
+    await act(async () => {
+      render(<WizardSummary onboardingData={dataWithSecretsEncryption} onEdit={mockOnEdit} />);
+    });
+
+    expect(screen.getByText("step4.sections.secretsEncryption.active")).toBeInTheDocument();
+    expect(screen.queryByText("step4.sections.secretsEncryption.inactive")).not.toBeInTheDocument();
+  });
+
+  it("shows secrets encryption as inactive when the admin did not activate it", async () => {
+    await act(async () => {
+      render(<WizardSummary onboardingData={baseData} onEdit={mockOnEdit} />);
+    });
+
+    expect(screen.getByText("step4.sections.secretsEncryption.inactive")).toBeInTheDocument();
+    expect(screen.queryByText("step4.sections.secretsEncryption.active")).not.toBeInTheDocument();
   });
 
   it("renders the store logo if provided", async () => {

--- a/client/src/components/pages/Onboarding/hooks/__tests__/useOnboardingSubmit.test.js
+++ b/client/src/components/pages/Onboarding/hooks/__tests__/useOnboardingSubmit.test.js
@@ -120,6 +120,7 @@ describe("useOnboardingSubmit", () => {
           walletBackend: undefined,
           activateSecretsEncryption: undefined,
           secretsUnlockPassword: undefined,
+          secretsUnlockPasswordConfirmation: undefined,
           timezone: "America/Mexico_City",
         }),
       );

--- a/client/src/components/pages/Onboarding/hooks/__tests__/useOnboardingSubmit.test.js
+++ b/client/src/components/pages/Onboarding/hooks/__tests__/useOnboardingSubmit.test.js
@@ -1,6 +1,7 @@
 import { addToast } from "@heroui/react";
 import { renderHook, act } from "@testing-library/react";
 
+import { authenticateUser, logoutSession } from "@/lib/auth/authSession";
 import { activateSecretsEncryption } from "@/services/secretsService";
 import { loginWallet, logoutWallet } from "@/services/walletService";
 import { submitInitialSetup } from "@services/initialSetupService";
@@ -19,6 +20,11 @@ jest.mock("next-intl", () => ({
 
 jest.mock("@services/initialSetupService", () => ({
   submitInitialSetup: jest.fn(),
+}));
+
+jest.mock("@/lib/auth/authSession", () => ({
+  authenticateUser: jest.fn(),
+  logoutSession: jest.fn(),
 }));
 
 jest.mock("@/services/secretsService", () => ({
@@ -73,9 +79,11 @@ function renderOnboardingSubmit(onboardingDataOverrides = {}, needsBusinessType 
 beforeEach(() => {
   jest.clearAllMocks();
   submitInitialSetup.mockResolvedValue(makeSetupResponse());
+  authenticateUser.mockResolvedValue({ user: { id: "user-1" }, permissions: [] });
   activateSecretsEncryption.mockResolvedValue({ message: "Secrets encryption activated" });
   loginWallet.mockResolvedValue({ token: "wallet-token" });
   logoutWallet.mockResolvedValue(null);
+  logoutSession.mockResolvedValue(null);
   mockUpload.mockResolvedValue([{ url: "https://uploads.test/logo.png" }]);
 });
 
@@ -280,7 +288,29 @@ describe("useOnboardingSubmit", () => {
   });
 
   describe("secrets encryption activation", () => {
-    it("logs into the wallet, activates encryption with the chosen password, then logs out", async () => {
+    it("authenticates a regular session, logs into the wallet, activates encryption, then logs out of both sessions in order", async () => {
+      const callOrder = [];
+      authenticateUser.mockImplementationOnce(async () => {
+        callOrder.push("authenticateUser");
+        return { user: { id: "user-1" }, permissions: [] };
+      });
+      loginWallet.mockImplementationOnce(async () => {
+        callOrder.push("loginWallet");
+        return { token: "wallet-token" };
+      });
+      activateSecretsEncryption.mockImplementationOnce(async () => {
+        callOrder.push("activateSecretsEncryption");
+        return { message: "Secrets encryption activated" };
+      });
+      logoutWallet.mockImplementationOnce(async () => {
+        callOrder.push("logoutWallet");
+        return null;
+      });
+      logoutSession.mockImplementationOnce(async () => {
+        callOrder.push("logoutSession");
+        return null;
+      });
+
       const { result: submitHook } = renderOnboardingSubmit({
         activateSecretsEncryption: true,
         secretsUnlockPassword: "correct-unlock-password",
@@ -290,9 +320,17 @@ describe("useOnboardingSubmit", () => {
         await submitHook.current.handleComplete();
       });
 
+      expect(authenticateUser).toHaveBeenCalledWith({ name: "testuser", pin: "0000", skipRefresh: true });
       expect(loginWallet).toHaveBeenCalledWith("Abcd123$");
       expect(activateSecretsEncryption).toHaveBeenCalledWith("correct-unlock-password");
-      expect(logoutWallet).toHaveBeenCalledTimes(1);
+      expect(logoutSession).toHaveBeenCalledWith({ skipRefresh: true });
+      expect(callOrder).toEqual([
+        "authenticateUser",
+        "loginWallet",
+        "activateSecretsEncryption",
+        "logoutWallet",
+        "logoutSession",
+      ]);
     });
 
     it("does not attempt activation when the admin did not opt in", async () => {
@@ -302,12 +340,34 @@ describe("useOnboardingSubmit", () => {
         await submitHook.current.handleComplete();
       });
 
+      expect(authenticateUser).not.toHaveBeenCalled();
       expect(loginWallet).not.toHaveBeenCalled();
       expect(activateSecretsEncryption).not.toHaveBeenCalled();
       expect(logoutWallet).not.toHaveBeenCalled();
+      expect(logoutSession).not.toHaveBeenCalled();
     });
 
-    it("shows an error toast and still logs out of the wallet when activation fails", async () => {
+    it("shows an error toast and still logs out of both sessions when authentication fails", async () => {
+      authenticateUser.mockRejectedValueOnce(new Error("Invalid credentials"));
+      const { result: submitHook } = renderOnboardingSubmit({
+        activateSecretsEncryption: true,
+        secretsUnlockPassword: "correct-unlock-password",
+      });
+
+      await act(async () => {
+        await submitHook.current.handleComplete();
+      });
+
+      expect(loginWallet).not.toHaveBeenCalled();
+      expect(activateSecretsEncryption).not.toHaveBeenCalled();
+      expect(addToast).toHaveBeenCalledWith(
+        expect.objectContaining({ color: "danger", description: "Invalid credentials" }),
+      );
+      expect(logoutWallet).toHaveBeenCalledTimes(1);
+      expect(logoutSession).toHaveBeenCalledWith({ skipRefresh: true });
+    });
+
+    it("shows an error toast and still logs out of both sessions when activation fails", async () => {
       activateSecretsEncryption.mockRejectedValueOnce(new Error("Could not reach the server"));
       const { result: submitHook } = renderOnboardingSubmit({
         activateSecretsEncryption: true,
@@ -322,6 +382,7 @@ describe("useOnboardingSubmit", () => {
         expect.objectContaining({ color: "danger", description: "Could not reach the server" }),
       );
       expect(logoutWallet).toHaveBeenCalledTimes(1);
+      expect(logoutSession).toHaveBeenCalledWith({ skipRefresh: true });
     });
 
     it("falls back to the translated message when the activation error has none", async () => {

--- a/client/src/components/pages/Onboarding/hooks/__tests__/useOnboardingSubmit.test.js
+++ b/client/src/components/pages/Onboarding/hooks/__tests__/useOnboardingSubmit.test.js
@@ -1,0 +1,406 @@
+import { addToast } from "@heroui/react";
+import { renderHook, act } from "@testing-library/react";
+
+import { activateSecretsEncryption } from "@/services/secretsService";
+import { loginWallet, logoutWallet } from "@/services/walletService";
+import { submitInitialSetup } from "@services/initialSetupService";
+
+import { useOnboardingSubmit } from "../useOnboardingSubmit";
+
+const mockUpload = jest.fn();
+
+jest.mock("@heroui/react", () => ({
+  addToast: jest.fn(),
+}));
+
+jest.mock("next-intl", () => ({
+  useTranslations: () => (translationKey) => translationKey,
+}));
+
+jest.mock("@services/initialSetupService", () => ({
+  submitInitialSetup: jest.fn(),
+}));
+
+jest.mock("@/services/secretsService", () => ({
+  activateSecretsEncryption: jest.fn(),
+}));
+
+jest.mock("@/services/walletService", () => ({
+  loginWallet: jest.fn(),
+  logoutWallet: jest.fn(),
+}));
+
+jest.mock("@components/hooks/useUpload", () => ({
+  useUpload: () => ({ upload: mockUpload }),
+}));
+
+function makeSetupResponse(setupResponseBody = {}) {
+  return { json: () => Promise.resolve(setupResponseBody) };
+}
+
+const defaultOnboardingData = {
+  businessType: "store",
+  walletBackend: "phoenixd",
+  nwcUri: "",
+  phoenixdRemote: false,
+  phoenixdUrl: "",
+  phoenixdPassword: "",
+  activateSecretsEncryption: false,
+  secretsUnlockPassword: "",
+  userName: "testuser",
+  userPassword: "Abcd123$",
+  userPasswordConfirmation: "Abcd123$",
+  userPin: "0000",
+  businessName: "My Business",
+  businessAddress: "",
+  businessPhone: "",
+  businessEmail: "",
+  businessRFC: "",
+  businessCurrency: "USD",
+  timezone: "America/Mexico_City",
+  businessLogo: null,
+};
+
+function renderOnboardingSubmit(onboardingDataOverrides = {}, needsBusinessType = false) {
+  return renderHook(() => (
+    useOnboardingSubmit({
+      onboardingData: { ...defaultOnboardingData, ...onboardingDataOverrides },
+      needsBusinessType,
+    })
+  ));
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  submitInitialSetup.mockResolvedValue(makeSetupResponse());
+  activateSecretsEncryption.mockResolvedValue({ message: "Secrets encryption activated" });
+  loginWallet.mockResolvedValue({ token: "wallet-token" });
+  logoutWallet.mockResolvedValue(null);
+  mockUpload.mockResolvedValue([{ url: "https://uploads.test/logo.png" }]);
+});
+
+describe("useOnboardingSubmit", () => {
+  describe("needsBusinessType only", () => {
+    it("submits only the business type and skips the rest of the pipeline", async () => {
+      const { result: submitHook } = renderOnboardingSubmit({}, true);
+
+      await act(async () => {
+        await submitHook.current.handleComplete();
+      });
+
+      expect(submitInitialSetup).toHaveBeenCalledWith({ businessType: "store" });
+      expect(submitInitialSetup).toHaveBeenCalledTimes(1);
+      expect(loginWallet).not.toHaveBeenCalled();
+      expect(addToast).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "submitOnboardingToast.title", color: "success" }),
+      );
+    });
+  });
+
+  describe("payload building", () => {
+    it("excludes internal-only fields and sends the browser-detected timezone", async () => {
+      const { result: submitHook } = renderOnboardingSubmit();
+
+      await act(async () => {
+        await submitHook.current.handleComplete();
+      });
+
+      expect(submitInitialSetup).toHaveBeenCalledWith(
+        expect.objectContaining({
+          businessLogo: undefined,
+          userPasswordConfirmation: undefined,
+          walletBackend: undefined,
+          activateSecretsEncryption: undefined,
+          secretsUnlockPassword: undefined,
+          timezone: "America/Mexico_City",
+        }),
+      );
+      expect(mockUpload).not.toHaveBeenCalled();
+    });
+
+    it("does not send wallet-backend-specific fields for the default local phoenixd backend", async () => {
+      const { result: submitHook } = renderOnboardingSubmit();
+
+      await act(async () => {
+        await submitHook.current.handleComplete();
+      });
+
+      expect(submitInitialSetup).toHaveBeenCalledWith(
+        expect.objectContaining({
+          nwcUri: undefined,
+          phoenixdRemote: undefined,
+          phoenixdUrl: undefined,
+          phoenixdPassword: undefined,
+        }),
+      );
+    });
+
+    it("uploads the business logo and sends its URL", async () => {
+      const businessLogo = new File(["fake"], "logo.png", { type: "image/png" });
+      const { result: submitHook } = renderOnboardingSubmit({ businessLogo });
+
+      await act(async () => {
+        await submitHook.current.handleComplete();
+      });
+
+      expect(mockUpload).toHaveBeenCalledWith([businessLogo]);
+      expect(submitInitialSetup).toHaveBeenCalledWith(
+        expect.objectContaining({ businessLogoUrl: "https://uploads.test/logo.png" }),
+      );
+    });
+
+    it("sends the NWC URI only when the wallet backend is nwc", async () => {
+      const { result: submitHook } = renderOnboardingSubmit({
+        walletBackend: "nwc",
+        nwcUri: "nostr+walletconnect://abc",
+      });
+
+      await act(async () => {
+        await submitHook.current.handleComplete();
+      });
+
+      expect(submitInitialSetup).toHaveBeenCalledWith(
+        expect.objectContaining({ nwcUri: "nostr+walletconnect://abc" }),
+      );
+    });
+
+    it("sends the phoenixd remote fields only when a remote node was attempted", async () => {
+      const { result: submitHook } = renderOnboardingSubmit({
+        phoenixdRemote: true,
+        phoenixdUrl: "http://100.1.1.1:9740",
+        phoenixdPassword: "remote-password",
+      });
+
+      await act(async () => {
+        await submitHook.current.handleComplete();
+      });
+
+      expect(submitInitialSetup).toHaveBeenCalledWith(
+        expect.objectContaining({
+          phoenixdRemote: true,
+          phoenixdUrl: "http://100.1.1.1:9740",
+          phoenixdPassword: "remote-password",
+        }),
+      );
+    });
+  });
+
+  describe("response body parsing", () => {
+    it("still completes successfully when the setup response body is not valid JSON", async () => {
+      submitInitialSetup.mockResolvedValueOnce({ json: () => Promise.reject(new Error("invalid json")) });
+      const { result: submitHook } = renderOnboardingSubmit();
+
+      await act(async () => {
+        await submitHook.current.handleComplete();
+      });
+
+      expect(addToast).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "submitOnboardingToast.title", color: "success" }),
+      );
+    });
+  });
+
+  describe("NWC onboarding result toast", () => {
+    it("shows the NWC activated toast, deferring the reload to it instead of the generic success toast", async () => {
+      submitInitialSetup.mockResolvedValueOnce(makeSetupResponse({ nwcSaved: true }));
+      const { result: submitHook } = renderOnboardingSubmit({
+        walletBackend: "nwc",
+        nwcUri: "nostr+walletconnect://abc",
+      });
+
+      await act(async () => {
+        await submitHook.current.handleComplete();
+      });
+
+      expect(addToast).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({ title: "submitOnboardingToast.title", onClose: undefined }),
+      );
+      expect(addToast).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          title: "submitOnboardingToast.nwcSavedTitle",
+          color: "primary",
+          onClose: expect.any(Function),
+        }),
+      );
+    });
+
+    it("shows an error toast when the NWC backend could not be connected", async () => {
+      submitInitialSetup.mockResolvedValueOnce(makeSetupResponse({ nwcSaved: false }));
+      const { result: submitHook } = renderOnboardingSubmit({
+        walletBackend: "nwc",
+        nwcUri: "nostr+walletconnect://abc",
+      });
+
+      await act(async () => {
+        await submitHook.current.handleComplete();
+      });
+
+      expect(addToast).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "submitOnboardingToast.nwcErrorTitle", color: "danger" }),
+      );
+    });
+  });
+
+  describe("phoenixd remote onboarding result toast", () => {
+    it("shows the phoenixd remote activated toast when the backend connects successfully", async () => {
+      submitInitialSetup.mockResolvedValueOnce(makeSetupResponse({ phoenixdRemoteSaved: true }));
+      const { result: submitHook } = renderOnboardingSubmit({
+        phoenixdRemote: true,
+        phoenixdUrl: "http://100.1.1.1:9740",
+        phoenixdPassword: "remote-password",
+      });
+
+      await act(async () => {
+        await submitHook.current.handleComplete();
+      });
+
+      expect(addToast).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "submitOnboardingToast.phoenixdRemoteSavedTitle", color: "primary" }),
+      );
+    });
+
+    it("shows an error toast when the remote phoenixd node could not be connected", async () => {
+      submitInitialSetup.mockResolvedValueOnce(makeSetupResponse({ phoenixdRemoteSaved: false }));
+      const { result: submitHook } = renderOnboardingSubmit({
+        phoenixdRemote: true,
+        phoenixdUrl: "http://100.1.1.1:9740",
+        phoenixdPassword: "remote-password",
+      });
+
+      await act(async () => {
+        await submitHook.current.handleComplete();
+      });
+
+      expect(addToast).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "submitOnboardingToast.phoenixdRemoteErrorTitle", color: "danger" }),
+      );
+    });
+  });
+
+  describe("secrets encryption activation", () => {
+    it("logs into the wallet, activates encryption with the chosen password, then logs out", async () => {
+      const { result: submitHook } = renderOnboardingSubmit({
+        activateSecretsEncryption: true,
+        secretsUnlockPassword: "correct-unlock-password",
+      });
+
+      await act(async () => {
+        await submitHook.current.handleComplete();
+      });
+
+      expect(loginWallet).toHaveBeenCalledWith("Abcd123$");
+      expect(activateSecretsEncryption).toHaveBeenCalledWith("correct-unlock-password");
+      expect(logoutWallet).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not attempt activation when the admin did not opt in", async () => {
+      const { result: submitHook } = renderOnboardingSubmit();
+
+      await act(async () => {
+        await submitHook.current.handleComplete();
+      });
+
+      expect(loginWallet).not.toHaveBeenCalled();
+      expect(activateSecretsEncryption).not.toHaveBeenCalled();
+      expect(logoutWallet).not.toHaveBeenCalled();
+    });
+
+    it("shows an error toast and still logs out of the wallet when activation fails", async () => {
+      activateSecretsEncryption.mockRejectedValueOnce(new Error("Could not reach the server"));
+      const { result: submitHook } = renderOnboardingSubmit({
+        activateSecretsEncryption: true,
+        secretsUnlockPassword: "correct-unlock-password",
+      });
+
+      await act(async () => {
+        await submitHook.current.handleComplete();
+      });
+
+      expect(addToast).toHaveBeenCalledWith(
+        expect.objectContaining({ color: "danger", description: "Could not reach the server" }),
+      );
+      expect(logoutWallet).toHaveBeenCalledTimes(1);
+    });
+
+    it("falls back to the translated message when the activation error has none", async () => {
+      activateSecretsEncryption.mockRejectedValueOnce(new Error());
+      const { result: submitHook } = renderOnboardingSubmit({
+        activateSecretsEncryption: true,
+        secretsUnlockPassword: "correct-unlock-password",
+      });
+
+      await act(async () => {
+        await submitHook.current.handleComplete();
+      });
+
+      expect(addToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          color: "danger",
+          description: "submitOnboardingToast.secretsEncryptionErrorDescription",
+        }),
+      );
+    });
+  });
+
+  describe("setup submit feedback", () => {
+    it("shows a localized error toast when setup submission fails", async () => {
+      submitInitialSetup.mockRejectedValueOnce(new Error("Server unavailable"));
+      const { result: submitHook } = renderOnboardingSubmit();
+
+      await act(async () => {
+        await submitHook.current.handleComplete();
+      });
+
+      expect(addToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "submitOnboardingToast.errorTitle",
+          description: "Server unavailable",
+          color: "danger",
+        }),
+      );
+    });
+
+    it("prevents duplicate submissions while one is already in flight", async () => {
+      let resolveSetupSubmission;
+      submitInitialSetup.mockImplementationOnce(() => new Promise((resolveSetup) => {
+        resolveSetupSubmission = resolveSetup;
+      }));
+      const { result: submitHook } = renderOnboardingSubmit();
+
+      let firstSubmission;
+      await act(async () => {
+        firstSubmission = submitHook.current.handleComplete();
+        await submitHook.current.handleComplete();
+      });
+
+      expect(submitInitialSetup).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        resolveSetupSubmission(makeSetupResponse());
+        await firstSubmission;
+      });
+    });
+
+    it("exposes isSubmittingSetup as true only while a submission is in flight", async () => {
+      let resolveSetupSubmission;
+      submitInitialSetup.mockImplementationOnce(() => new Promise((resolveSetup) => {
+        resolveSetupSubmission = resolveSetup;
+      }));
+      const { result: submitHook } = renderOnboardingSubmit();
+
+      let submission;
+      act(() => {
+        submission = submitHook.current.handleComplete();
+      });
+      expect(submitHook.current.isSubmittingSetup).toBe(true);
+
+      await act(async () => {
+        resolveSetupSubmission(makeSetupResponse());
+        await submission;
+      });
+      expect(submitHook.current.isSubmittingSetup).toBe(false);
+    });
+  });
+});

--- a/client/src/components/pages/Onboarding/hooks/useOnboardingSubmit.js
+++ b/client/src/components/pages/Onboarding/hooks/useOnboardingSubmit.js
@@ -1,0 +1,171 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+
+import { addToast } from "@heroui/react";
+import { useTranslations } from "next-intl";
+
+import { activateSecretsEncryption } from "@/services/secretsService";
+import { loginWallet, logoutWallet } from "@/services/walletService";
+import { useUpload } from "@components/hooks/useUpload";
+import { submitInitialSetup } from "@services/initialSetupService";
+
+const TOAST_REDIRECT_TIMEOUT_MS = 3000;
+
+function addRedirectToast(toastProps) {
+  addToast({
+    ...toastProps,
+    timeout: TOAST_REDIRECT_TIMEOUT_MS,
+    shouldShowTimeoutProgress: true,
+  });
+}
+
+function buildInitialSetupPayload(onboardingData, { businessLogoUrl, isPhoenixdRemoteAttempt }) {
+  return {
+    ...onboardingData,
+    businessLogoUrl,
+    businessLogo: undefined,
+    userPasswordConfirmation: undefined,
+    walletBackend: undefined,
+    activateSecretsEncryption: undefined,
+    secretsUnlockPassword: undefined,
+    nwcUri: onboardingData.walletBackend === "nwc" && onboardingData.nwcUri ? onboardingData.nwcUri : undefined,
+    phoenixdRemote: isPhoenixdRemoteAttempt ? true : undefined,
+    phoenixdUrl: isPhoenixdRemoteAttempt ? onboardingData.phoenixdUrl : undefined,
+    phoenixdPassword: isPhoenixdRemoteAttempt ? onboardingData.phoenixdPassword : undefined,
+  };
+}
+
+async function activateSecretsEncryptionAfterSetup({ userPassword, secretsUnlockPassword, onboardingTranslations }) {
+  try {
+    await loginWallet(userPassword);
+    await activateSecretsEncryption(secretsUnlockPassword);
+  } catch (secretsEncryptionActivationError) {
+    addToast({
+      color: "danger",
+      description:
+        secretsEncryptionActivationError.message ||
+        onboardingTranslations("submitOnboardingToast.secretsEncryptionErrorDescription"),
+    });
+  } finally {
+    await logoutWallet().catch(() => {});
+  }
+}
+
+function getWalletBackendActivationToastProps(
+  { nwcSaved, isNwcAttempt, phoenixdRemoteSaved, isPhoenixdRemoteAttempt },
+  onboardingTranslations,
+) {
+  if (nwcSaved) {
+    return {
+      title: onboardingTranslations("submitOnboardingToast.nwcSavedTitle"),
+      description: onboardingTranslations("submitOnboardingToast.nwcSavedDescription"),
+      color: "primary",
+    };
+  }
+  if (isNwcAttempt) {
+    return {
+      title: onboardingTranslations("submitOnboardingToast.nwcErrorTitle"),
+      description: onboardingTranslations("submitOnboardingToast.nwcErrorDescription"),
+      color: "danger",
+    };
+  }
+  if (phoenixdRemoteSaved) {
+    return {
+      title: onboardingTranslations("submitOnboardingToast.phoenixdRemoteSavedTitle"),
+      description: onboardingTranslations("submitOnboardingToast.phoenixdRemoteSavedDescription"),
+      color: "primary",
+    };
+  }
+  if (isPhoenixdRemoteAttempt) {
+    return {
+      title: onboardingTranslations("submitOnboardingToast.phoenixdRemoteErrorTitle"),
+      description: onboardingTranslations("submitOnboardingToast.phoenixdRemoteErrorDescription"),
+      color: "danger",
+    };
+  }
+  return null;
+}
+
+export function useOnboardingSubmit({ onboardingData, needsBusinessType }) {
+  const onboardingTranslations = useTranslations();
+  const { upload } = useUpload();
+  const [isSubmittingSetup, setIsSubmittingSetup] = useState(false);
+  const isSubmittingSetupRef = useRef(false);
+
+  const handleComplete = useCallback(async () => {
+    if (isSubmittingSetupRef.current) return;
+    isSubmittingSetupRef.current = true;
+    setIsSubmittingSetup(true);
+
+    try {
+      if (needsBusinessType) {
+        await submitInitialSetup({
+          businessType: onboardingData.businessType,
+        });
+        addRedirectToast({
+          title: onboardingTranslations("submitOnboardingToast.title"),
+          description: onboardingTranslations("submitOnboardingToast.description"),
+          color: "success",
+          onClose: () => window.location.reload(),
+        });
+        return;
+      }
+
+      let businessLogoUrl = null;
+      if (onboardingData.businessLogo) {
+        const [uploaded] = await upload([onboardingData.businessLogo]);
+        businessLogoUrl = uploaded?.url ?? uploaded?.path;
+      }
+
+      const isPhoenixdRemoteAttempt = onboardingData.walletBackend === "phoenixd" && Boolean(onboardingData.phoenixdRemote);
+
+      const setupResponse = await submitInitialSetup(
+        buildInitialSetupPayload(onboardingData, { businessLogoUrl, isPhoenixdRemoteAttempt }),
+      );
+
+      const isNwcAttempt = onboardingData.walletBackend === "nwc";
+      let nwcSaved = false;
+      let phoenixdRemoteSaved = false;
+      try {
+        const setupResponseBody = await setupResponse.json();
+        nwcSaved = Boolean(setupResponseBody?.nwcSaved);
+        phoenixdRemoteSaved = Boolean(setupResponseBody?.phoenixdRemoteSaved);
+      } catch {}
+
+      if (onboardingData.activateSecretsEncryption) {
+        await activateSecretsEncryptionAfterSetup({
+          userPassword: onboardingData.userPassword,
+          secretsUnlockPassword: onboardingData.secretsUnlockPassword,
+          onboardingTranslations,
+        });
+      }
+
+      addRedirectToast({
+        title: onboardingTranslations("submitOnboardingToast.title"),
+        description: onboardingTranslations("submitOnboardingToast.description"),
+        color: "success",
+        onClose: (isNwcAttempt || isPhoenixdRemoteAttempt) ? undefined : () => window.location.reload(),
+      });
+
+      const walletBackendActivationToastProps = getWalletBackendActivationToastProps(
+        { nwcSaved, isNwcAttempt, phoenixdRemoteSaved, isPhoenixdRemoteAttempt },
+        onboardingTranslations,
+      );
+      if (walletBackendActivationToastProps) {
+        addRedirectToast({ ...walletBackendActivationToastProps, onClose: () => window.location.reload() });
+      }
+    } catch (setupSubmissionError) {
+      addToast({
+        title: onboardingTranslations("submitOnboardingToast.errorTitle"),
+        description: setupSubmissionError.message,
+        color: "danger",
+      });
+    } finally {
+      isSubmittingSetupRef.current = false;
+      setIsSubmittingSetup(false);
+    }
+  }, [needsBusinessType, onboardingData, onboardingTranslations, upload]);
+
+  return { handleComplete, isSubmittingSetup };
+}

--- a/client/src/components/pages/Onboarding/hooks/useOnboardingSubmit.js
+++ b/client/src/components/pages/Onboarding/hooks/useOnboardingSubmit.js
@@ -30,6 +30,7 @@ function buildInitialSetupPayload(onboardingData, { businessLogoUrl, isPhoenixdR
     walletBackend: undefined,
     activateSecretsEncryption: undefined,
     secretsUnlockPassword: undefined,
+    secretsUnlockPasswordConfirmation: undefined,
     nwcUri: onboardingData.walletBackend === "nwc" && onboardingData.nwcUri ? onboardingData.nwcUri : undefined,
     phoenixdRemote: isPhoenixdRemoteAttempt ? true : undefined,
     phoenixdUrl: isPhoenixdRemoteAttempt ? onboardingData.phoenixdUrl : undefined,

--- a/client/src/components/pages/Onboarding/hooks/useOnboardingSubmit.js
+++ b/client/src/components/pages/Onboarding/hooks/useOnboardingSubmit.js
@@ -5,6 +5,7 @@ import { useCallback, useRef, useState } from "react";
 import { addToast } from "@heroui/react";
 import { useTranslations } from "next-intl";
 
+import { authenticateUser, logoutSession } from "@/lib/auth/authSession";
 import { activateSecretsEncryption } from "@/services/secretsService";
 import { loginWallet, logoutWallet } from "@/services/walletService";
 import { useUpload } from "@components/hooks/useUpload";
@@ -36,19 +37,27 @@ function buildInitialSetupPayload(onboardingData, { businessLogoUrl, isPhoenixdR
   };
 }
 
-async function activateSecretsEncryptionAfterSetup({ userPassword, secretsUnlockPassword, onboardingTranslations }) {
+async function activateSecretsEncryptionAfterSetup({
+  userName,
+  userPin,
+  userPassword,
+  secretsUnlockPassword,
+  onboardingTranslations,
+}) {
   try {
+    await authenticateUser({ name: userName, pin: userPin, skipRefresh: true });
     await loginWallet(userPassword);
     await activateSecretsEncryption(secretsUnlockPassword);
-  } catch (secretsEncryptionActivationError) {
+  } catch (secretsEncryptionSetupError) {
     addToast({
       color: "danger",
       description:
-        secretsEncryptionActivationError.message ||
+        secretsEncryptionSetupError.message ||
         onboardingTranslations("submitOnboardingToast.secretsEncryptionErrorDescription"),
     });
   } finally {
     await logoutWallet().catch(() => {});
+    await logoutSession({ skipRefresh: true }).catch(() => {});
   }
 }
 
@@ -135,6 +144,8 @@ export function useOnboardingSubmit({ onboardingData, needsBusinessType }) {
 
       if (onboardingData.activateSecretsEncryption) {
         await activateSecretsEncryptionAfterSetup({
+          userName: onboardingData.userName,
+          userPin: onboardingData.userPin,
           userPassword: onboardingData.userPassword,
           secretsUnlockPassword: onboardingData.secretsUnlockPassword,
           onboardingTranslations,

--- a/client/src/components/pages/Onboarding/locales/en.js
+++ b/client/src/components/pages/Onboarding/locales/en.js
@@ -11,6 +11,7 @@ const onboardingEn = {
     phoenixdRemoteErrorDescription: "Check the URL and password — you'll need to redo the initial setup to try again.",
     nwcErrorTitle: "Could not connect the NWC wallet",
     nwcErrorDescription: "Check the connection URI — you'll need to redo the initial setup to try again.",
+    secretsEncryptionErrorDescription: "Could not activate secrets encryption. You can retry from Settings.",
   },
   buttons: {
     next: "Next",
@@ -98,6 +99,12 @@ const onboardingEn = {
     uriHint: "The URI will be saved to ambrosia.conf and the NWC backend will be activated immediately.",
     uriInvalid: "Invalid NWC URI format",
   },
+  stepSecretsEncryption: {
+    title: "Extra security for your wallet connection",
+    subtitle: "Optionally protect your Lightning connection details with a password",
+    activateLabel: "Encrypt phoenixd password, NWC connection, and notification key with a password",
+    laterHint: "You can also set this up later from Settings.",
+  },
   restore: {
     toggleLink: "Restoring from a previous backup?",
     title: "Restore from backup",
@@ -133,6 +140,11 @@ const onboardingEn = {
         title: "Admin account",
         userName: "User Name",
         password: "Password",
+      },
+      secretsEncryption: {
+        title: "Secrets encryption",
+        active: "Will be activated",
+        inactive: "Not activated",
       },
       businessDetails: {
         title: "Business details",

--- a/client/src/components/pages/Onboarding/locales/es.js
+++ b/client/src/components/pages/Onboarding/locales/es.js
@@ -11,6 +11,7 @@ const onboardingEs = {
     phoenixdRemoteSavedDescription: "El backend está conectado al nodo remoto y listo para usarse.",
     phoenixdRemoteErrorTitle: "No se pudo conectar al nodo phoenixd remoto",
     phoenixdRemoteErrorDescription: "Revisa la URL y el password — vas a tener que rehacer la configuración inicial para volver a intentarlo.",
+    secretsEncryptionErrorDescription: "No se pudo activar el cifrado de secretos. Puedes volver a intentarlo desde Configuración.",
   },
   buttons: {
     next: "Siguiente",
@@ -99,6 +100,12 @@ const onboardingEs = {
     uriHint: "El URI se guardará en ambrosia.conf y el backend NWC se activará inmediatamente.",
     uriInvalid: "Formato de URI NWC inválido",
   },
+  stepSecretsEncryption: {
+    title: "Seguridad extra para tu conexión de wallet",
+    subtitle: "Protege de forma opcional los datos de tu conexión Lightning con una contraseña",
+    activateLabel: "Cifrar la contraseña de phoenixd, la conexión NWC y la clave de notificaciones con una contraseña",
+    laterHint: "También puedes configurar esto más adelante desde Configuración.",
+  },
   restore: {
     toggleLink: "¿Estás restaurando un respaldo anterior?",
     title: "Restaurar desde respaldo",
@@ -134,6 +141,11 @@ const onboardingEs = {
         title: "Cuenta de administrador",
         userName: "Nombre de usuario",
         password: "Contraseña",
+      },
+      secretsEncryption: {
+        title: "Cifrado de secretos",
+        active: "Se va a activar",
+        inactive: "No activado",
       },
       businessDetails: {
         title: "Detalles del negocio",

--- a/client/src/components/pages/Store/Settings/SecretsEncryption/SecretsEncryptionCard.jsx
+++ b/client/src/components/pages/Store/Settings/SecretsEncryption/SecretsEncryptionCard.jsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useState } from "react";
+
+import { useTranslations } from "next-intl";
+
+import { SecretsEncryptionCardDetails } from "./SecretsEncryptionCardDetails";
+import { SecretsEncryptionCardSummary } from "./SecretsEncryptionCardSummary";
+
+export function SecretsEncryptionCard() {
+  const secretsEncryptionCardTranslations = useTranslations();
+  const [showDetails, setShowDetails] = useState(false);
+
+  const handleHide = () => setShowDetails(false);
+
+  if (showDetails) {
+    return (
+      <SecretsEncryptionCardDetails
+        onHide={handleHide}
+        secretsEncryptionCardTranslations={secretsEncryptionCardTranslations}
+      />
+    );
+  }
+
+  return (
+    <SecretsEncryptionCardSummary
+      onReveal={() => setShowDetails(true)}
+      secretsEncryptionCardTranslations={secretsEncryptionCardTranslations}
+    />
+  );
+}

--- a/client/src/components/pages/Store/Settings/SecretsEncryption/SecretsEncryptionCardDetails.jsx
+++ b/client/src/components/pages/Store/Settings/SecretsEncryption/SecretsEncryptionCardDetails.jsx
@@ -15,6 +15,7 @@ const HIDE_BUTTON_CLASS_NAME = "h-8 min-w-16 px-3 rounded-small sm:h-10 sm:min-w
 export function SecretsEncryptionCardDetails({ onHide, secretsEncryptionCardTranslations }) {
   const [secretsStatus, setSecretsStatus] = useState(null);
   const [unlockPassword, setUnlockPassword] = useState("");
+  const [unlockPasswordConfirmation, setUnlockPasswordConfirmation] = useState("");
   const [submitting, setSubmitting] = useState(false);
 
   const handleAuthorized = async () => {
@@ -36,6 +37,7 @@ export function SecretsEncryptionCardDetails({ onHide, secretsEncryptionCardTran
       addToast({ color: "success", description: secretsEncryptionCardTranslations("secretsEncryptionCard.activateSuccess") });
       setSecretsStatus({ encryptionActive: true, locked: false });
       setUnlockPassword("");
+      setUnlockPasswordConfirmation("");
     } catch (activateSecretsEncryptionError) {
       addToast({
         color: "danger",
@@ -81,7 +83,12 @@ export function SecretsEncryptionCardDetails({ onHide, secretsEncryptionCardTran
           </p>
 
           <RequirePermission allOf={["settings_update"]}>
-            <SecretsUnlockPasswordField unlockPassword={unlockPassword} onUnlockPasswordChange={setUnlockPassword} />
+            <SecretsUnlockPasswordField
+              unlockPassword={unlockPassword}
+              onUnlockPasswordChange={setUnlockPassword}
+              unlockPasswordConfirmation={unlockPasswordConfirmation}
+              onUnlockPasswordConfirmationChange={setUnlockPasswordConfirmation}
+            />
           </RequirePermission>
 
           <div className="flex gap-2">
@@ -89,7 +96,7 @@ export function SecretsEncryptionCardDetails({ onHide, secretsEncryptionCardTran
               <Button
                 color="primary"
                 className={PASSWORD_ACTION_BUTTON_CLASS_NAME}
-                isDisabled={!unlockPassword || submitting}
+                isDisabled={!unlockPassword || unlockPassword !== unlockPasswordConfirmation || submitting}
                 isLoading={submitting}
                 onPress={handleActivate}
               >

--- a/client/src/components/pages/Store/Settings/SecretsEncryption/SecretsEncryptionCardDetails.jsx
+++ b/client/src/components/pages/Store/Settings/SecretsEncryption/SecretsEncryptionCardDetails.jsx
@@ -142,11 +142,9 @@ export function SecretsEncryptionCardDetails({ onHide, secretsEncryptionCardTran
 
     return (
       <div className="flex flex-col gap-4">
-        <div className="flex items-start gap-2 bg-green-50 border border-green-200 rounded-lg p-3">
-          <p className="text-sm text-green-800 font-medium">
-            {secretsEncryptionCardTranslations("secretsEncryptionCard.unlockedDescription")}
-          </p>
-        </div>
+        <p className="text-sm text-green-800 font-medium">
+          {secretsEncryptionCardTranslations("secretsEncryptionCard.unlockedDescription")}
+        </p>
         <div>
           <Button variant="bordered" onPress={onHide} className={HIDE_BUTTON_CLASS_NAME}>
             {secretsEncryptionCardTranslations("secretsEncryptionCard.hideButton")}

--- a/client/src/components/pages/Store/Settings/SecretsEncryption/SecretsEncryptionCardDetails.jsx
+++ b/client/src/components/pages/Store/Settings/SecretsEncryption/SecretsEncryptionCardDetails.jsx
@@ -1,0 +1,178 @@
+"use client";
+
+import { useState } from "react";
+
+import { addToast, Button, Card, CardBody, CardHeader, Input, Spinner } from "@heroui/react";
+
+import { RequirePermission } from "@/hooks/usePermission";
+import { activateSecretsEncryption, getSecretsStatus, unlockSecrets } from "@/services/secretsService";
+import WalletGuard from "@components/auth/WalletGuard";
+import { SecretsUnlockPasswordField } from "@components/shared/SecretsUnlockPasswordField";
+
+const PASSWORD_ACTION_BUTTON_CLASS_NAME = "bg-green-800 h-8 min-w-16 px-3 rounded-small sm:h-10 sm:min-w-20 sm:px-4 sm:rounded-medium";
+const HIDE_BUTTON_CLASS_NAME = "h-8 min-w-16 px-3 rounded-small sm:h-10 sm:min-w-20 sm:px-4 sm:rounded-medium border border-border text-foreground hover:bg-muted transition-colors";
+
+export function SecretsEncryptionCardDetails({ onHide, secretsEncryptionCardTranslations }) {
+  const [secretsStatus, setSecretsStatus] = useState(null);
+  const [unlockPassword, setUnlockPassword] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleAuthorized = async () => {
+    try {
+      const secretsStatusResponse = await getSecretsStatus();
+      setSecretsStatus(secretsStatusResponse);
+    } catch {
+      addToast({
+        color: "danger",
+        description: secretsEncryptionCardTranslations("secretsEncryptionCard.statusLoadError"),
+      });
+    }
+  };
+
+  const handleActivate = async () => {
+    setSubmitting(true);
+    try {
+      await activateSecretsEncryption(unlockPassword);
+      addToast({ color: "success", description: secretsEncryptionCardTranslations("secretsEncryptionCard.activateSuccess") });
+      setSecretsStatus({ encryptionActive: true, locked: false });
+      setUnlockPassword("");
+    } catch (activateSecretsEncryptionError) {
+      addToast({
+        color: "danger",
+        description:
+          activateSecretsEncryptionError.message || secretsEncryptionCardTranslations("secretsEncryptionCard.activateError"),
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleUnlock = async () => {
+    setSubmitting(true);
+    try {
+      await unlockSecrets(unlockPassword);
+      addToast({ color: "success", description: secretsEncryptionCardTranslations("secretsEncryptionCard.unlockSuccess") });
+      setSecretsStatus({ encryptionActive: true, locked: false });
+      setUnlockPassword("");
+    } catch (unlockSecretsError) {
+      addToast({
+        color: "danger",
+        description: unlockSecretsError.message || secretsEncryptionCardTranslations("secretsEncryptionCard.unlockError"),
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const renderStatusDependentContent = () => {
+    if (!secretsStatus) {
+      return (
+        <div className="flex justify-center py-6">
+          <Spinner size="lg" color="success" />
+        </div>
+      );
+    }
+
+    if (!secretsStatus.encryptionActive) {
+      return (
+        <div className="flex flex-col gap-4">
+          <p className="text-sm text-gray-500">
+            {secretsEncryptionCardTranslations("secretsEncryptionCard.inactiveDescription")}
+          </p>
+
+          <RequirePermission allOf={["settings_update"]}>
+            <SecretsUnlockPasswordField unlockPassword={unlockPassword} onUnlockPasswordChange={setUnlockPassword} />
+          </RequirePermission>
+
+          <div className="flex gap-2">
+            <RequirePermission allOf={["settings_update"]}>
+              <Button
+                color="primary"
+                className={PASSWORD_ACTION_BUTTON_CLASS_NAME}
+                isDisabled={!unlockPassword || submitting}
+                isLoading={submitting}
+                onPress={handleActivate}
+              >
+                {secretsEncryptionCardTranslations("secretsEncryptionCard.activateButton")}
+              </Button>
+            </RequirePermission>
+            <Button variant="bordered" isDisabled={submitting} onPress={onHide} className={HIDE_BUTTON_CLASS_NAME}>
+              {secretsEncryptionCardTranslations("secretsEncryptionCard.hideButton")}
+            </Button>
+          </div>
+        </div>
+      );
+    }
+
+    if (secretsStatus.locked) {
+      return (
+        <div className="flex flex-col gap-4">
+          <p className="text-sm text-gray-500">
+            {secretsEncryptionCardTranslations("secretsEncryptionCard.lockedDescription")}
+          </p>
+
+          <RequirePermission allOf={["settings_update"]}>
+            <Input
+              label={secretsEncryptionCardTranslations("secretsEncryptionCard.unlockPasswordLabel")}
+              type="password"
+              value={unlockPassword}
+              onValueChange={setUnlockPassword}
+            />
+          </RequirePermission>
+
+          <div className="flex gap-2">
+            <RequirePermission allOf={["settings_update"]}>
+              <Button
+                color="primary"
+                className={PASSWORD_ACTION_BUTTON_CLASS_NAME}
+                isDisabled={!unlockPassword || submitting}
+                isLoading={submitting}
+                onPress={handleUnlock}
+              >
+                {secretsEncryptionCardTranslations("secretsEncryptionCard.unlockButton")}
+              </Button>
+            </RequirePermission>
+            <Button variant="bordered" isDisabled={submitting} onPress={onHide} className={HIDE_BUTTON_CLASS_NAME}>
+              {secretsEncryptionCardTranslations("secretsEncryptionCard.hideButton")}
+            </Button>
+          </div>
+        </div>
+      );
+    }
+
+    return (
+      <div className="flex flex-col gap-4">
+        <div className="flex items-start gap-2 bg-green-50 border border-green-200 rounded-lg p-3">
+          <p className="text-sm text-green-800 font-medium">
+            {secretsEncryptionCardTranslations("secretsEncryptionCard.unlockedDescription")}
+          </p>
+        </div>
+        <div>
+          <Button variant="bordered" onPress={onHide} className={HIDE_BUTTON_CLASS_NAME}>
+            {secretsEncryptionCardTranslations("secretsEncryptionCard.hideButton")}
+          </Button>
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <WalletGuard
+      onCancel={onHide}
+      onAuthorized={handleAuthorized}
+      title={secretsEncryptionCardTranslations("secretsEncryptionCard.modalTitle")}
+      passwordLabel={secretsEncryptionCardTranslations("secretsEncryptionCard.passwordLabel")}
+      confirmText={secretsEncryptionCardTranslations("secretsEncryptionCard.confirmButton")}
+      cancelText={secretsEncryptionCardTranslations("secretsEncryptionCard.cancelButton")}
+    >
+      <Card shadow="none" className="rounded-lg mb-6 p-6 shadow-lg">
+        <CardHeader className="flex flex-col items-start">
+          <h2 className="text-2xl font-semibold text-green-900">
+            {secretsEncryptionCardTranslations("secretsEncryptionCard.title")}
+          </h2>
+        </CardHeader>
+        <CardBody>{renderStatusDependentContent()}</CardBody>
+      </Card>
+    </WalletGuard>
+  );
+}

--- a/client/src/components/pages/Store/Settings/SecretsEncryption/SecretsEncryptionCardSummary.jsx
+++ b/client/src/components/pages/Store/Settings/SecretsEncryption/SecretsEncryptionCardSummary.jsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { Button, Card, CardBody, CardFooter, CardHeader } from "@heroui/react";
+
+export function SecretsEncryptionCardSummary({ onReveal, secretsEncryptionCardTranslations }) {
+  return (
+    <Card shadow="none" className="rounded-lg mb-6 p-6 shadow-lg">
+      <CardHeader className="flex flex-col items-start pb-0">
+        <h2 className="text-lg sm:text-xl xl:text-2xl font-semibold text-green-900">
+          {secretsEncryptionCardTranslations("secretsEncryptionCard.title")}
+        </h2>
+      </CardHeader>
+
+      <CardBody>
+        <p className="text-sm text-gray-500">
+          {secretsEncryptionCardTranslations("secretsEncryptionCard.description")}
+        </p>
+      </CardBody>
+
+      <CardFooter>
+        <Button
+          color="primary"
+          className="bg-green-800 h-8 min-w-16 px-3 rounded-small sm:h-10 sm:min-w-20 sm:px-4 sm:rounded-medium"
+          onPress={onReveal}
+        >
+          {secretsEncryptionCardTranslations("secretsEncryptionCard.manageButton")}
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/client/src/components/pages/Store/Settings/SecretsEncryption/__tests__/SecretsEncryptionCard.test.jsx
+++ b/client/src/components/pages/Store/Settings/SecretsEncryption/__tests__/SecretsEncryptionCard.test.jsx
@@ -1,0 +1,78 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+
+import { SecretsEncryptionCard } from "../SecretsEncryptionCard";
+
+jest.mock("@/hooks/usePermission");
+
+jest.mock("@heroui/react", () => ({
+  addToast: jest.fn(),
+  Button: ({ onPress, children, ...props }) => (
+    <button type="button" onClick={onPress} {...props}>{children}</button>
+  ),
+  Card: ({ children }) => <div>{children}</div>,
+  CardHeader: ({ children }) => <div>{children}</div>,
+  CardBody: ({ children }) => <div>{children}</div>,
+  CardFooter: ({ children }) => <div>{children}</div>,
+  Input: ({ label, value, onValueChange }) => (
+    <div>
+      <label htmlFor={label}>{label}</label>
+      <input id={label} value={value} onChange={(event) => onValueChange(event.target.value)} />
+    </div>
+  ),
+  Spinner: () => <div data-testid="spinner" />,
+}));
+
+jest.mock("next-intl", () => ({
+  useTranslations: () => (key) => key,
+}));
+
+jest.mock("lucide-react", () => ({
+  AlertTriangle: () => <svg data-testid="icon-alert" />,
+}));
+
+jest.mock("@components/auth/WalletGuard", () => function MockWalletGuard({ children, onCancel }) {
+  return (
+    <div data-testid="wallet-guard">
+      <button type="button" data-testid="guard-cancel" onClick={onCancel}>cancel</button>
+      {children}
+    </div>
+  );
+},
+);
+
+describe("SecretsEncryptionCard", () => {
+  describe("Initial (summary) state", () => {
+    it("renders the summary card by default", () => {
+      render(<SecretsEncryptionCard />);
+      expect(screen.getByText("secretsEncryptionCard.manageButton")).toBeInTheDocument();
+    });
+
+    it("does not render the WalletGuard before reveal", () => {
+      render(<SecretsEncryptionCard />);
+      expect(screen.queryByTestId("wallet-guard")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Transition to details state", () => {
+    it("renders WalletGuard after the manage button is clicked", () => {
+      render(<SecretsEncryptionCard />);
+      fireEvent.click(screen.getByText("secretsEncryptionCard.manageButton"));
+      expect(screen.getByTestId("wallet-guard")).toBeInTheDocument();
+    });
+
+    it("hides the summary card after the manage button is clicked", () => {
+      render(<SecretsEncryptionCard />);
+      fireEvent.click(screen.getByText("secretsEncryptionCard.manageButton"));
+      expect(screen.queryByText("secretsEncryptionCard.manageButton")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Hide (return to summary state)", () => {
+    it("returns to summary state when WalletGuard cancel is pressed", () => {
+      render(<SecretsEncryptionCard />);
+      fireEvent.click(screen.getByText("secretsEncryptionCard.manageButton"));
+      fireEvent.click(screen.getByTestId("guard-cancel"));
+      expect(screen.getByText("secretsEncryptionCard.manageButton")).toBeInTheDocument();
+    });
+  });
+});

--- a/client/src/components/pages/Store/Settings/SecretsEncryption/__tests__/SecretsEncryptionCardDetails.test.jsx
+++ b/client/src/components/pages/Store/Settings/SecretsEncryption/__tests__/SecretsEncryptionCardDetails.test.jsx
@@ -26,12 +26,24 @@ jest.mock("@heroui/react", () => ({
 }));
 
 jest.mock("@components/shared/SecretsUnlockPasswordField", () => ({
-  SecretsUnlockPasswordField: ({ unlockPassword, onUnlockPasswordChange }) => (
-    <input
-      data-testid="secrets-unlock-password-field"
-      value={unlockPassword}
-      onChange={(event) => onUnlockPasswordChange(event.target.value)}
-    />
+  SecretsUnlockPasswordField: ({
+    unlockPassword,
+    onUnlockPasswordChange,
+    unlockPasswordConfirmation,
+    onUnlockPasswordConfirmationChange,
+  }) => (
+    <>
+      <input
+        data-testid="secrets-unlock-password-field"
+        value={unlockPassword}
+        onChange={(event) => onUnlockPasswordChange(event.target.value)}
+      />
+      <input
+        data-testid="secrets-unlock-password-confirm-field"
+        value={unlockPasswordConfirmation}
+        onChange={(event) => onUnlockPasswordConfirmationChange(event.target.value)}
+      />
+    </>
   ),
 }));
 
@@ -148,10 +160,24 @@ describe("SecretsEncryptionCardDetails", () => {
       expect(screen.getByText("secretsEncryptionCard.activateButton")).toBeDisabled();
     });
 
+    it("disables the activate button when the passwords don't match", () => {
+      fireEvent.change(screen.getByTestId("secrets-unlock-password-field"), {
+        target: { value: "correct-unlock-password" },
+      });
+      fireEvent.change(screen.getByTestId("secrets-unlock-password-confirm-field"), {
+        target: { value: "different-password" },
+      });
+
+      expect(screen.getByText("secretsEncryptionCard.activateButton")).toBeDisabled();
+    });
+
     it("activates encryption with the entered password and shows the confirmed state", async () => {
       secretsService.activateSecretsEncryption.mockResolvedValue({ message: "Secrets encryption activated" });
 
       fireEvent.change(screen.getByTestId("secrets-unlock-password-field"), {
+        target: { value: "correct-unlock-password" },
+      });
+      fireEvent.change(screen.getByTestId("secrets-unlock-password-confirm-field"), {
         target: { value: "correct-unlock-password" },
       });
       await act(async () => {
@@ -171,6 +197,9 @@ describe("SecretsEncryptionCardDetails", () => {
       const { addToast } = require("@heroui/react");
 
       fireEvent.change(screen.getByTestId("secrets-unlock-password-field"), {
+        target: { value: "correct-unlock-password" },
+      });
+      fireEvent.change(screen.getByTestId("secrets-unlock-password-confirm-field"), {
         target: { value: "correct-unlock-password" },
       });
       await act(async () => {

--- a/client/src/components/pages/Store/Settings/SecretsEncryption/__tests__/SecretsEncryptionCardDetails.test.jsx
+++ b/client/src/components/pages/Store/Settings/SecretsEncryption/__tests__/SecretsEncryptionCardDetails.test.jsx
@@ -1,0 +1,244 @@
+import { render, screen, fireEvent, act } from "@testing-library/react";
+
+import * as secretsService from "@/services/secretsService";
+
+import { SecretsEncryptionCardDetails } from "../SecretsEncryptionCardDetails";
+
+jest.mock("@/hooks/usePermission");
+
+jest.mock("@/services/secretsService");
+
+jest.mock("@heroui/react", () => ({
+  addToast: jest.fn(),
+  Button: ({ onPress, children, isDisabled, ...props }) => (
+    <button type="button" disabled={isDisabled} onClick={onPress} {...props}>{children}</button>
+  ),
+  Card: ({ children }) => <div>{children}</div>,
+  CardHeader: ({ children }) => <div>{children}</div>,
+  CardBody: ({ children }) => <div>{children}</div>,
+  Input: ({ label, value, onValueChange }) => (
+    <div>
+      <label htmlFor={label}>{label}</label>
+      <input id={label} value={value} onChange={(event) => onValueChange(event.target.value)} />
+    </div>
+  ),
+  Spinner: () => <div data-testid="spinner" />,
+}));
+
+jest.mock("@components/shared/SecretsUnlockPasswordField", () => ({
+  SecretsUnlockPasswordField: ({ unlockPassword, onUnlockPasswordChange }) => (
+    <input
+      data-testid="secrets-unlock-password-field"
+      value={unlockPassword}
+      onChange={(event) => onUnlockPasswordChange(event.target.value)}
+    />
+  ),
+}));
+
+jest.mock("@components/auth/WalletGuard", () => function MockWalletGuard({ children, onAuthorized, onCancel, title, passwordLabel, confirmText, cancelText }) {
+  return (
+    <div>
+      <span data-testid="guard-title">{title}</span>
+      <span data-testid="guard-password-label">{passwordLabel}</span>
+      <button type="button" data-testid="guard-confirm" onClick={onAuthorized}>{confirmText}</button>
+      <button type="button" data-testid="guard-cancel" onClick={onCancel}>{cancelText}</button>
+      {children}
+    </div>
+  );
+},
+);
+
+const translate = (key) => key;
+
+function renderDetails(props = {}) {
+  return render(<SecretsEncryptionCardDetails secretsEncryptionCardTranslations={translate} onHide={jest.fn()} {...props} />);
+}
+
+async function authorize() {
+  await act(async () => {
+    fireEvent.click(screen.getByTestId("guard-confirm"));
+  });
+}
+
+describe("SecretsEncryptionCardDetails", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("WalletGuard props", () => {
+    it("passes the modal title to WalletGuard", () => {
+      renderDetails();
+      expect(screen.getByTestId("guard-title").textContent).toBe("secretsEncryptionCard.modalTitle");
+    });
+
+    it("passes the password label to WalletGuard", () => {
+      renderDetails();
+      expect(screen.getByTestId("guard-password-label").textContent).toBe("secretsEncryptionCard.passwordLabel");
+    });
+
+    it("forwards onHide as onCancel to WalletGuard", () => {
+      const onHide = jest.fn();
+      renderDetails({ onHide });
+      fireEvent.click(screen.getByTestId("guard-cancel"));
+      expect(onHide).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("Before authorization", () => {
+    it("shows a spinner and does not fetch the status", () => {
+      renderDetails();
+      expect(screen.getByTestId("spinner")).toBeInTheDocument();
+      expect(secretsService.getSecretsStatus).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("onAuthorized — loading the current status", () => {
+    it("shows an error toast when the status fetch fails", async () => {
+      secretsService.getSecretsStatus.mockRejectedValue(new Error("network error"));
+      const { addToast } = require("@heroui/react");
+      renderDetails();
+
+      await authorize();
+
+      expect(addToast).toHaveBeenCalledWith(
+        expect.objectContaining({ color: "danger", description: "secretsEncryptionCard.statusLoadError" }),
+      );
+    });
+
+    it("shows the activation form when encryption is not active", async () => {
+      secretsService.getSecretsStatus.mockResolvedValue({ encryptionActive: false, locked: false });
+      renderDetails();
+
+      await authorize();
+
+      expect(screen.getByText("secretsEncryptionCard.inactiveDescription")).toBeInTheDocument();
+      expect(screen.getByText("secretsEncryptionCard.activateButton")).toBeInTheDocument();
+    });
+
+    it("shows the unlock form when encryption is active and locked", async () => {
+      secretsService.getSecretsStatus.mockResolvedValue({ encryptionActive: true, locked: true });
+      renderDetails();
+
+      await authorize();
+
+      expect(screen.getByText("secretsEncryptionCard.lockedDescription")).toBeInTheDocument();
+      expect(screen.getByText("secretsEncryptionCard.unlockButton")).toBeInTheDocument();
+    });
+
+    it("shows the confirmed state when encryption is active and unlocked", async () => {
+      secretsService.getSecretsStatus.mockResolvedValue({ encryptionActive: true, locked: false });
+      renderDetails();
+
+      await authorize();
+
+      expect(screen.getByText("secretsEncryptionCard.unlockedDescription")).toBeInTheDocument();
+      expect(screen.queryByText("secretsEncryptionCard.activateButton")).not.toBeInTheDocument();
+      expect(screen.queryByText("secretsEncryptionCard.unlockButton")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Activating encryption", () => {
+    beforeEach(async () => {
+      secretsService.getSecretsStatus.mockResolvedValue({ encryptionActive: false, locked: false });
+      renderDetails();
+      await authorize();
+    });
+
+    it("disables the activate button while the password is empty", () => {
+      expect(screen.getByText("secretsEncryptionCard.activateButton")).toBeDisabled();
+    });
+
+    it("activates encryption with the entered password and shows the confirmed state", async () => {
+      secretsService.activateSecretsEncryption.mockResolvedValue({ message: "Secrets encryption activated" });
+
+      fireEvent.change(screen.getByTestId("secrets-unlock-password-field"), {
+        target: { value: "correct-unlock-password" },
+      });
+      await act(async () => {
+        fireEvent.click(screen.getByText("secretsEncryptionCard.activateButton"));
+      });
+
+      expect(secretsService.activateSecretsEncryption).toHaveBeenCalledWith("correct-unlock-password");
+      expect(screen.getByText("secretsEncryptionCard.unlockedDescription")).toBeInTheDocument();
+      const { addToast } = require("@heroui/react");
+      expect(addToast).toHaveBeenCalledWith(
+        expect.objectContaining({ color: "success", description: "secretsEncryptionCard.activateSuccess" }),
+      );
+    });
+
+    it("shows an error toast when activation fails", async () => {
+      secretsService.activateSecretsEncryption.mockRejectedValue(new Error("Could not reach the server"));
+      const { addToast } = require("@heroui/react");
+
+      fireEvent.change(screen.getByTestId("secrets-unlock-password-field"), {
+        target: { value: "correct-unlock-password" },
+      });
+      await act(async () => {
+        fireEvent.click(screen.getByText("secretsEncryptionCard.activateButton"));
+      });
+
+      expect(addToast).toHaveBeenCalledWith(
+        expect.objectContaining({ color: "danger", description: "Could not reach the server" }),
+      );
+    });
+  });
+
+  describe("Unlocking encryption", () => {
+    beforeEach(async () => {
+      secretsService.getSecretsStatus.mockResolvedValue({ encryptionActive: true, locked: true });
+      renderDetails();
+      await authorize();
+    });
+
+    it("disables the unlock button while the password is empty", () => {
+      expect(screen.getByText("secretsEncryptionCard.unlockButton")).toBeDisabled();
+    });
+
+    it("unlocks with the entered password and shows the confirmed state", async () => {
+      secretsService.unlockSecrets.mockResolvedValue({ message: "Secrets unlocked" });
+
+      fireEvent.change(screen.getByLabelText("secretsEncryptionCard.unlockPasswordLabel"), {
+        target: { value: "correct-unlock-password" },
+      });
+      await act(async () => {
+        fireEvent.click(screen.getByText("secretsEncryptionCard.unlockButton"));
+      });
+
+      expect(secretsService.unlockSecrets).toHaveBeenCalledWith("correct-unlock-password");
+      expect(screen.getByText("secretsEncryptionCard.unlockedDescription")).toBeInTheDocument();
+      const { addToast } = require("@heroui/react");
+      expect(addToast).toHaveBeenCalledWith(
+        expect.objectContaining({ color: "success", description: "secretsEncryptionCard.unlockSuccess" }),
+      );
+    });
+
+    it("shows an error toast when unlocking fails", async () => {
+      secretsService.unlockSecrets.mockRejectedValue(new Error("Invalid credentials"));
+      const { addToast } = require("@heroui/react");
+
+      fireEvent.change(screen.getByLabelText("secretsEncryptionCard.unlockPasswordLabel"), {
+        target: { value: "wrong-password" },
+      });
+      await act(async () => {
+        fireEvent.click(screen.getByText("secretsEncryptionCard.unlockButton"));
+      });
+
+      expect(addToast).toHaveBeenCalledWith(
+        expect.objectContaining({ color: "danger", description: "Invalid credentials" }),
+      );
+    });
+  });
+
+  describe("Interaction", () => {
+    it("calls onHide when the hide button is pressed", async () => {
+      const onHide = jest.fn();
+      secretsService.getSecretsStatus.mockResolvedValue({ encryptionActive: true, locked: false });
+      renderDetails({ onHide });
+
+      await authorize();
+      fireEvent.click(screen.getByText("secretsEncryptionCard.hideButton"));
+
+      expect(onHide).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/client/src/components/pages/Store/Settings/SecretsEncryption/__tests__/SecretsEncryptionCardSummary.test.jsx
+++ b/client/src/components/pages/Store/Settings/SecretsEncryption/__tests__/SecretsEncryptionCardSummary.test.jsx
@@ -1,0 +1,49 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+
+import { SecretsEncryptionCardSummary } from "../SecretsEncryptionCardSummary";
+
+jest.mock("@heroui/react", () => ({
+  Button: ({ onPress, children, ...props }) => (
+    <button type="button" onClick={onPress} {...props}>{children}</button>
+  ),
+  Card: ({ children }) => <div>{children}</div>,
+  CardHeader: ({ children }) => <div>{children}</div>,
+  CardBody: ({ children }) => <div>{children}</div>,
+  CardFooter: ({ children }) => <div>{children}</div>,
+}));
+
+const translate = (key) => key;
+
+function renderSummary(props = {}) {
+  return render(
+    <SecretsEncryptionCardSummary secretsEncryptionCardTranslations={translate} onReveal={jest.fn()} {...props} />,
+  );
+}
+
+describe("SecretsEncryptionCardSummary", () => {
+  describe("Rendering", () => {
+    it("renders the title", () => {
+      renderSummary();
+      expect(screen.getByText("secretsEncryptionCard.title")).toBeInTheDocument();
+    });
+
+    it("renders the description", () => {
+      renderSummary();
+      expect(screen.getByText("secretsEncryptionCard.description")).toBeInTheDocument();
+    });
+
+    it("renders the manage button", () => {
+      renderSummary();
+      expect(screen.getByText("secretsEncryptionCard.manageButton")).toBeInTheDocument();
+    });
+  });
+
+  describe("Interaction", () => {
+    it("calls onReveal when the manage button is pressed", () => {
+      const onReveal = jest.fn();
+      renderSummary({ onReveal });
+      fireEvent.click(screen.getByText("secretsEncryptionCard.manageButton"));
+      expect(onReveal).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/client/src/components/pages/Store/Settings/SecretsEncryption/locales/en.js
+++ b/client/src/components/pages/Store/Settings/SecretsEncryption/locales/en.js
@@ -1,0 +1,25 @@
+const secretsEncryptionCardEn = {
+  secretsEncryptionCard: {
+    title: "Secrets encryption",
+    description: "Protect your phoenixd password, NWC connection, and push notification key with a password only you know.",
+    manageButton: "Manage encryption",
+    modalTitle: "Confirm wallet access",
+    passwordLabel: "Wallet password",
+    confirmButton: "Enter",
+    cancelButton: "Cancel",
+    hideButton: "Close",
+    statusLoadError: "Could not load the secrets encryption status",
+    inactiveDescription: "Secrets encryption is not active. Choose a password to protect your Lightning connection details.",
+    unlockPasswordLabel: "Unlock password",
+    activateButton: "Activate encryption",
+    activateSuccess: "Secrets encryption is now active",
+    activateError: "Could not activate secrets encryption",
+    lockedDescription: "Secrets are encrypted and currently locked. Enter the unlock password to make them available again.",
+    unlockButton: "Unlock",
+    unlockSuccess: "Secrets unlocked",
+    unlockError: "Could not unlock secrets — check the password",
+    unlockedDescription: "Secrets encryption is active and unlocked.",
+  },
+};
+
+export default secretsEncryptionCardEn;

--- a/client/src/components/pages/Store/Settings/SecretsEncryption/locales/es.js
+++ b/client/src/components/pages/Store/Settings/SecretsEncryption/locales/es.js
@@ -1,0 +1,25 @@
+const secretsEncryptionCardEs = {
+  secretsEncryptionCard: {
+    title: "Cifrado de secretos",
+    description: "Protege la contraseña de phoenixd, la conexión NWC y la clave de notificaciones push con una contraseña que solo tú conoces.",
+    manageButton: "Administrar cifrado",
+    modalTitle: "Confirmar acceso a Wallet",
+    passwordLabel: "Contraseña de wallet",
+    confirmButton: "Entrar",
+    cancelButton: "Cancelar",
+    hideButton: "Cerrar",
+    statusLoadError: "No se pudo cargar el estado del cifrado de secretos",
+    inactiveDescription: "El cifrado de secretos no está activo. Elige una contraseña para proteger los datos de tu conexión Lightning.",
+    unlockPasswordLabel: "Contraseña de desbloqueo",
+    activateButton: "Activar cifrado",
+    activateSuccess: "El cifrado de secretos ya está activo",
+    activateError: "No se pudo activar el cifrado de secretos",
+    lockedDescription: "Los secretos están cifrados y actualmente bloqueados. Ingresa la contraseña de desbloqueo para volver a tener acceso a ellos.",
+    unlockButton: "Desbloquear",
+    unlockSuccess: "Secretos desbloqueados",
+    unlockError: "No se pudo desbloquear los secretos — revisa la contraseña",
+    unlockedDescription: "El cifrado de secretos está activo y desbloqueado.",
+  },
+};
+
+export default secretsEncryptionCardEs;

--- a/client/src/components/pages/Store/Settings/Settings.jsx
+++ b/client/src/components/pages/Store/Settings/Settings.jsx
@@ -18,6 +18,7 @@ import { NwcConnectionCard } from "./NwcConnection/NwcConnectionCard";
 import { PhoenixdRemoteCard } from "./PhoenixdRemote/PhoenixdRemoteCard";
 import { Printers } from "./Printers";
 import { QRUrl } from "./QRUrl";
+import { SecretsEncryptionCard } from "./SecretsEncryption/SecretsEncryptionCard";
 import { SecureConnection } from "./SecureConnection/SecureConnection";
 import { Seed } from "./Seed";
 import { StoreInfo } from "./StoreInfo";
@@ -49,6 +50,7 @@ export function Settings() {
               <NwcConnectionCard />
               <PhoenixdRemoteCard />
               <SystemCard />
+              <SecretsEncryptionCard />
               <Tutorials />
             </>
           )}

--- a/client/src/components/pages/Store/Settings/locales/en.js
+++ b/client/src/components/pages/Store/Settings/locales/en.js
@@ -4,6 +4,7 @@ import lightningEn from "../Lightning/locales/en";
 import nwcConnectionEn from "../NwcConnection/locales/en";
 import phoenixdRemoteCardEn from "../PhoenixdRemote/locales/en";
 import printersEn from "../Printers/locales/en";
+import secretsEncryptionCardEn from "../SecretsEncryption/locales/en";
 import seedEn from "../Seed/locales/en";
 import storeInfoEn from "../StoreInfo/locales/en";
 import systemEn from "../System/locales/en";
@@ -106,6 +107,7 @@ const settingsEn = {
   ...lightningEn,
   ...nwcConnectionEn,
   ...phoenixdRemoteCardEn,
+  ...secretsEncryptionCardEn,
 };
 
 export default settingsEn;

--- a/client/src/components/pages/Store/Settings/locales/es.js
+++ b/client/src/components/pages/Store/Settings/locales/es.js
@@ -4,6 +4,7 @@ import lightningEs from "../Lightning/locales/es";
 import nwcConnectionEs from "../NwcConnection/locales/es";
 import phoenixdRemoteCardEs from "../PhoenixdRemote/locales/es";
 import printersEs from "../Printers/locales/es";
+import secretsEncryptionCardEs from "../SecretsEncryption/locales/es";
 import seedEs from "../Seed/locales/es";
 import storeInfoEs from "../StoreInfo/locales/es";
 import systemEs from "../System/locales/es";
@@ -106,6 +107,7 @@ const settingsEs = {
   ...lightningEs,
   ...nwcConnectionEs,
   ...phoenixdRemoteCardEs,
+  ...secretsEncryptionCardEs,
 };
 
 export default settingsEs;

--- a/client/src/components/shared/SecretsUnlockPasswordField.jsx
+++ b/client/src/components/shared/SecretsUnlockPasswordField.jsx
@@ -1,21 +1,66 @@
 "use client";
 
+import { useState } from "react";
+
 import { Input } from "@heroui/react";
-import { AlertTriangle } from "lucide-react";
+import { AlertTriangle, Eye, EyeOff } from "lucide-react";
 import { useTranslations } from "next-intl";
 
-export function SecretsUnlockPasswordField({ unlockPassword, onUnlockPasswordChange }) {
+export function SecretsUnlockPasswordField({
+  unlockPassword,
+  onUnlockPasswordChange,
+  unlockPasswordConfirmation,
+  onUnlockPasswordConfirmationChange,
+}) {
   const secretsUnlockPasswordTranslations = useTranslations("secretsUnlockPassword");
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+
+  const passwordsMatch = unlockPassword === unlockPasswordConfirmation;
 
   return (
     <div className="space-y-3">
-      <Input
-        label={secretsUnlockPasswordTranslations("passwordLabel")}
-        type="password"
-        value={unlockPassword}
-        onValueChange={onUnlockPasswordChange}
-        description={secretsUnlockPasswordTranslations("passwordDescription")}
-      />
+      <div className="relative">
+        <Input
+          label={secretsUnlockPasswordTranslations("passwordLabel")}
+          type={showPassword ? "text" : "password"}
+          value={unlockPassword}
+          onValueChange={onUnlockPasswordChange}
+          description={secretsUnlockPasswordTranslations("passwordDescription")}
+          endContent={(
+            <button
+              type="button"
+              onClick={() => setShowPassword(!showPassword)}
+              className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+            >
+              {showPassword ? <EyeOff className="w-5 h-5" /> : <Eye className="w-5 h-5" />}
+            </button>
+          )}
+        />
+      </div>
+      <div className="relative">
+        <Input
+          label={secretsUnlockPasswordTranslations("confirmPasswordLabel")}
+          type={showConfirmPassword ? "text" : "password"}
+          value={unlockPasswordConfirmation}
+          onValueChange={onUnlockPasswordConfirmationChange}
+          isInvalid={Boolean(unlockPasswordConfirmation) && !passwordsMatch}
+          errorMessage={
+            Boolean(unlockPasswordConfirmation) && !passwordsMatch
+              ? secretsUnlockPasswordTranslations("passwordsDoNotMatch")
+              : ""
+          }
+          endContent={(
+            <button
+              type="button"
+              onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+              className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+            >
+              {showConfirmPassword ? <EyeOff className="w-5 h-5" /> : <Eye className="w-5 h-5" />}
+            </button>
+          )}
+        />
+      </div>
       <div className="flex items-start gap-2 bg-amber-50 border border-amber-200 rounded-lg p-3">
         <AlertTriangle className="w-5 h-5 text-amber-600 shrink-0 mt-0.5" />
         <p className="text-sm text-amber-800">{secretsUnlockPasswordTranslations("passwordWarning")}</p>

--- a/client/src/components/shared/SecretsUnlockPasswordField.jsx
+++ b/client/src/components/shared/SecretsUnlockPasswordField.jsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { Input } from "@heroui/react";
+import { AlertTriangle } from "lucide-react";
+import { useTranslations } from "next-intl";
+
+export function SecretsUnlockPasswordField({ unlockPassword, onUnlockPasswordChange }) {
+  const secretsUnlockPasswordTranslations = useTranslations("secretsUnlockPassword");
+
+  return (
+    <div className="space-y-3">
+      <Input
+        label={secretsUnlockPasswordTranslations("passwordLabel")}
+        type="password"
+        value={unlockPassword}
+        onValueChange={onUnlockPasswordChange}
+        description={secretsUnlockPasswordTranslations("passwordDescription")}
+      />
+      <div className="flex items-start gap-2 bg-amber-50 border border-amber-200 rounded-lg p-3">
+        <AlertTriangle className="w-5 h-5 text-amber-600 shrink-0 mt-0.5" />
+        <p className="text-sm text-amber-800">{secretsUnlockPasswordTranslations("passwordWarning")}</p>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/shared/__tests__/SecretsUnlockPasswordField.test.jsx
+++ b/client/src/components/shared/__tests__/SecretsUnlockPasswordField.test.jsx
@@ -1,0 +1,62 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+
+import { SecretsUnlockPasswordField } from "../SecretsUnlockPasswordField";
+
+jest.mock("@heroui/react", () => ({
+  Input: ({ label, value, onValueChange, description }) => (
+    <div>
+      <label htmlFor={label}>{label}</label>
+      <input id={label} value={value} onChange={(event) => onValueChange(event.target.value)} />
+      {description && <span>{description}</span>}
+    </div>
+  ),
+}));
+
+jest.mock("lucide-react", () => ({
+  AlertTriangle: () => <svg data-testid="icon-alert" />,
+}));
+
+function renderField(props = {}) {
+  return render(
+    <SecretsUnlockPasswordField unlockPassword="" onUnlockPasswordChange={jest.fn()} {...props} />,
+  );
+}
+
+describe("SecretsUnlockPasswordField", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("Rendering", () => {
+    it("renders the password label and current value", () => {
+      renderField({ unlockPassword: "correct-unlock-password" });
+
+      expect(screen.getByLabelText("passwordLabel").value).toBe("correct-unlock-password");
+    });
+
+    it("renders the password description", () => {
+      renderField();
+
+      expect(screen.getByText("passwordDescription")).toBeInTheDocument();
+    });
+
+    it("renders the write-it-down warning", () => {
+      renderField();
+
+      expect(screen.getByText("passwordWarning")).toBeInTheDocument();
+    });
+  });
+
+  describe("Interaction", () => {
+    it("calls onUnlockPasswordChange with the entered value", () => {
+      const onUnlockPasswordChange = jest.fn();
+      renderField({ onUnlockPasswordChange });
+
+      fireEvent.change(screen.getByLabelText("passwordLabel"), {
+        target: { value: "new-unlock-password" },
+      });
+
+      expect(onUnlockPasswordChange).toHaveBeenCalledWith("new-unlock-password");
+    });
+  });
+});

--- a/client/src/components/shared/__tests__/SecretsUnlockPasswordField.test.jsx
+++ b/client/src/components/shared/__tests__/SecretsUnlockPasswordField.test.jsx
@@ -3,22 +3,32 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import { SecretsUnlockPasswordField } from "../SecretsUnlockPasswordField";
 
 jest.mock("@heroui/react", () => ({
-  Input: ({ label, value, onValueChange, description }) => (
+  Input: ({ label, type, value, onValueChange, description, endContent, isInvalid, errorMessage }) => (
     <div>
       <label htmlFor={label}>{label}</label>
-      <input id={label} value={value} onChange={(event) => onValueChange(event.target.value)} />
+      <input id={label} type={type} value={value} onChange={(event) => onValueChange(event.target.value)} />
       {description && <span>{description}</span>}
+      {isInvalid && errorMessage && <span>{errorMessage}</span>}
+      {endContent}
     </div>
   ),
 }));
 
 jest.mock("lucide-react", () => ({
   AlertTriangle: () => <svg data-testid="icon-alert" />,
+  Eye: () => <svg data-testid="icon-eye" />,
+  EyeOff: () => <svg data-testid="icon-eye-off" />,
 }));
 
 function renderField(props = {}) {
   return render(
-    <SecretsUnlockPasswordField unlockPassword="" onUnlockPasswordChange={jest.fn()} {...props} />,
+    <SecretsUnlockPasswordField
+      unlockPassword=""
+      onUnlockPasswordChange={jest.fn()}
+      unlockPasswordConfirmation=""
+      onUnlockPasswordConfirmationChange={jest.fn()}
+      {...props}
+    />,
   );
 }
 
@@ -45,6 +55,12 @@ describe("SecretsUnlockPasswordField", () => {
 
       expect(screen.getByText("passwordWarning")).toBeInTheDocument();
     });
+
+    it("renders the confirm password label and current value", () => {
+      renderField({ unlockPasswordConfirmation: "correct-unlock-password" });
+
+      expect(screen.getByLabelText("confirmPasswordLabel").value).toBe("correct-unlock-password");
+    });
   });
 
   describe("Interaction", () => {
@@ -57,6 +73,59 @@ describe("SecretsUnlockPasswordField", () => {
       });
 
       expect(onUnlockPasswordChange).toHaveBeenCalledWith("new-unlock-password");
+    });
+
+    it("calls onUnlockPasswordConfirmationChange with the entered value", () => {
+      const onUnlockPasswordConfirmationChange = jest.fn();
+      renderField({ onUnlockPasswordConfirmationChange });
+
+      fireEvent.change(screen.getByLabelText("confirmPasswordLabel"), {
+        target: { value: "new-unlock-password" },
+      });
+
+      expect(onUnlockPasswordConfirmationChange).toHaveBeenCalledWith("new-unlock-password");
+    });
+
+    it("toggles the password field between hidden and visible", () => {
+      renderField();
+
+      expect(screen.getByLabelText("passwordLabel")).toHaveAttribute("type", "password");
+
+      const [togglePasswordButton] = screen.getAllByRole("button");
+      fireEvent.click(togglePasswordButton);
+
+      expect(screen.getByLabelText("passwordLabel")).toHaveAttribute("type", "text");
+    });
+
+    it("toggles the confirm password field between hidden and visible", () => {
+      renderField();
+
+      expect(screen.getByLabelText("confirmPasswordLabel")).toHaveAttribute("type", "password");
+
+      const [, toggleConfirmPasswordButton] = screen.getAllByRole("button");
+      fireEvent.click(toggleConfirmPasswordButton);
+
+      expect(screen.getByLabelText("confirmPasswordLabel")).toHaveAttribute("type", "text");
+    });
+  });
+
+  describe("Password match validation", () => {
+    it("does not show an error while the confirm field is still empty", () => {
+      renderField({ unlockPassword: "correct-unlock-password", unlockPasswordConfirmation: "" });
+
+      expect(screen.queryByText("passwordsDoNotMatch")).not.toBeInTheDocument();
+    });
+
+    it("does not show an error when the passwords match", () => {
+      renderField({ unlockPassword: "correct-unlock-password", unlockPasswordConfirmation: "correct-unlock-password" });
+
+      expect(screen.queryByText("passwordsDoNotMatch")).not.toBeInTheDocument();
+    });
+
+    it("shows an error when the passwords don't match", () => {
+      renderField({ unlockPassword: "correct-unlock-password", unlockPasswordConfirmation: "different-password" });
+
+      expect(screen.getByText("passwordsDoNotMatch")).toBeInTheDocument();
     });
   });
 });

--- a/client/src/lib/auth/__tests__/authSession.test.js
+++ b/client/src/lib/auth/__tests__/authSession.test.js
@@ -1,0 +1,95 @@
+jest.mock("@/lib/http", () => ({
+  httpClient: jest.fn(),
+  parseJsonResponse: jest.fn(),
+}));
+
+import { httpClient, parseJsonResponse } from "@/lib/http";
+
+import { authenticateUser, logoutSession } from "../authSession";
+
+describe("authSession", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    httpClient.mockResolvedValue({ ok: true });
+    parseJsonResponse.mockResolvedValue({ user: { id: "user-1" }, perms: ["settings_update"] });
+  });
+
+  describe("authenticateUser", () => {
+    it("logs in with the given name and pin, with skipRefresh disabled by default", async () => {
+      await authenticateUser({ name: "cooluser1", pin: "0000" });
+
+      expect(httpClient).toHaveBeenCalledWith("/auth/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "cooluser1", pin: "0000" }),
+        skipRefresh: false,
+      });
+    });
+
+    it("passes skipRefresh through to httpClient when requested", async () => {
+      await authenticateUser({ name: "cooluser1", pin: "0000", skipRefresh: true });
+
+      expect(httpClient).toHaveBeenCalledWith("/auth/login", expect.objectContaining({ skipRefresh: true }));
+    });
+
+    it("returns the authenticated user and permissions", async () => {
+      const authenticatedSession = await authenticateUser({ name: "cooluser1", pin: "0000" });
+
+      expect(authenticatedSession).toEqual({ user: { id: "user-1" }, permissions: ["settings_update"] });
+    });
+
+    it("throws with the server message when authentication fails", async () => {
+      httpClient.mockResolvedValueOnce({ ok: false, status: 401 });
+      parseJsonResponse.mockResolvedValueOnce({ message: "Invalid PIN" });
+
+      await expect(authenticateUser({ name: "cooluser1", pin: "wrong-pin" })).rejects.toMatchObject({
+        message: "Invalid PIN",
+        status: 401,
+      });
+    });
+
+    it("throws the fallback message when the server provides none", async () => {
+      httpClient.mockResolvedValueOnce({ ok: false, status: 401 });
+      parseJsonResponse.mockResolvedValueOnce({});
+
+      await expect(authenticateUser({ name: "cooluser1", pin: "wrong-pin" })).rejects.toMatchObject({
+        message: "Invalid Credentials",
+        status: 401,
+      });
+    });
+  });
+
+  describe("logoutSession", () => {
+    it("logs out with skipRefresh disabled by default", async () => {
+      await logoutSession();
+
+      expect(httpClient).toHaveBeenCalledWith("/auth/logout", { method: "POST", skipRefresh: false });
+    });
+
+    it("passes skipRefresh through to httpClient when requested", async () => {
+      await logoutSession({ skipRefresh: true });
+
+      expect(httpClient).toHaveBeenCalledWith("/auth/logout", { method: "POST", skipRefresh: true });
+    });
+
+    it("throws with the server message when logout fails", async () => {
+      httpClient.mockResolvedValueOnce({ ok: false, status: 500 });
+      parseJsonResponse.mockResolvedValueOnce({ message: "Logout unavailable" });
+
+      await expect(logoutSession()).rejects.toMatchObject({
+        message: "Logout unavailable",
+        status: 500,
+      });
+    });
+
+    it("throws the fallback message when the server provides none", async () => {
+      httpClient.mockResolvedValueOnce({ ok: false, status: 500 });
+      parseJsonResponse.mockResolvedValueOnce({});
+
+      await expect(logoutSession()).rejects.toMatchObject({
+        message: "Logout failed",
+        status: 500,
+      });
+    });
+  });
+});

--- a/client/src/lib/auth/authSession.js
+++ b/client/src/lib/auth/authSession.js
@@ -17,13 +17,14 @@ export async function getCurrentSession() {
   };
 }
 
-export async function authenticateUser({ name, pin }) {
+export async function authenticateUser({ name, pin, skipRefresh = false }) {
   const response = await httpClient("/auth/login", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
     },
     body: JSON.stringify({ name, pin }),
+    skipRefresh,
   });
 
   const data = await parseJsonResponse(response, null);
@@ -44,9 +45,10 @@ export async function authenticateUser({ name, pin }) {
   };
 }
 
-export async function logoutSession() {
+export async function logoutSession({ skipRefresh = false } = {}) {
   const response = await httpClient("/auth/logout", {
     method: "POST",
+    skipRefresh,
   });
 
   const data = await parseJsonResponse(response, null);

--- a/client/src/services/__tests__/secretsService.test.js
+++ b/client/src/services/__tests__/secretsService.test.js
@@ -1,0 +1,153 @@
+jest.mock("@/lib/http/httpClient", () => ({
+  httpClient: jest.fn(),
+}));
+
+jest.mock("@/lib/http/parseJsonResponse", () => ({
+  parseJsonResponse: jest.fn(),
+}));
+
+import { httpClient } from "@/lib/http/httpClient";
+import { parseJsonResponse } from "@/lib/http/parseJsonResponse";
+
+import { activateSecretsEncryption, getSecretsStatus, unlockSecrets } from "../secretsService";
+
+function makeResponse(status, ok = true) {
+  return { status, ok };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("secretsService", () => {
+  describe("getSecretsStatus", () => {
+    it("calls GET /secrets/status", async () => {
+      httpClient.mockResolvedValue(makeResponse(200));
+      parseJsonResponse.mockResolvedValue({ encryptionActive: true, locked: false });
+
+      await getSecretsStatus();
+
+      expect(httpClient).toHaveBeenCalledWith("/secrets/status", { skipForbiddenRedirect: true });
+    });
+
+    it("returns the parsed status", async () => {
+      const secretsStatus = { encryptionActive: true, locked: false };
+      httpClient.mockResolvedValue(makeResponse(200));
+      parseJsonResponse.mockResolvedValue(secretsStatus);
+
+      const secretsStatusResult = await getSecretsStatus();
+
+      expect(secretsStatusResult).toEqual(secretsStatus);
+    });
+
+    it("throws with the server message when the response is not ok", async () => {
+      httpClient.mockResolvedValue(makeResponse(401, false));
+      parseJsonResponse.mockResolvedValue({ message: "Invalid credentials" });
+
+      await expect(getSecretsStatus()).rejects.toMatchObject({
+        message: "Invalid credentials",
+        status: 401,
+      });
+    });
+
+    it("throws the fallback message when the server provides none", async () => {
+      httpClient.mockResolvedValue(makeResponse(500, false));
+      parseJsonResponse.mockResolvedValue({});
+
+      await expect(getSecretsStatus()).rejects.toMatchObject({
+        message: "Could not load the secrets encryption status",
+        status: 500,
+      });
+    });
+  });
+
+  describe("unlockSecrets", () => {
+    it("calls POST /secrets/unlock with the unlock password in the body", async () => {
+      httpClient.mockResolvedValue(makeResponse(200));
+      parseJsonResponse.mockResolvedValue({ message: "Secrets unlocked" });
+
+      await unlockSecrets("correct-unlock-password");
+
+      expect(httpClient).toHaveBeenCalledWith("/secrets/unlock", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ unlockPassword: "correct-unlock-password" }),
+        skipForbiddenRedirect: true,
+      });
+    });
+
+    it("returns the parsed response body", async () => {
+      httpClient.mockResolvedValue(makeResponse(200));
+      parseJsonResponse.mockResolvedValue({ message: "Secrets unlocked" });
+
+      const unlockSecretsResult = await unlockSecrets("correct-unlock-password");
+
+      expect(unlockSecretsResult).toEqual({ message: "Secrets unlocked" });
+    });
+
+    it("throws with the server message when the response is not ok", async () => {
+      httpClient.mockResolvedValue(makeResponse(401, false));
+      parseJsonResponse.mockResolvedValue({ message: "Invalid credentials" });
+
+      await expect(unlockSecrets("wrong-password")).rejects.toMatchObject({
+        message: "Invalid credentials",
+        status: 401,
+      });
+    });
+
+    it("throws the fallback message when the server provides none", async () => {
+      httpClient.mockResolvedValue(makeResponse(500, false));
+      parseJsonResponse.mockResolvedValue({});
+
+      await expect(unlockSecrets("correct-unlock-password")).rejects.toMatchObject({
+        message: "Could not unlock secrets",
+        status: 500,
+      });
+    });
+  });
+
+  describe("activateSecretsEncryption", () => {
+    it("calls POST /secrets/activate with the unlock password in the body", async () => {
+      httpClient.mockResolvedValue(makeResponse(200));
+      parseJsonResponse.mockResolvedValue({ message: "Secrets encryption activated" });
+
+      await activateSecretsEncryption("correct-unlock-password");
+
+      expect(httpClient).toHaveBeenCalledWith("/secrets/activate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ unlockPassword: "correct-unlock-password" }),
+        skipForbiddenRedirect: true,
+      });
+    });
+
+    it("returns the parsed response body", async () => {
+      httpClient.mockResolvedValue(makeResponse(200));
+      parseJsonResponse.mockResolvedValue({ message: "Secrets encryption activated" });
+
+      const activateSecretsEncryptionResult = await activateSecretsEncryption("correct-unlock-password");
+
+      expect(activateSecretsEncryptionResult).toEqual({ message: "Secrets encryption activated" });
+    });
+
+    it("throws with the server message when the response is not ok", async () => {
+      httpClient.mockResolvedValue(makeResponse(409, false));
+      parseJsonResponse.mockResolvedValue({ message: "Secrets are locked" });
+
+      await expect(activateSecretsEncryption("correct-unlock-password")).rejects.toMatchObject({
+        message: "Secrets are locked",
+        status: 409,
+      });
+    });
+
+    it("throws the fallback message when the server provides none", async () => {
+      httpClient.mockResolvedValue(makeResponse(500, false));
+      parseJsonResponse.mockResolvedValue({});
+
+      await expect(activateSecretsEncryption("correct-unlock-password")).rejects.toMatchObject({
+        message: "Could not activate secrets encryption",
+        status: 500,
+      });
+    });
+  });
+});

--- a/client/src/services/secretsService.js
+++ b/client/src/services/secretsService.js
@@ -1,0 +1,60 @@
+import { httpClient } from "@/lib/http/httpClient";
+import { parseJsonResponse } from "@/lib/http/parseJsonResponse";
+
+function createSecretsServiceError(message, errorDetails = {}) {
+  const secretsServiceError = new Error(message);
+  secretsServiceError.status = errorDetails.status;
+  return secretsServiceError;
+}
+
+async function parseSecretsResponseOrThrow(secretsHttpResponse, fallbackValue, fallbackMessage) {
+  const secretsResponseBody = await parseJsonResponse(secretsHttpResponse, fallbackValue);
+  if (!secretsHttpResponse.ok) {
+    throw createSecretsServiceError(
+      secretsResponseBody?.message ?? fallbackMessage,
+      { status: secretsHttpResponse.status },
+    );
+  }
+  return secretsResponseBody;
+}
+
+export async function getSecretsStatus() {
+  const secretsStatusResponse = await httpClient("/secrets/status", { skipForbiddenRedirect: true });
+  return await parseSecretsResponseOrThrow(
+    secretsStatusResponse,
+    null,
+    "Could not load the secrets encryption status",
+  );
+}
+
+export async function unlockSecrets(unlockPassword) {
+  const unlockSecretsResponse = await httpClient("/secrets/unlock", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ unlockPassword }),
+    skipForbiddenRedirect: true,
+  });
+  return await parseSecretsResponseOrThrow(
+    unlockSecretsResponse,
+    null,
+    "Could not unlock secrets",
+  );
+}
+
+export async function activateSecretsEncryption(unlockPassword) {
+  const activateSecretsEncryptionResponse = await httpClient("/secrets/activate", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ unlockPassword }),
+    skipForbiddenRedirect: true,
+  });
+  return await parseSecretsResponseOrThrow(
+    activateSecretsEncryptionResponse,
+    null,
+    "Could not activate secrets encryption",
+  );
+}

--- a/server/app/src/main/kotlin/pos/ambrosia/Ambrosia.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/Ambrosia.kt
@@ -243,6 +243,7 @@ class Ambrosia : CliktCommand() {
 
         try {
             ensureNwcUriPersisted()
+            ensurePhoenixdPasswordPersisted()
             val (keyStore, storePassword, privateKeyPassword) = ensureKeyStore()
 
             val server =
@@ -408,6 +409,14 @@ class Ambrosia : CliktCommand() {
         if (SecretsStore.getSecretOrNull("nwc-uri") != null) return
 
         SecretsStore.setSecret("nwc-uri", nwcUri)
+    }
+
+    private fun ensurePhoenixdPasswordPersisted() {
+        if (SecretsStore.isLocked()) return
+        if (SecretsStore.getSecretOrNull("phoenixd-password") != null) return
+        if (options.phoenixdPassword.isBlank()) return
+
+        SecretsStore.setSecret("phoenixd-password", options.phoenixdPassword)
     }
 
     private fun readEnvironmentVapidKeysOrNull(): VapidKeys? {

--- a/server/app/src/main/kotlin/pos/ambrosia/Ambrosia.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/Ambrosia.kt
@@ -242,6 +242,7 @@ class Ambrosia : CliktCommand() {
         Runtime.getRuntime().addShutdownHook(Thread { DatabaseConnection.close() })
 
         try {
+            ensureNwcUriPersisted()
             val (keyStore, storePassword, privateKeyPassword) = ensureKeyStore()
 
             val server =
@@ -399,6 +400,14 @@ class Ambrosia : CliktCommand() {
         if (missingVapidConfig) {
             println(yellow("Generated Web Push VAPID keys in ambrosia.conf"))
         }
+    }
+
+    private fun ensureNwcUriPersisted() {
+        val nwcUri = options.nwcUri ?: return
+        if (SecretsStore.isLocked()) return
+        if (SecretsStore.getSecretOrNull("nwc-uri") != null) return
+
+        SecretsStore.setSecret("nwc-uri", nwcUri)
     }
 
     private fun readEnvironmentVapidKeysOrNull(): VapidKeys? {

--- a/server/app/src/main/kotlin/pos/ambrosia/Ambrosia.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/Ambrosia.kt
@@ -40,6 +40,7 @@ import pos.ambrosia.config.replaceConfFileProperty
 import pos.ambrosia.config.writeConfValues
 import pos.ambrosia.db.DatabaseConnection
 import pos.ambrosia.services.BackupService
+import pos.ambrosia.services.SecretsStore
 import pos.ambrosia.services.TokenService
 import pos.ambrosia.services.VapidKeyService
 import pos.ambrosia.services.VapidKeys
@@ -98,6 +99,7 @@ class Ambrosia : CliktCommand() {
     init {
         SystemFileSystem.createDirectories(datadir)
         InjectLogs.ensureLogConfig(datadir.toString())
+        attemptAutoUnlock()
         ensureWebPushConfig()
 
         context {
@@ -255,15 +257,10 @@ class Ambrosia : CliktCommand() {
                                     put("docker", options.docker.toString())
                                     put("secret", options.secret)
                                     put("phoenixd-url", options.phoenixdUrl)
-                                    put("phoenixd-password", options.phoenixdPassword)
                                     put("phoenixd-remote", options.phoenixdRemote.toString())
                                     put("phoenix.webhook-secret", options.phoenixdWebhookSecret)
-                                    options.nwcUri?.let { put("nwc-uri", it) }
                                     options.webPushVapidPublicKey.takeIf { it.isNotBlank() }?.let {
                                         put("web-push.vapid-public-key", it)
-                                    }
-                                    options.webPushVapidPrivateKey.takeIf { it.isNotBlank() }?.let {
-                                        put("web-push.vapid-private-key", it)
                                     }
                                     options.webPushVapidSubject.takeIf { it.isNotBlank() }?.let {
                                         put("web-push.vapid-subject", it)
@@ -349,11 +346,30 @@ class Ambrosia : CliktCommand() {
         return KeyStoreInfo(keyStore, storePassword, privateKeyPassword)
     }
 
+    private fun attemptAutoUnlock() {
+        if (!SecretsStore.isEncryptionActive()) return
+
+        val autoUnlockPassword = System.getenv("AUTO_UNLOCK_PASSWORD") ?: return
+        if (!SecretsStore.unlock(autoUnlockPassword.toCharArray())) {
+            System.err.println("AUTO_UNLOCK_PASSWORD is set but incorrect — cannot unlock secrets, aborting startup")
+            throw IllegalStateException("Invalid AUTO_UNLOCK_PASSWORD")
+        }
+    }
+
     private fun ensureWebPushConfig() {
         val existingValues = readConfValues(confFile)
-        val environmentVapidKeys = readEnvironmentVapidKeysOrNull()
         val missingVapidConfig =
             WEB_PUSH_VAPID_CONF_KEYS.any { existingValues[it].isNullOrBlank() }
+        val encryptionIsLocked = SecretsStore.isLocked()
+        if (missingVapidConfig && encryptionIsLocked) return
+
+        val environmentVapidKeys = readEnvironmentVapidKeysOrNull()
+        val currentDecryptedPrivateKeyOrNull =
+            if (missingVapidConfig || encryptionIsLocked) {
+                null
+            } else {
+                SecretsStore.getSecretOrNull(WEB_PUSH_VAPID_PRIVATE_KEY_CONF)
+            }
         val vapidKeys =
             if (missingVapidConfig) {
                 environmentVapidKeys ?: VapidKeyService.generateKeys(
@@ -362,24 +378,26 @@ class Ambrosia : CliktCommand() {
             } else {
                 environmentVapidKeys ?: VapidKeys(
                     publicKey = existingValues.getValue(WEB_PUSH_VAPID_PUBLIC_KEY_CONF),
-                    privateKey = existingValues.getValue(WEB_PUSH_VAPID_PRIVATE_KEY_CONF),
+                    privateKey = currentDecryptedPrivateKeyOrNull ?: "",
                     subject = existingValues.getValue(WEB_PUSH_VAPID_SUBJECT_CONF),
                 )
             }
 
-        val nextValues =
+        val nonSecretValues =
             mapOf(
                 WEB_PUSH_ENABLED_CONF to (existingValues[WEB_PUSH_ENABLED_CONF] ?: System.getenv("WEB_PUSH_ENABLED") ?: "true"),
                 WEB_PUSH_VAPID_PUBLIC_KEY_CONF to vapidKeys.publicKey,
-                WEB_PUSH_VAPID_PRIVATE_KEY_CONF to vapidKeys.privateKey,
                 WEB_PUSH_VAPID_SUBJECT_CONF to vapidKeys.subject,
             )
+        if (nonSecretValues.any { (key, value) -> existingValues[key] != value }) {
+            writeConfValues(confFile, nonSecretValues)
+        }
+        if (!encryptionIsLocked && vapidKeys.privateKey != currentDecryptedPrivateKeyOrNull) {
+            SecretsStore.setSecret(WEB_PUSH_VAPID_PRIVATE_KEY_CONF, vapidKeys.privateKey)
+        }
 
-        if (nextValues.any { (key, value) -> existingValues[key] != value }) {
-            writeConfValues(confFile, nextValues)
-            if (missingVapidConfig) {
-                println(yellow("Generated Web Push VAPID keys in ambrosia.conf"))
-            }
+        if (missingVapidConfig) {
+            println(yellow("Generated Web Push VAPID keys in ambrosia.conf"))
         }
     }
 

--- a/server/app/src/main/kotlin/pos/ambrosia/Ambrosia.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/Ambrosia.kt
@@ -244,6 +244,7 @@ class Ambrosia : CliktCommand() {
         try {
             ensureNwcUriPersisted()
             ensurePhoenixdPasswordPersisted()
+            ensurePhoenixdWebhookSecretPersisted()
             val (keyStore, storePassword, privateKeyPassword) = ensureKeyStore()
 
             val server =
@@ -260,7 +261,6 @@ class Ambrosia : CliktCommand() {
                                     put("secret", options.secret)
                                     put("phoenixd-url", options.phoenixdUrl)
                                     put("phoenixd-remote", options.phoenixdRemote.toString())
-                                    put("phoenix.webhook-secret", options.phoenixdWebhookSecret)
                                     options.webPushVapidPublicKey.takeIf { it.isNotBlank() }?.let {
                                         put("web-push.vapid-public-key", it)
                                     }
@@ -417,6 +417,14 @@ class Ambrosia : CliktCommand() {
         if (options.phoenixdPassword.isBlank()) return
 
         SecretsStore.setSecret("phoenixd-password", options.phoenixdPassword)
+    }
+
+    private fun ensurePhoenixdWebhookSecretPersisted() {
+        if (SecretsStore.isLocked()) return
+        if (SecretsStore.getSecretOrNull("phoenixd-webhook-secret") != null) return
+        if (options.phoenixdWebhookSecret.isBlank()) return
+
+        SecretsStore.setSecret("phoenixd-webhook-secret", options.phoenixdWebhookSecret)
     }
 
     private fun readEnvironmentVapidKeysOrNull(): VapidKeys? {

--- a/server/app/src/main/kotlin/pos/ambrosia/Api.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/Api.kt
@@ -46,6 +46,7 @@ import pos.ambrosia.api.configureProjects
 import pos.ambrosia.api.configureReports
 import pos.ambrosia.api.configureRoles
 import pos.ambrosia.api.configureRouting
+import pos.ambrosia.api.configureSecrets
 import pos.ambrosia.api.configureShifts
 import pos.ambrosia.api.configureSpaces
 import pos.ambrosia.api.configureStoreOrders
@@ -109,6 +110,7 @@ class Api {
         configureReports()
         configureShifts()
         configureWallet()
+        configureSecrets()
         configureBackup()
         configureBackupProgressWebsocket()
         configurePrinters()

--- a/server/app/src/main/kotlin/pos/ambrosia/api/Handler.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/api/Handler.kt
@@ -36,6 +36,7 @@ import pos.ambrosia.utils.PhoenixServiceException
 import pos.ambrosia.utils.PrintTicketException
 import pos.ambrosia.utils.ProductIsBundleComponentException
 import pos.ambrosia.utils.ResourceNotFoundException
+import pos.ambrosia.utils.SecretsLockedException
 import pos.ambrosia.utils.TimeEntryLockedException
 import pos.ambrosia.utils.UnauthorizedApiException
 import pos.ambrosia.utils.UnsupportedBackendOperationException
@@ -64,6 +65,10 @@ fun Application.handler() {
         exception<TimeEntryLockedException> { call, cause ->
             logger.warn("Locked time entry mutation rejected: ${cause.message}")
             call.respond(HttpStatusCode.Conflict, Message(cause.message ?: "Time entry is locked"))
+        }
+        exception<SecretsLockedException> { call, cause ->
+            logger.warn("Locked secrets access rejected: ${cause.message}")
+            call.respond(HttpStatusCode.Conflict, Message(cause.message ?: "Secrets are locked"))
         }
         exception<InvalidCredentialsException> { call, cause ->
             logger.warn("Invalid login attempt: ${cause.message}")

--- a/server/app/src/main/kotlin/pos/ambrosia/api/InitialSetup.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/api/InitialSetup.kt
@@ -33,6 +33,7 @@ import pos.ambrosia.services.CurrencyService
 import pos.ambrosia.services.PermissionsService
 import pos.ambrosia.services.PhoenixService
 import pos.ambrosia.services.RolesService
+import pos.ambrosia.services.SecretsStore
 import pos.ambrosia.services.TokenService
 import pos.ambrosia.services.UsersService
 import pos.ambrosia.services.WalletAdminNotificationService
@@ -181,7 +182,7 @@ private fun Route.initialSetupRoutes() {
         val nwcSaved =
             initialSetupRequest.nwcUri?.takeIf { it.isNotBlank() }?.let { uri ->
                 try {
-                    File(datadir.toString(), "ambrosia.conf").appendText("\nnwc-uri=$uri\n")
+                    SecretsStore.setSecret("nwc-uri", uri)
                     logger.info("NWC URI saved to ambrosia.conf — hot-reloading backend")
                     val walletAdminNotificationService =
                         WalletAdminNotificationService(createConfiguredAdminNotificationService(call.application.environment))
@@ -207,8 +208,9 @@ private fun Route.initialSetupRoutes() {
             } else {
                 try {
                     File(datadir.toString(), "ambrosia.conf").appendText(
-                        "\nphoenixd-remote=true\nphoenixd-url=$trimmedPhoenixdUrl\nphoenixd-password=$phoenixdPassword\n",
+                        "\nphoenixd-remote=true\nphoenixd-url=$trimmedPhoenixdUrl\n",
                     )
+                    SecretsStore.setSecret("phoenixd-password", phoenixdPassword)
                     logger.info("Remote phoenixd node saved to ambrosia.conf — hot-reloading backend")
                     ActiveLightningBackend.reinitializePhoenixBackend(trimmedPhoenixdUrl, phoenixdPassword)
                     true

--- a/server/app/src/main/kotlin/pos/ambrosia/api/Secrets.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/api/Secrets.kt
@@ -1,0 +1,50 @@
+package pos.ambrosia.api
+
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.Application
+import io.ktor.server.auth.authenticate
+import io.ktor.server.request.receive
+import io.ktor.server.response.respond
+import io.ktor.server.routing.get
+import io.ktor.server.routing.post
+import io.ktor.server.routing.route
+import io.ktor.server.routing.routing
+import pos.ambrosia.config.readConfValues
+import pos.ambrosia.models.ActivateSecretsEncryptionRequest
+import pos.ambrosia.models.Message
+import pos.ambrosia.models.SecretsStatusResponse
+import pos.ambrosia.models.UnlockSecretsRequest
+import pos.ambrosia.services.SecretsStore
+import pos.ambrosia.utils.InvalidCredentialsException
+
+fun Application.configureSecrets() {
+    routing {
+        route("/secrets") {
+            authenticate("auth-jwt-wallet") {
+                get("/status") {
+                    call.respond(
+                        HttpStatusCode.OK,
+                        SecretsStatusResponse(
+                            encryptionActive = SecretsStore.isEncryptionActive(),
+                            locked = SecretsStore.isLocked(),
+                        ),
+                    )
+                }
+                post("/unlock") {
+                    val unlockRequest = call.receive<UnlockSecretsRequest>()
+                    val unlockSucceeded = SecretsStore.unlock(unlockRequest.unlockPassword.toCharArray())
+                    if (!unlockSucceeded) {
+                        throw InvalidCredentialsException()
+                    }
+                    call.respond(HttpStatusCode.OK, Message("Secrets unlocked"))
+                }
+                post("/activate") {
+                    val activateRequest = call.receive<ActivateSecretsEncryptionRequest>()
+                    val currentPlaintextValues = readConfValues(SecretsStore.ambrosiaConfigFile)
+                    SecretsStore.activateEncryption(activateRequest.unlockPassword.toCharArray(), currentPlaintextValues)
+                    call.respond(HttpStatusCode.OK, Message("Secrets encryption activated"))
+                }
+            }
+        }
+    }
+}

--- a/server/app/src/main/kotlin/pos/ambrosia/api/Wallet.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/api/Wallet.kt
@@ -469,19 +469,20 @@ private fun Application.initializeLightningBackend(walletAdminNotificationServic
             ?.getString()
             .toBoolean()
     val phoenixdUrl = environment.config.propertyOrNull("phoenixd-url")?.getString() ?: ""
-    val phoenixdPassword = SecretsStore.getSecretOrNull("phoenixd-password") ?: AppConfig.getLocalPhoenixdPassword()
 
-    val backend: LightningBackend =
-        if (nwcUri != null) {
+    if (nwcUri != null) {
+        ActiveLightningBackend.set(
             NwcService.create(nwcUri, this) { paymentNotification ->
                 walletAdminNotificationService.notifyIncomingPaymentReceived(paymentNotification)
-            }
-        } else {
-            PhoenixService(phoenixdUrl, phoenixdPassword)
-        }
-    ActiveLightningBackend.set(backend)
+            },
+        )
+        return
+    }
 
-    if (nwcUri == null && phoenixdRemote) {
+    val phoenixdPassword = SecretsStore.getSecretOrNull("phoenixd-password") ?: AppConfig.getLocalPhoenixdPassword()
+    ActiveLightningBackend.set(PhoenixService(phoenixdUrl, phoenixdPassword))
+
+    if (phoenixdRemote) {
         ActiveLightningBackend.startPhoenixPaymentEventsListener(
             phoenixdUrl,
             phoenixdPassword,

--- a/server/app/src/main/kotlin/pos/ambrosia/api/Wallet.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/api/Wallet.kt
@@ -49,6 +49,7 @@ import pos.ambrosia.services.PaymentService
 import pos.ambrosia.services.PhoenixService
 import pos.ambrosia.services.RefundService
 import pos.ambrosia.services.RolesService
+import pos.ambrosia.services.SecretsStore
 import pos.ambrosia.services.TokenService
 import pos.ambrosia.services.WalletAdminNotificationService
 import pos.ambrosia.services.WalletRateService
@@ -60,32 +61,12 @@ import pos.ambrosia.utils.authenticateAdmin
 import pos.ambrosia.utils.getCurrentUser
 
 fun Application.configureWallet() {
-    val phoenixService = PhoenixService(environment)
     val walletAdminNotificationService =
         WalletAdminNotificationService(createConfiguredAdminNotificationService(environment))
-    val nwcUri = environment.config.propertyOrNull("nwc-uri")?.getString()
-    val phoenixdRemote =
-        environment.config
-            .propertyOrNull("phoenixd-remote")
-            ?.getString()
-            .toBoolean()
-    val backend: LightningBackend =
-        if (nwcUri != null) {
-            NwcService.create(nwcUri, this) { paymentNotification ->
-                walletAdminNotificationService.notifyIncomingPaymentReceived(paymentNotification)
-            }
-        } else {
-            phoenixService
-        }
-    ActiveLightningBackend.set(backend)
-    if (nwcUri == null && phoenixdRemote) {
-        val phoenixdUrl = environment.config.propertyOrNull("phoenixd-url")?.getString() ?: ""
-        val phoenixdPassword = environment.config.propertyOrNull("phoenixd-password")?.getString() ?: ""
-        ActiveLightningBackend.startPhoenixPaymentEventsListener(
-            phoenixdUrl,
-            phoenixdPassword,
-            buildPhoenixPaymentReceivedHandler(walletAdminNotificationService),
-        )
+    if (SecretsStore.isLocked()) {
+        SecretsStore.onUnlock { initializeLightningBackend(walletAdminNotificationService) }
+    } else {
+        initializeLightningBackend(walletAdminNotificationService)
     }
     monitor.subscribe(ApplicationStopping) { ActiveLightningBackend.closeActive() }
 
@@ -200,12 +181,12 @@ fun Route.wallet(
             } catch (exception: Exception) {
                 throw NwcConnectionException(code = "nwc_reconfigure_failed")
             }
-            replaceConfFileProperty(Path(datadir, "ambrosia.conf"), "nwc-uri", trimmedNwcUri)
+            SecretsStore.setSecret("nwc-uri", trimmedNwcUri)
             call.respond(HttpStatusCode.OK, Message("NWC backend reconfigured"))
         }
         post("/update-phoenixd-remote") {
             val updatePhoenixdRemoteRequest = call.receive<UpdatePhoenixdRemoteRequest>()
-            val configFile = Path(datadir, "ambrosia.conf")
+            val ambrosiaConfigFile = Path(datadir, "ambrosia.conf")
             if (updatePhoenixdRemoteRequest.phoenixdRemote) {
                 val trimmedPhoenixdUrl = updatePhoenixdRemoteRequest.phoenixdUrl?.trim()
                 val trimmedPhoenixdPassword = updatePhoenixdRemoteRequest.phoenixdPassword?.trim()
@@ -213,9 +194,9 @@ fun Route.wallet(
                     call.respond(HttpStatusCode.BadRequest, Message("Missing url or password"))
                     return@post
                 }
-                replaceConfFileProperty(configFile, "phoenixd-remote", "true")
-                replaceConfFileProperty(configFile, "phoenixd-url", trimmedPhoenixdUrl)
-                replaceConfFileProperty(configFile, "phoenixd-password", trimmedPhoenixdPassword)
+                replaceConfFileProperty(ambrosiaConfigFile, "phoenixd-remote", "true")
+                replaceConfFileProperty(ambrosiaConfigFile, "phoenixd-url", trimmedPhoenixdUrl)
+                SecretsStore.setSecret("phoenixd-password", trimmedPhoenixdPassword)
                 ActiveLightningBackend.reinitializePhoenixBackend(trimmedPhoenixdUrl, trimmedPhoenixdPassword)
                 ActiveLightningBackend.startPhoenixPaymentEventsListener(
                     trimmedPhoenixdUrl,
@@ -224,9 +205,9 @@ fun Route.wallet(
                 )
                 call.respond(HttpStatusCode.OK, Message("Remote phoenixd node configured"))
             } else {
-                replaceConfFileProperty(configFile, "phoenixd-remote", "false")
-                replaceConfFileProperty(configFile, "phoenixd-url", AppConfig.getLocalPhoenixdUrl())
-                replaceConfFileProperty(configFile, "phoenixd-password", AppConfig.getLocalPhoenixdPassword())
+                replaceConfFileProperty(ambrosiaConfigFile, "phoenixd-remote", "false")
+                replaceConfFileProperty(ambrosiaConfigFile, "phoenixd-url", AppConfig.getLocalPhoenixdUrl())
+                SecretsStore.setSecret("phoenixd-password", AppConfig.getLocalPhoenixdPassword())
                 call.respond(HttpStatusCode.OK, Message("Switched to local phoenixd — restart required to apply"))
             }
         }
@@ -477,6 +458,35 @@ fun Route.wallet(
                 call.respond(HttpStatusCode.OK, payment)
             }
         }
+    }
+}
+
+private fun Application.initializeLightningBackend(walletAdminNotificationService: WalletAdminNotificationService) {
+    val nwcUri = SecretsStore.getSecretOrNull("nwc-uri")
+    val phoenixdRemote =
+        environment.config
+            .propertyOrNull("phoenixd-remote")
+            ?.getString()
+            .toBoolean()
+    val phoenixdUrl = environment.config.propertyOrNull("phoenixd-url")?.getString() ?: ""
+    val phoenixdPassword = SecretsStore.getSecretOrNull("phoenixd-password") ?: AppConfig.getLocalPhoenixdPassword()
+
+    val backend: LightningBackend =
+        if (nwcUri != null) {
+            NwcService.create(nwcUri, this) { paymentNotification ->
+                walletAdminNotificationService.notifyIncomingPaymentReceived(paymentNotification)
+            }
+        } else {
+            PhoenixService(phoenixdUrl, phoenixdPassword)
+        }
+    ActiveLightningBackend.set(backend)
+
+    if (nwcUri == null && phoenixdRemote) {
+        ActiveLightningBackend.startPhoenixPaymentEventsListener(
+            phoenixdUrl,
+            phoenixdPassword,
+            buildPhoenixPaymentReceivedHandler(walletAdminNotificationService),
+        )
     }
 }
 

--- a/server/app/src/main/kotlin/pos/ambrosia/api/Webhook.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/api/Webhook.kt
@@ -10,6 +10,7 @@ import io.ktor.server.routing.routing
 import kotlinx.serialization.json.Json
 import pos.ambrosia.config.AppConfig
 import pos.ambrosia.logger
+import pos.ambrosia.services.SecretsStore
 import pos.ambrosia.services.WalletAdminNotificationService
 import pos.ambrosia.utils.PhoenixServiceException
 import java.security.MessageDigest
@@ -27,7 +28,7 @@ fun Application.configurePhoenixWebhook() {
 
 fun Route.phoenixWebhook(walletAdminNotificationService: WalletAdminNotificationService = WalletAdminNotificationService()) {
     post("/webhook/phoenixd") {
-        val secret = call.application.getPhoenixWebhookSecret()
+        val secret = getPhoenixWebhookSecret()
         if (secret.isNullOrBlank()) {
             logger.error("Phoenix webhook-secret not configured in phoenix.conf or application config")
             throw PhoenixServiceException("Missing phoenix webhook-secret; set webhook-secret in phoenix.conf")
@@ -95,6 +96,6 @@ private fun hexToBytes(hex: String): ByteArray? {
     }
 }
 
-private fun Application.getPhoenixWebhookSecret(): String? =
-    environment.config.propertyOrNull("phoenix.webhook-secret")?.getString()
+private fun getPhoenixWebhookSecret(): String? =
+    SecretsStore.getSecretOrNull("phoenixd-webhook-secret")
         ?: AppConfig.getPhoenixProperty("webhook-secret")

--- a/server/app/src/main/kotlin/pos/ambrosia/models/AppModels.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/models/AppModels.kt
@@ -102,6 +102,22 @@ data class RestartCapabilitiesResponse(
 )
 
 @Serializable
+data class SecretsStatusResponse(
+    val encryptionActive: Boolean,
+    val locked: Boolean,
+)
+
+@Serializable
+data class UnlockSecretsRequest(
+    val unlockPassword: String,
+)
+
+@Serializable
+data class ActivateSecretsEncryptionRequest(
+    val unlockPassword: String,
+)
+
+@Serializable
 data class User(
     val id: String? = null,
     val name: String,

--- a/server/app/src/main/kotlin/pos/ambrosia/services/ActiveLightningBackend.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/services/ActiveLightningBackend.kt
@@ -18,6 +18,7 @@ import pos.ambrosia.models.phoenix.PayOfferRequest
 import pos.ambrosia.models.phoenix.PayOnchainRequest
 import pos.ambrosia.models.phoenix.PaymentResponse
 import pos.ambrosia.models.phoenix.PhoenixBalance
+import pos.ambrosia.utils.SecretsLockedException
 import java.util.concurrent.atomic.AtomicReference
 
 private const val NWC_CONNECTION_TIMEOUT_MS = 15_000L
@@ -84,7 +85,12 @@ object ActiveLightningBackend : LightningBackend, PaymentVerifier {
         logger.info("Phoenix backend hot-reloaded — no restart required")
     }
 
-    private fun current(): LightningBackend = backendReference.get() ?: error("Lightning backend not initialized")
+    private fun current(): LightningBackend =
+        backendReference.get() ?: if (SecretsStore.isLocked()) {
+            throw SecretsLockedException()
+        } else {
+            error("Lightning backend not initialized")
+        }
 
     override suspend fun getNodeInfo(): NodeInfo = current().getNodeInfo()
 

--- a/server/app/src/main/kotlin/pos/ambrosia/services/PhoenixService.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/services/PhoenixService.kt
@@ -105,11 +105,6 @@ class PhoenixService(
         httpClient,
     )
 
-    constructor(app: ApplicationEnvironment) : this(
-        app,
-        buildHttpClient(app.config.property("phoenixd-password").getString()),
-    )
-
     constructor(phoenixdUrl: String, phoenixdPassword: String) : this(phoenixdUrl, buildHttpClient(phoenixdPassword))
 
     override fun close() {

--- a/server/app/src/main/kotlin/pos/ambrosia/services/SecretsStore.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/services/SecretsStore.kt
@@ -16,7 +16,8 @@ object SecretsStore {
     private const val ENCRYPTION_ACTIVE_CONF = "secrets-encrypted"
     private const val KDF_SALT_CONF = "secrets-kdf-salt"
     private const val KDF_SALT_LENGTH_BYTES = 32
-    private val ENCRYPTABLE_CONF_KEYS = setOf("phoenixd-password", "nwc-uri", "web-push-vapid-private-key")
+    private val ENCRYPTABLE_CONF_KEYS =
+        setOf("phoenixd-password", "nwc-uri", "web-push-vapid-private-key", "phoenixd-webhook-secret")
 
     var ambrosiaConfigFile: Path = Path(datadir, "ambrosia.conf")
     private val unlockKeyReference = AtomicReference<SecretKeySpec?>(null)

--- a/server/app/src/main/kotlin/pos/ambrosia/services/SecretsStore.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/services/SecretsStore.kt
@@ -1,0 +1,100 @@
+package pos.ambrosia.services
+
+import kotlinx.io.files.Path
+import org.bouncycastle.util.encoders.Hex
+import pos.ambrosia.config.readConfValues
+import pos.ambrosia.config.replaceConfFileProperty
+import pos.ambrosia.config.writeConfValues
+import pos.ambrosia.datadir
+import pos.ambrosia.utils.SecretsCipher
+import pos.ambrosia.utils.SecretsLockedException
+import java.security.SecureRandom
+import java.util.concurrent.atomic.AtomicReference
+import javax.crypto.spec.SecretKeySpec
+
+object SecretsStore {
+    private const val ENCRYPTION_ACTIVE_CONF = "secrets-encrypted"
+    private const val KDF_SALT_CONF = "secrets-kdf-salt"
+    private const val KDF_SALT_LENGTH_BYTES = 32
+    private val ENCRYPTABLE_CONF_KEYS = setOf("phoenixd-password", "nwc-uri", "web-push-vapid-private-key")
+
+    var ambrosiaConfigFile: Path = Path(datadir, "ambrosia.conf")
+    private val unlockKeyReference = AtomicReference<SecretKeySpec?>(null)
+    private val unlockCallbacks = mutableListOf<() -> Unit>()
+    private val secureRandom = SecureRandom()
+
+    fun resetForTesting() {
+        ambrosiaConfigFile = Path(datadir, "ambrosia.conf")
+        unlockKeyReference.set(null)
+        unlockCallbacks.clear()
+    }
+
+    fun lockForTesting() {
+        unlockKeyReference.set(null)
+    }
+
+    fun isEncryptionActive(): Boolean = readConfValues(ambrosiaConfigFile)[ENCRYPTION_ACTIVE_CONF] == "true"
+
+    fun isLocked(): Boolean = isEncryptionActive() && unlockKeyReference.get() == null
+
+    fun onUnlock(callback: () -> Unit) {
+        unlockCallbacks.add(callback)
+    }
+
+    fun unlock(unlockPassword: CharArray): Boolean {
+        val storedValues = readConfValues(ambrosiaConfigFile)
+        val kdfSaltHex = storedValues[KDF_SALT_CONF] ?: return false
+        val candidateEnvelope = ENCRYPTABLE_CONF_KEYS.firstNotNullOfOrNull { storedValues[it] } ?: return false
+
+        val candidateKey = SecretsCipher.deriveKey(unlockPassword, Hex.decode(kdfSaltHex))
+        val unlockSucceeded = runCatching { SecretsCipher.decrypt(candidateEnvelope, candidateKey) }.isSuccess
+
+        if (unlockSucceeded) {
+            unlockKeyReference.set(candidateKey)
+            unlockCallbacks.forEach { it() }
+        }
+        return unlockSucceeded
+    }
+
+    fun getSecretOrNull(key: String): String? {
+        val storedValue = readConfValues(ambrosiaConfigFile)[key] ?: return null
+        if (key !in ENCRYPTABLE_CONF_KEYS || !isEncryptionActive()) return storedValue
+
+        val secretKey = unlockKeyReference.get() ?: throw SecretsLockedException()
+        return SecretsCipher.decrypt(storedValue, secretKey)
+    }
+
+    fun setSecret(
+        key: String,
+        plaintextValue: String,
+    ) {
+        if (key !in ENCRYPTABLE_CONF_KEYS || !isEncryptionActive()) {
+            replaceConfFileProperty(ambrosiaConfigFile, key, plaintextValue)
+            return
+        }
+
+        val secretKey = unlockKeyReference.get() ?: throw SecretsLockedException()
+        replaceConfFileProperty(ambrosiaConfigFile, key, SecretsCipher.encrypt(plaintextValue, secretKey))
+    }
+
+    fun activateEncryption(
+        unlockPassword: CharArray,
+        plaintextValues: Map<String, String>,
+    ) {
+        val kdfSalt = ByteArray(KDF_SALT_LENGTH_BYTES).also { secureRandom.nextBytes(it) }
+        val secretKey = SecretsCipher.deriveKey(unlockPassword, kdfSalt)
+
+        val encryptedValues =
+            plaintextValues
+                .filterKeys { it in ENCRYPTABLE_CONF_KEYS }
+                .mapValues { (_, plaintextValue) -> SecretsCipher.encrypt(plaintextValue, secretKey) }
+
+        writeConfValues(
+            ambrosiaConfigFile,
+            encryptedValues + mapOf(KDF_SALT_CONF to Hex.toHexString(kdfSalt), ENCRYPTION_ACTIVE_CONF to "true"),
+        )
+
+        unlockKeyReference.set(secretKey)
+        unlockCallbacks.forEach { it() }
+    }
+}

--- a/server/app/src/main/kotlin/pos/ambrosia/services/SecretsStore.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/services/SecretsStore.kt
@@ -56,25 +56,25 @@ object SecretsStore {
         return unlockSucceeded
     }
 
-    fun getSecretOrNull(key: String): String? {
-        val storedValue = readConfValues(ambrosiaConfigFile)[key] ?: return null
-        if (key !in ENCRYPTABLE_CONF_KEYS || !isEncryptionActive()) return storedValue
+    fun getSecretOrNull(secretName: String): String? {
+        val storedValue = readConfValues(ambrosiaConfigFile)[secretName] ?: return null
+        if (secretName !in ENCRYPTABLE_CONF_KEYS || !isEncryptionActive()) return storedValue
 
         val secretKey = unlockKeyReference.get() ?: throw SecretsLockedException()
         return SecretsCipher.decrypt(storedValue, secretKey)
     }
 
     fun setSecret(
-        key: String,
+        secretName: String,
         plaintextValue: String,
     ) {
-        if (key !in ENCRYPTABLE_CONF_KEYS || !isEncryptionActive()) {
-            replaceConfFileProperty(ambrosiaConfigFile, key, plaintextValue)
+        if (secretName !in ENCRYPTABLE_CONF_KEYS || !isEncryptionActive()) {
+            replaceConfFileProperty(ambrosiaConfigFile, secretName, plaintextValue)
             return
         }
 
         val secretKey = unlockKeyReference.get() ?: throw SecretsLockedException()
-        replaceConfFileProperty(ambrosiaConfigFile, key, SecretsCipher.encrypt(plaintextValue, secretKey))
+        replaceConfFileProperty(ambrosiaConfigFile, secretName, SecretsCipher.encrypt(plaintextValue, secretKey))
     }
 
     fun activateEncryption(

--- a/server/app/src/main/kotlin/pos/ambrosia/services/VapidKeyService.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/services/VapidKeyService.kt
@@ -1,6 +1,7 @@
 package pos.ambrosia.services
 
 import io.ktor.server.application.ApplicationEnvironment
+import pos.ambrosia.utils.SecretsLockedException
 import java.math.BigInteger
 import java.security.KeyPairGenerator
 import java.security.interfaces.ECPrivateKey
@@ -26,7 +27,12 @@ class VapidKeyService(
 
     fun getConfiguredKeysOrNull(): VapidKeys? {
         val configuredPublicKey = environment.configValue("web-push.vapid-public-key")
-        val configuredPrivateKey = environment.configValue("web-push.vapid-private-key")
+        val configuredPrivateKey =
+            try {
+                SecretsStore.getSecretOrNull("web-push-vapid-private-key")
+            } catch (secretsLockedException: SecretsLockedException) {
+                null
+            }
         val configuredSubject = environment.configValue("web-push.vapid-subject")
 
         if (configuredPublicKey == null || configuredPrivateKey == null || configuredSubject == null) {

--- a/server/app/src/main/kotlin/pos/ambrosia/utils/Exceptions.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/utils/Exceptions.kt
@@ -98,6 +98,10 @@ class TimeEntryLockedException(
     message: String = "Time entry is locked because it belongs to an invoice",
 ) : IllegalStateException(message)
 
+class SecretsLockedException(
+    message: String = "Secrets are locked — unlock the server before using this feature",
+) : IllegalStateException(message)
+
 class InitialSetupException(
     message: String = "Initial setup failed",
 ) : RuntimeException(message)

--- a/server/app/src/main/kotlin/pos/ambrosia/utils/SecretsCipher.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/utils/SecretsCipher.kt
@@ -1,0 +1,81 @@
+package pos.ambrosia.utils
+
+import org.bouncycastle.crypto.generators.Argon2BytesGenerator
+import org.bouncycastle.crypto.params.Argon2Parameters
+import org.bouncycastle.util.encoders.Hex
+import java.security.SecureRandom
+import javax.crypto.Cipher
+import javax.crypto.spec.GCMParameterSpec
+import javax.crypto.spec.SecretKeySpec
+
+object SecretsCipher {
+    private const val ARGON2_ITERATIONS = 3
+    private const val ARGON2_MEMORY_KB = 32 * 1024
+    private const val ARGON2_PARALLELISM = 1
+    private const val AES_KEY_LENGTH_BYTES = 32
+    private const val INITIALIZATION_VECTOR_LENGTH_BYTES = 12
+    private const val AUTHENTICATION_TAG_LENGTH_BITS = 128
+    private const val ENVELOPE_SEPARATOR = ":"
+    private val secureRandom = SecureRandom()
+
+    fun deriveKey(
+        unlockPassword: CharArray,
+        kdfSalt: ByteArray,
+    ): SecretKeySpec {
+        val argon2Parameters =
+            Argon2Parameters
+                .Builder(Argon2Parameters.ARGON2_id)
+                .withVersion(Argon2Parameters.ARGON2_VERSION_13)
+                .withIterations(ARGON2_ITERATIONS)
+                .withMemoryAsKB(ARGON2_MEMORY_KB)
+                .withParallelism(ARGON2_PARALLELISM)
+                .withSalt(kdfSalt)
+                .build()
+
+        val argon2Generator = Argon2BytesGenerator()
+        argon2Generator.init(argon2Parameters)
+
+        val derivedKeyBytes = ByteArray(AES_KEY_LENGTH_BYTES)
+        argon2Generator.generateBytes(unlockPassword, derivedKeyBytes)
+        unlockPassword.fill(Char(0))
+
+        return SecretKeySpec(derivedKeyBytes, "AES")
+    }
+
+    fun encrypt(
+        plaintext: String,
+        secretKey: SecretKeySpec,
+    ): String {
+        val initializationVector = ByteArray(INITIALIZATION_VECTOR_LENGTH_BYTES).also { secureRandom.nextBytes(it) }
+
+        val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+        cipher.init(
+            Cipher.ENCRYPT_MODE,
+            secretKey,
+            GCMParameterSpec(AUTHENTICATION_TAG_LENGTH_BITS, initializationVector),
+        )
+        val ciphertext = cipher.doFinal(plaintext.toByteArray(Charsets.UTF_8))
+
+        return Hex.toHexString(initializationVector) + ENVELOPE_SEPARATOR + Hex.toHexString(ciphertext)
+    }
+
+    fun decrypt(
+        envelope: String,
+        secretKey: SecretKeySpec,
+    ): String {
+        val separatorIndex = envelope.indexOf(ENVELOPE_SEPARATOR)
+        require(separatorIndex > 0) { "Malformed secrets envelope" }
+
+        val initializationVector = Hex.decode(envelope.substring(0, separatorIndex))
+        val ciphertext = Hex.decode(envelope.substring(separatorIndex + 1))
+
+        val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+        cipher.init(
+            Cipher.DECRYPT_MODE,
+            secretKey,
+            GCMParameterSpec(AUTHENTICATION_TAG_LENGTH_BITS, initializationVector),
+        )
+
+        return String(cipher.doFinal(ciphertext), Charsets.UTF_8)
+    }
+}

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/ActiveLightningBackendTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/ActiveLightningBackendTest.kt
@@ -3,18 +3,43 @@ package pos.ambrosia.utest
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.runBlocking
+import kotlinx.io.files.Path
+import org.junit.After
+import org.junit.Before
 import org.mockito.kotlin.mock
 import pos.ambrosia.nwc.NwcClientPort
 import pos.ambrosia.services.ActiveLightningBackend
 import pos.ambrosia.services.NwcService
 import pos.ambrosia.services.PaymentVerifier
+import pos.ambrosia.services.SecretsStore
 import pos.ambrosia.utils.FakeLightningBackend
+import pos.ambrosia.utils.SecretsLockedException
+import java.io.File
+import java.nio.file.Files
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class ActiveLightningBackendTest {
+    private lateinit var configFile: File
+
+    @Before
+    fun setUp() {
+        ActiveLightningBackend.closeActive()
+        configFile = Files.createTempFile("activeLightningBackendTestConfig", ".conf").toFile()
+        SecretsStore.resetForTesting()
+        SecretsStore.ambrosiaConfigFile = Path(configFile.absolutePath)
+    }
+
+    @After
+    fun tearDown() {
+        ActiveLightningBackend.closeActive()
+        SecretsStore.resetForTesting()
+        configFile.delete()
+    }
+
     @Test
     fun `paymentVerifier resolves the active backend even when captured before a switch`() {
         runBlocking {
@@ -77,5 +102,24 @@ class ActiveLightningBackendTest {
         ActiveLightningBackend.set(nwcService)
 
         assertTrue(ActiveLightningBackend.isNwcActive())
+    }
+
+    @Test
+    fun `getNodeInfo throws SecretsLockedException when no backend was set and secrets are locked`() {
+        configFile.writeText("secrets-encrypted=true\n")
+
+        assertFailsWith<SecretsLockedException> {
+            runBlocking { ActiveLightningBackend.getNodeInfo() }
+        }
+    }
+
+    @Test
+    fun `getNodeInfo throws the generic not-initialized error when no backend was set and encryption is inactive`() {
+        val thrownException =
+            assertFailsWith<IllegalStateException> {
+                runBlocking { ActiveLightningBackend.getNodeInfo() }
+            }
+
+        assertEquals("Lightning backend not initialized", thrownException.message)
     }
 }

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/JvmWebPushDispatchClientTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/JvmWebPushDispatchClientTest.kt
@@ -2,16 +2,22 @@ package pos.ambrosia.utest
 
 import io.ktor.server.config.MapApplicationConfig
 import io.ktor.server.engine.applicationEnvironment
+import kotlinx.io.files.Path
 import org.bouncycastle.jce.provider.BouncyCastleProvider
+import org.junit.After
+import org.junit.Before
 import org.junit.BeforeClass
 import pos.ambrosia.services.JvmWebPushDispatchClient
 import pos.ambrosia.services.JvmWebPushSender
 import pos.ambrosia.services.NoopWebPushDispatchClient
+import pos.ambrosia.services.SecretsStore
 import pos.ambrosia.services.VapidKeys
 import pos.ambrosia.services.WebPushDispatchClients
 import pos.ambrosia.services.WebPushDispatchPayload
 import pos.ambrosia.services.WebPushDispatchSubscription
+import java.io.File
 import java.math.BigInteger
+import java.nio.file.Files
 import java.security.KeyPairGenerator
 import java.security.Security
 import java.security.interfaces.ECPrivateKey
@@ -24,6 +30,21 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class JvmWebPushDispatchClientTest {
+    private lateinit var configFile: File
+
+    @Before
+    fun setUp() {
+        configFile = Files.createTempFile("jvmWebPushDispatchClientTestConfig", ".conf").toFile()
+        SecretsStore.resetForTesting()
+        SecretsStore.ambrosiaConfigFile = Path(configFile.absolutePath)
+    }
+
+    @After
+    fun tearDown() {
+        SecretsStore.resetForTesting()
+        configFile.delete()
+    }
+
     @Test
     fun `factory uses noop client when push dispatch is not configured`() {
         val environment = applicationEnvironment { config = MapApplicationConfig() }
@@ -68,13 +89,13 @@ class JvmWebPushDispatchClientTest {
     @Test
     fun `factory uses JVM dispatcher when web push is enabled and VAPID is configured`() {
         val vapidKeys = generateVapidKeys()
+        configFile.writeText("web-push-vapid-private-key=${vapidKeys.privateKey}\n")
         val environment =
             applicationEnvironment {
                 config =
                     MapApplicationConfig(
                         "web-push.enabled" to "true",
                         "web-push.vapid-public-key" to vapidKeys.publicKey,
-                        "web-push.vapid-private-key" to vapidKeys.privateKey,
                         "web-push.vapid-subject" to vapidKeys.subject,
                     )
             }

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/PhoenixWebhookRouteTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/PhoenixWebhookRouteTest.kt
@@ -9,21 +9,39 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.server.application.install
-import io.ktor.server.config.MapApplicationConfig
 import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.server.testing.testApplication
+import kotlinx.io.files.Path
+import org.junit.After
+import org.junit.Before
 import pos.ambrosia.api.calculatePhoenixSignature
 import pos.ambrosia.api.configurePhoenixWebhook
+import pos.ambrosia.services.SecretsStore
+import java.io.File
+import java.nio.file.Files
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class PhoenixWebhookRouteTest {
+    private lateinit var configFile: File
+
+    @Before
+    fun setUp() {
+        configFile = Files.createTempFile("phoenixWebhookRouteTestConfig", ".conf").toFile()
+        SecretsStore.resetForTesting()
+        SecretsStore.ambrosiaConfigFile = Path(configFile.absolutePath)
+    }
+
+    @After
+    fun tearDown() {
+        SecretsStore.resetForTesting()
+        configFile.delete()
+    }
+
     @Test
     fun `rejects webhook without signature header`() =
         testApplication {
-            environment {
-                config = MapApplicationConfig("phoenix.webhook-secret" to "supersecret")
-            }
+            configFile.writeText("phoenixd-webhook-secret=supersecret\n")
             application {
                 this@application.install(ContentNegotiation) { json() }
                 configurePhoenixWebhook()
@@ -47,9 +65,7 @@ class PhoenixWebhookRouteTest {
                 {"type":"payment_received","amountSat":15,"paymentHash":"abc123"}
                 """.trimIndent()
 
-            environment {
-                config = MapApplicationConfig("phoenix.webhook-secret" to secret)
-            }
+            configFile.writeText("phoenixd-webhook-secret=$secret\n")
             application {
                 this@application.install(ContentNegotiation) { json() }
                 configurePhoenixWebhook()

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/SecretsCipherTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/SecretsCipherTest.kt
@@ -1,0 +1,76 @@
+package pos.ambrosia.utest
+
+import pos.ambrosia.utils.SecretsCipher
+import java.security.SecureRandom
+import javax.crypto.BadPaddingException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+class SecretsCipherTest {
+    private val secureRandom = SecureRandom()
+
+    private fun randomSalt(): ByteArray = ByteArray(32).also { secureRandom.nextBytes(it) }
+
+    @Test
+    fun `encrypt then decrypt with the same key returns the original plaintext`() {
+        val secretKey = SecretsCipher.deriveKey("correct-unlock-password".toCharArray(), randomSalt())
+
+        val envelope = SecretsCipher.encrypt("http://100.1.1.1:9740-password", secretKey)
+
+        assertEquals("http://100.1.1.1:9740-password", SecretsCipher.decrypt(envelope, secretKey))
+    }
+
+    @Test
+    fun `decrypting with a key derived from the wrong password fails`() {
+        val salt = randomSalt()
+        val correctKey = SecretsCipher.deriveKey("correct-unlock-password".toCharArray(), salt)
+        val wrongKey = SecretsCipher.deriveKey("wrong-unlock-password".toCharArray(), salt)
+
+        val envelope = SecretsCipher.encrypt("remote-password", correctKey)
+
+        assertFailsWith<BadPaddingException> {
+            SecretsCipher.decrypt(envelope, wrongKey)
+        }
+    }
+
+    @Test
+    fun `decrypting a malformed envelope fails`() {
+        val secretKey = SecretsCipher.deriveKey("correct-unlock-password".toCharArray(), randomSalt())
+
+        assertFailsWith<IllegalArgumentException> {
+            SecretsCipher.decrypt("not-a-valid-envelope", secretKey)
+        }
+    }
+
+    @Test
+    fun `encrypting the same plaintext twice produces different envelopes`() {
+        val secretKey = SecretsCipher.deriveKey("correct-unlock-password".toCharArray(), randomSalt())
+
+        assertNotEquals(
+            SecretsCipher.encrypt("remote-password", secretKey),
+            SecretsCipher.encrypt("remote-password", secretKey),
+        )
+    }
+
+    @Test
+    fun `deriving a key from the same password and salt produces the same key`() {
+        val salt = randomSalt()
+
+        val firstKey = SecretsCipher.deriveKey("correct-unlock-password".toCharArray(), salt)
+        val secondKey = SecretsCipher.deriveKey("correct-unlock-password".toCharArray(), salt)
+
+        assertEquals(firstKey, secondKey)
+    }
+
+    @Test
+    fun `deriveKey clears the unlock password array after use`() {
+        val unlockPassword = "correct-unlock-password".toCharArray()
+
+        SecretsCipher.deriveKey(unlockPassword, randomSalt())
+
+        assertTrue(unlockPassword.all { it == Char(0) })
+    }
+}

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/SecretsRouteTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/SecretsRouteTest.kt
@@ -1,0 +1,160 @@
+package pos.ambrosia.utest
+
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.Application
+import io.ktor.server.application.install
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.testing.testApplication
+import kotlinx.io.files.Path
+import kotlinx.serialization.json.Json
+import org.junit.After
+import org.junit.Before
+import pos.ambrosia.api.configureSecrets
+import pos.ambrosia.api.handler
+import pos.ambrosia.models.SecretsStatusResponse
+import pos.ambrosia.services.SecretsStore
+import pos.ambrosia.utils.ExposedTestDb
+import pos.ambrosia.utils.installWalletAuth
+import pos.ambrosia.utils.withWalletAuthCookie
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+private fun Application.installTestSecretsRoutes() {
+    install(ContentNegotiation) { json() }
+    handler()
+    configureSecrets()
+}
+
+class SecretsRouteTest {
+    private lateinit var databaseFile: File
+    private lateinit var configFile: File
+
+    @Before
+    fun setUp() {
+        databaseFile = ExposedTestDb.connect()
+        configFile = Files.createTempFile("secretsRouteTestConfig", ".conf").toFile()
+        SecretsStore.resetForTesting()
+        SecretsStore.ambrosiaConfigFile = Path(configFile.absolutePath)
+    }
+
+    @After
+    fun tearDown() {
+        ExposedTestDb.cleanup(databaseFile)
+        SecretsStore.resetForTesting()
+        configFile.delete()
+    }
+
+    @Test
+    fun `status returns unauthorized without a wallet session`() =
+        testApplication {
+            installWalletAuth()
+            application { installTestSecretsRoutes() }
+
+            val statusResponse = client.get("/secrets/status")
+
+            assertEquals(HttpStatusCode.Unauthorized, statusResponse.status)
+        }
+
+    @Test
+    fun `status reflects inactive encryption by default`() =
+        testApplication {
+            val walletAccessToken = installWalletAuth()
+            application { installTestSecretsRoutes() }
+
+            val statusResponse = client.get("/secrets/status") { withWalletAuthCookie(walletAccessToken) }
+            val status = Json.decodeFromString<SecretsStatusResponse>(statusResponse.bodyAsText())
+
+            assertEquals(HttpStatusCode.OK, statusResponse.status)
+            assertFalse(status.encryptionActive)
+            assertFalse(status.locked)
+        }
+
+    @Test
+    fun `unlock returns unauthorized without a wallet session`() =
+        testApplication {
+            installWalletAuth()
+            application { installTestSecretsRoutes() }
+
+            val unlockResponse = client.post("/secrets/unlock")
+
+            assertEquals(HttpStatusCode.Unauthorized, unlockResponse.status)
+        }
+
+    @Test
+    fun `unlock with the wrong password returns unauthorized`() =
+        testApplication {
+            val walletAccessToken = installWalletAuth()
+            application { installTestSecretsRoutes() }
+
+            val activateResponse =
+                client.post("/secrets/activate") {
+                    withWalletAuthCookie(walletAccessToken)
+                    contentType(ContentType.Application.Json)
+                    setBody("""{"unlockPassword":"correct-unlock-password"}""")
+                }
+            assertEquals(HttpStatusCode.OK, activateResponse.status)
+            SecretsStore.lockForTesting()
+
+            val unlockResponse =
+                client.post("/secrets/unlock") {
+                    withWalletAuthCookie(walletAccessToken)
+                    contentType(ContentType.Application.Json)
+                    setBody("""{"unlockPassword":"wrong-unlock-password"}""")
+                }
+
+            assertEquals(HttpStatusCode.Unauthorized, unlockResponse.status)
+        }
+
+    @Test
+    fun `activate returns unauthorized without a wallet session`() =
+        testApplication {
+            installWalletAuth()
+            application { installTestSecretsRoutes() }
+
+            val activateResponse = client.post("/secrets/activate")
+
+            assertEquals(HttpStatusCode.Unauthorized, activateResponse.status)
+        }
+
+    @Test
+    fun `activate then status reports active and unlocked, and unlock with the same password succeeds`() =
+        testApplication {
+            val walletAccessToken = installWalletAuth()
+            application { installTestSecretsRoutes() }
+            configFile.writeText("phoenixd-password=remote-password\n")
+
+            val activateResponse =
+                client.post("/secrets/activate") {
+                    withWalletAuthCookie(walletAccessToken)
+                    contentType(ContentType.Application.Json)
+                    setBody("""{"unlockPassword":"correct-unlock-password"}""")
+                }
+            assertEquals(HttpStatusCode.OK, activateResponse.status)
+
+            val statusResponse = client.get("/secrets/status") { withWalletAuthCookie(walletAccessToken) }
+            val status = Json.decodeFromString<SecretsStatusResponse>(statusResponse.bodyAsText())
+            assertTrue(status.encryptionActive)
+            assertFalse(status.locked)
+
+            SecretsStore.lockForTesting()
+            val unlockResponse =
+                client.post("/secrets/unlock") {
+                    withWalletAuthCookie(walletAccessToken)
+                    contentType(ContentType.Application.Json)
+                    setBody("""{"unlockPassword":"correct-unlock-password"}""")
+                }
+
+            assertEquals(HttpStatusCode.OK, unlockResponse.status)
+        }
+}

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/SecretsStoreTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/SecretsStoreTest.kt
@@ -1,0 +1,153 @@
+package pos.ambrosia.utest
+
+import kotlinx.io.files.Path
+import org.bouncycastle.util.encoders.Hex
+import org.junit.After
+import org.junit.Before
+import pos.ambrosia.services.SecretsStore
+import pos.ambrosia.utils.SecretsCipher
+import pos.ambrosia.utils.SecretsLockedException
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class SecretsStoreTest {
+    private lateinit var configFile: File
+
+    @Before
+    fun setUp() {
+        configFile = Files.createTempFile("secretsStoreTestConfig", ".conf").toFile()
+        SecretsStore.resetForTesting()
+        SecretsStore.ambrosiaConfigFile = Path(configFile.absolutePath)
+    }
+
+    @After
+    fun tearDown() {
+        SecretsStore.resetForTesting()
+        configFile.delete()
+    }
+
+    private fun writeLockedEncryptedConfig(unlockPassword: String) {
+        val kdfSalt = ByteArray(32)
+        val secretKey = SecretsCipher.deriveKey(unlockPassword.toCharArray(), kdfSalt)
+        val envelope = SecretsCipher.encrypt("remote-password", secretKey)
+        configFile.writeText(
+            "secrets-encrypted=true\nsecrets-kdf-salt=${Hex.toHexString(kdfSalt)}\nphoenixd-password=$envelope\n",
+        )
+    }
+
+    @Test
+    fun `isEncryptionActive returns false when the flag is absent`() {
+        assertFalse(SecretsStore.isEncryptionActive())
+    }
+
+    @Test
+    fun `isLocked returns false when encryption is not active`() {
+        assertFalse(SecretsStore.isLocked())
+    }
+
+    @Test
+    fun `getSecretOrNull returns null for a key that is not configured`() {
+        assertNull(SecretsStore.getSecretOrNull("phoenixd-password"))
+    }
+
+    @Test
+    fun `getSecretOrNull passes through plaintext when encryption is not active`() {
+        configFile.writeText("phoenixd-password=plain-password\n")
+
+        assertEquals("plain-password", SecretsStore.getSecretOrNull("phoenixd-password"))
+    }
+
+    @Test
+    fun `setSecret writes plaintext when encryption is not active`() {
+        SecretsStore.setSecret("phoenixd-password", "plain-password")
+
+        assertEquals("phoenixd-password=plain-password", configFile.readText().trim())
+    }
+
+    @Test
+    fun `activateEncryption encrypts only the encryptable keys and marks encryption active`() {
+        SecretsStore.activateEncryption(
+            "correct-unlock-password".toCharArray(),
+            mapOf("phoenixd-password" to "remote-password", "phoenixd-url" to "http://100.1.1.1:9740"),
+        )
+
+        assertTrue(SecretsStore.isEncryptionActive())
+        assertFalse(SecretsStore.isLocked())
+        assertFalse(configFile.readText().contains("remote-password"))
+        assertFalse(configFile.readText().contains("phoenixd-url"))
+    }
+
+    @Test
+    fun `activateEncryption leaves the store unlocked so the encrypted value can be read back immediately`() {
+        SecretsStore.activateEncryption("correct-unlock-password".toCharArray(), mapOf("phoenixd-password" to "remote-password"))
+
+        assertEquals("remote-password", SecretsStore.getSecretOrNull("phoenixd-password"))
+    }
+
+    @Test
+    fun `getSecretOrNull throws SecretsLockedException when encryption is active and locked`() {
+        writeLockedEncryptedConfig("correct-unlock-password")
+
+        assertFailsWith<SecretsLockedException> {
+            SecretsStore.getSecretOrNull("phoenixd-password")
+        }
+    }
+
+    @Test
+    fun `setSecret throws SecretsLockedException when encryption is active and locked`() {
+        writeLockedEncryptedConfig("correct-unlock-password")
+
+        assertFailsWith<SecretsLockedException> {
+            SecretsStore.setSecret("phoenixd-password", "new-password")
+        }
+    }
+
+    @Test
+    fun `getSecretOrNull ignores lock state for keys outside the encryptable set`() {
+        writeLockedEncryptedConfig("correct-unlock-password")
+        SecretsStore.setSecret("phoenixd-url", "http://100.1.1.1:9740")
+
+        assertEquals("http://100.1.1.1:9740", SecretsStore.getSecretOrNull("phoenixd-url"))
+    }
+
+    @Test
+    fun `unlock with the correct password re-derives the key and unlocks the store`() {
+        SecretsStore.activateEncryption("correct-unlock-password".toCharArray(), mapOf("phoenixd-password" to "remote-password"))
+        SecretsStore.lockForTesting()
+
+        val unlockSucceeded = SecretsStore.unlock("correct-unlock-password".toCharArray())
+
+        assertTrue(unlockSucceeded)
+        assertFalse(SecretsStore.isLocked())
+        assertEquals("remote-password", SecretsStore.getSecretOrNull("phoenixd-password"))
+    }
+
+    @Test
+    fun `unlock with the wrong password fails and keeps the store locked`() {
+        SecretsStore.activateEncryption("correct-unlock-password".toCharArray(), mapOf("phoenixd-password" to "remote-password"))
+        SecretsStore.lockForTesting()
+
+        val unlockSucceeded = SecretsStore.unlock("wrong-unlock-password".toCharArray())
+
+        assertFalse(unlockSucceeded)
+        assertTrue(SecretsStore.isLocked())
+    }
+
+    @Test
+    fun `unlock fires the registered onUnlock callbacks`() {
+        SecretsStore.activateEncryption("correct-unlock-password".toCharArray(), mapOf("phoenixd-password" to "remote-password"))
+        SecretsStore.lockForTesting()
+        var callbackFired = false
+        SecretsStore.onUnlock { callbackFired = true }
+
+        SecretsStore.unlock("correct-unlock-password".toCharArray())
+
+        assertTrue(callbackFired)
+    }
+}

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/VapidKeyServiceTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/VapidKeyServiceTest.kt
@@ -1,0 +1,105 @@
+package pos.ambrosia.utest
+
+import io.ktor.server.config.MapApplicationConfig
+import io.ktor.server.engine.applicationEnvironment
+import kotlinx.io.files.Path
+import org.junit.After
+import org.junit.Before
+import pos.ambrosia.services.SecretsStore
+import pos.ambrosia.services.VapidKeyService
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class VapidKeyServiceTest {
+    private lateinit var configFile: File
+
+    @Before
+    fun setUp() {
+        configFile = Files.createTempFile("vapidKeyServiceTestConfig", ".conf").toFile()
+        SecretsStore.resetForTesting()
+        SecretsStore.ambrosiaConfigFile = Path(configFile.absolutePath)
+    }
+
+    @After
+    fun tearDown() {
+        SecretsStore.resetForTesting()
+        configFile.delete()
+    }
+
+    private fun vapidKeyService(vararg additionalConfigEntries: Pair<String, String>): VapidKeyService =
+        VapidKeyService(
+            applicationEnvironment {
+                config =
+                    MapApplicationConfig(
+                        "web-push.vapid-public-key" to "real-public-key",
+                        "web-push.vapid-subject" to "mailto:test@example.com",
+                        *additionalConfigEntries,
+                    )
+            },
+        )
+
+    @Test
+    fun `isWebPushEnabled returns true when the enabled flag is absent`() {
+        assertTrue(vapidKeyService().isWebPushEnabled())
+    }
+
+    @Test
+    fun `isWebPushEnabled returns false when the enabled flag is explicitly false`() {
+        assertFalse(vapidKeyService("web-push.enabled" to "false").isWebPushEnabled())
+    }
+
+    @Test
+    fun `getConfiguredKeysOrNull returns null when the public key is missing`() {
+        configFile.writeText("web-push-vapid-private-key=real-private-key\n")
+        val service =
+            VapidKeyService(
+                applicationEnvironment { config = MapApplicationConfig("web-push.vapid-subject" to "mailto:test@example.com") },
+            )
+
+        assertNull(service.getConfiguredKeysOrNull())
+    }
+
+    @Test
+    fun `getConfiguredKeysOrNull returns null when the private key is not configured`() {
+        assertNull(vapidKeyService().getConfiguredKeysOrNull())
+    }
+
+    @Test
+    fun `getConfiguredKeysOrNull returns the configured keys when encryption is not active`() {
+        configFile.writeText("web-push-vapid-private-key=real-private-key\n")
+
+        val configuredKeys = vapidKeyService().getConfiguredKeysOrNull()
+
+        assertEquals("real-public-key", configuredKeys?.publicKey)
+        assertEquals("real-private-key", configuredKeys?.privateKey)
+        assertEquals("mailto:test@example.com", configuredKeys?.subject)
+    }
+
+    @Test
+    fun `getConfiguredKeysOrNull returns the decrypted private key when encryption is active and unlocked`() {
+        SecretsStore.activateEncryption(
+            "correct-unlock-password".toCharArray(),
+            mapOf("web-push-vapid-private-key" to "real-private-key"),
+        )
+
+        val configuredKeys = vapidKeyService().getConfiguredKeysOrNull()
+
+        assertEquals("real-private-key", configuredKeys?.privateKey)
+    }
+
+    @Test
+    fun `getConfiguredKeysOrNull returns null instead of throwing when encryption is active and locked`() {
+        SecretsStore.activateEncryption(
+            "correct-unlock-password".toCharArray(),
+            mapOf("web-push-vapid-private-key" to "real-private-key"),
+        )
+        SecretsStore.lockForTesting()
+
+        assertNull(vapidKeyService().getConfiguredKeysOrNull())
+    }
+}

--- a/server/e2e_tests_py/ambrosia/test_server.py
+++ b/server/e2e_tests_py/ambrosia/test_server.py
@@ -8,7 +8,9 @@ import logging
 import os
 import signal
 import subprocess
+import threading
 import time
+from collections import deque
 from pathlib import Path
 
 import httpx
@@ -40,6 +42,9 @@ class AmbrosiaTestServer:
     STARTUP_TIMEOUT = 120  # seconds
     HEALTH_CHECK_INTERVAL = 1  # seconds
 
+    # Number of trailing output lines kept in memory for startup-failure diagnostics
+    MAX_BUFFERED_OUTPUT_LINES = 2000
+
     def __init__(
         self,
         port: int = SERVER_PORT,
@@ -53,6 +58,9 @@ class AmbrosiaTestServer:
         self.server_url = f"http://{self.SERVER_HOST}:{self.port}"
         self.health_check_url = f"{self.server_url}/"
         self._gradle_dir = Path(__file__).parent.parent.parent
+        self._stdout_lines: deque[str] = deque(maxlen=self.MAX_BUFFERED_OUTPUT_LINES)
+        self._stderr_lines: deque[str] = deque(maxlen=self.MAX_BUFFERED_OUTPUT_LINES)
+        self._output_reader_threads: list[threading.Thread] = []
 
     def start_server(self) -> None:
         """Start the server using Gradle, equivalent to runGradleApp() in TestServer.kt."""
@@ -84,10 +92,16 @@ class AmbrosiaTestServer:
                 cwd=self._gradle_dir,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
+                text=True,
+                bufsize=1,
+                encoding="utf-8",
+                errors="replace",
                 preexec_fn=os.setsid if os.name != "nt" else None,
                 env=env,
             )
             logger.info(f"Server process started with PID: {self.server_process.pid}")
+
+            self._start_output_readers()
 
             # Wait for server to be ready
             self._wait_for_server()
@@ -96,6 +110,31 @@ class AmbrosiaTestServer:
             logger.error(f"Failed to start server: {e}")
             self._cleanup_server()
             raise
+
+    def _start_output_readers(self) -> None:
+        """Continuously drain stdout/stderr so the child never blocks on a full pipe buffer while readiness polling runs."""
+        if self.server_process is None:
+            return
+
+        def drain(pipe, buffer: deque[str]) -> None:
+            for line in iter(pipe.readline, ""):
+                buffer.append(line.rstrip("\n"))
+            pipe.close()
+
+        self._output_reader_threads = [
+            threading.Thread(
+                target=drain,
+                args=(self.server_process.stdout, self._stdout_lines),
+                daemon=True,
+            ),
+            threading.Thread(
+                target=drain,
+                args=(self.server_process.stderr, self._stderr_lines),
+                daemon=True,
+            ),
+        ]
+        for reader_thread in self._output_reader_threads:
+            reader_thread.start()
 
     def stop_server(self) -> None:
         """Stop the server process, equivalent to stopServer() in TestServer.kt."""
@@ -148,9 +187,9 @@ class AmbrosiaTestServer:
 
             # Check if process is still running
             if self.server_process and self.server_process.poll() is not None:
-                stdout, stderr = self.server_process.communicate()
                 logger.error(
-                    f"Server process died unexpectedly. stdout: {stdout}, stderr: {stderr}"
+                    f"Server process died unexpectedly. stdout: {self._buffered_output(self._stdout_lines)}, "
+                    f"stderr: {self._buffered_output(self._stderr_lines)}"
                 )
                 raise RuntimeError("Server process died during startup")
 
@@ -205,19 +244,20 @@ class AmbrosiaTestServer:
         if self.server_process:
             self.server_process = None
 
+    def _buffered_output(self, buffer: deque[str]) -> str:
+        """Return the buffered output collected so far by the background reader threads."""
+        return "\n".join(buffer)
+
     def _log_server_output(self) -> None:
-        """Log server output for debugging."""
-        if self.server_process:
-            try:
-                stdout, stderr = self.server_process.communicate(timeout=1)
-                if stdout:
-                    logger.error(f"Server stdout: {stdout.decode()}")
-                if stderr:
-                    logger.error(f"Server stderr: {stderr.decode()}")
-            except subprocess.TimeoutExpired:
-                logger.error("Could not read server output (timeout)")
-            except Exception as e:
-                logger.error(f"Error reading server output: {e}")
+        """Log server output for debugging, from the continuously-drained buffers."""
+        logger.error(
+            f"Server stdout (last {self.MAX_BUFFERED_OUTPUT_LINES} lines): "
+            f"{self._buffered_output(self._stdout_lines)}"
+        )
+        logger.error(
+            f"Server stderr (last {self.MAX_BUFFERED_OUTPUT_LINES} lines): "
+            f"{self._buffered_output(self._stderr_lines)}"
+        )
 
 
 # Pytest fixtures for easy integration


### PR DESCRIPTION
## Changes:

- Add `SecretsCipher` (Argon2id + AES-256-GCM) for encrypting secrets at rest, with tests.
- Add `SecretsStore` and the `/secrets` endpoints (status, unlock, activate), with tests.
- Connect the server boot sequence and wallet backend to `SecretsStore`, so encrypted secrets are available once unlocked.
- Add the client `secretsService` for the `/secrets` endpoints.
- Add a shared `SecretsUnlockPasswordField` component, used by both onboarding and Settings.
- Add the secrets encryption option to onboarding.
- Add a secrets encryption management card to Settings.
- Fix onboarding silently failing to activate secrets encryption — authenticate a regular session before logging into the wallet.
- Fix the unlocked secrets encryption status styling to match its sibling states.
- Add password confirmation to the shared secrets unlock field, to catch typos before they become unrecoverable.
- Wire the password confirmation into onboarding's step validation.
- Wire the password confirmation into the Settings activation flow.

### Screenshots:

**Onboarding**

<img width="689" height="331" alt="Screenshot 2026-09-10 at 12 43 08 p m" src="https://github.com/user-attachments/assets/c4bb911b-2fff-41e9-a55e-c53a7a323ae1" />
<img width="695" height="632" alt="Screenshot 2026-09-10 at 12 42 49 p m" src="https://github.com/user-attachments/assets/4dc0b365-9efe-40f0-894e-e1440d048ada" />
<img width="692" height="652" alt="Screenshot 2026-09-10 at 12 44 27 p m" src="https://github.com/user-attachments/assets/49fa8770-071f-42d8-a4e0-ddfffd99fab8" />

**Settings**

<img width="465" height="232" alt="Screenshot 2026-09-10 at 12 45 48 p m" src="https://github.com/user-attachments/assets/9b29cd73-df42-436c-92a2-8394ca5713ad" />
<img width="464" height="556" alt="Screenshot 2026-09-10 at 12 46 15 p m" src="https://github.com/user-attachments/assets/fcca1b4e-5f48-4d4e-bb27-752d6e175dfb" />
<img width="461" height="549" alt="Screenshot 2026-09-10 at 12 46 47 p m" src="https://github.com/user-attachments/assets/09e9a7a1-428e-4f6d-b739-d3d2d758de6f" />
<img width="469" height="225" alt="Screenshot 2026-09-10 at 12 47 02 p m" src="https://github.com/user-attachments/assets/d6a29c21-e5b1-4474-8d91-035b235e4563" />


