### PR TITLE
Feat(server): freelance reports api

### DIFF
--- a/server/app/src/main/kotlin/pos/ambrosia/Api.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/Api.kt
@@ -30,6 +30,7 @@ import pos.ambrosia.api.configureClients
 import pos.ambrosia.api.configureConfig
 import pos.ambrosia.api.configureCurrency
 import pos.ambrosia.api.configureDishes
+import pos.ambrosia.api.configureFreelanceReports
 import pos.ambrosia.api.configureHealth
 import pos.ambrosia.api.configureIngredients
 import pos.ambrosia.api.configureInitialSetup
@@ -124,6 +125,7 @@ class Api {
         configureProjects()
         configureCurrency()
         configureTimeEntries()
+        configureFreelanceReports()
         configureInitialSetup()
         if (environment.config.propertyOrNull("nwc-uri") == null) {
             configurePhoenixWebhook()

--- a/server/app/src/main/kotlin/pos/ambrosia/api/FreelanceReports.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/api/FreelanceReports.kt
@@ -1,0 +1,40 @@
+package pos.ambrosia.api
+
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.Application
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
+import io.ktor.server.routing.route
+import io.ktor.server.routing.routing
+import pos.ambrosia.services.FreelanceReportService
+import pos.ambrosia.utils.InvalidTimeEntryException
+import pos.ambrosia.utils.authorizePermission
+
+fun Application.configureFreelanceReports() {
+    val freelanceReportService = FreelanceReportService()
+    routing { route("/freelance/billing-reports") { freelanceBillingReports(freelanceReportService) } }
+}
+
+fun Route.freelanceBillingReports(freelanceReportService: FreelanceReportService) {
+    authorizePermission("freelance_reports_read") {
+        get("") {
+            val startDate =
+                call.request.queryParameters["from"]
+                    ?: throw InvalidTimeEntryException("Both from and to dates are required")
+            val endDate =
+                call.request.queryParameters["to"]
+                    ?: throw InvalidTimeEntryException("Both from and to dates are required")
+            val requestedClientId = call.request.queryParameters["client_id"]
+
+            call.respond(
+                HttpStatusCode.OK,
+                freelanceReportService.getBillingReport(
+                    startDate = startDate,
+                    endDate = endDate,
+                    clientId = requestedClientId,
+                ),
+            )
+        }
+    }
+}

--- a/server/app/src/main/kotlin/pos/ambrosia/models/AppModels.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/models/AppModels.kt
@@ -940,6 +940,41 @@ data class TimeEntryResponse(
 )
 
 @Serializable
+data class FreelanceReportTaskGroup(
+    val taskId: String,
+    val taskName: String,
+    val durationMinutes: Int,
+    val amountCents: Int,
+)
+
+@Serializable
+data class FreelanceReportProjectGroup(
+    val projectId: String,
+    val projectName: String,
+    val clientId: String,
+    val clientName: String,
+    val durationMinutes: Int,
+    val amountCents: Int,
+    val tasks: List<FreelanceReportTaskGroup>,
+)
+
+@Serializable
+data class FreelanceReportCurrencyGroup(
+    val currencyId: String,
+    val currencyAcronym: String,
+    val totalDurationMinutes: Int,
+    val totalAmountCents: Int,
+    val projects: List<FreelanceReportProjectGroup>,
+)
+
+@Serializable
+data class FreelanceReportResponse(
+    val from: String,
+    val to: String,
+    val currencies: List<FreelanceReportCurrencyGroup>,
+)
+
+@Serializable
 data class BackupManifest(
     val appVersion: String,
     val schemaInstalledRank: Int?,

--- a/server/app/src/main/kotlin/pos/ambrosia/services/BillableTimeAggregationService.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/services/BillableTimeAggregationService.kt
@@ -1,0 +1,171 @@
+package pos.ambrosia.services
+
+import org.jetbrains.exposed.v1.core.Op
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.dao.id.EntityID
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.greaterEq
+import org.jetbrains.exposed.v1.core.inList
+import org.jetbrains.exposed.v1.core.lessEq
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import pos.ambrosia.db.tables.ClientEntity
+import pos.ambrosia.db.tables.ClientsTable
+import pos.ambrosia.db.tables.CurrencyEntity
+import pos.ambrosia.db.tables.CurrencyTable
+import pos.ambrosia.db.tables.ProjectEntity
+import pos.ambrosia.db.tables.ProjectsTable
+import pos.ambrosia.db.tables.TaskEntity
+import pos.ambrosia.db.tables.TasksTable
+import pos.ambrosia.db.tables.TimeEntriesTable
+import pos.ambrosia.db.tables.TimeEntryEntity
+import pos.ambrosia.utils.InvalidTimeEntryException
+import java.math.BigDecimal
+import java.math.RoundingMode
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
+import java.util.UUID
+
+data class BillableTimeEntryLine(
+    val timeEntryId: String,
+    val entryDate: String,
+    val clientId: String,
+    val clientName: String,
+    val currencyId: String,
+    val currencyAcronym: String,
+    val projectId: String,
+    val projectName: String,
+    val taskId: String,
+    val taskName: String,
+    val durationMinutes: Int,
+    val isBillable: Boolean,
+    val rateCents: Int,
+    val amountCents: Int,
+)
+
+class BillableTimeAggregationService {
+    fun getBillableTimeEntryLines(
+        startDate: String,
+        endDate: String,
+        clientId: String? = null,
+        projectId: String? = null,
+        taskId: String? = null,
+    ): List<BillableTimeEntryLine> =
+        transaction {
+            val rangeStartDate = parseDate(startDate, "from")
+            val rangeEndDate = parseDate(endDate, "to")
+            if (rangeStartDate > rangeEndDate) throw InvalidTimeEntryException("from must be before or equal to to")
+
+            var queryCondition: Op<Boolean> =
+                (TimeEntriesTable.entryDate greaterEq rangeStartDate.toString()) and
+                    (TimeEntriesTable.entryDate lessEq rangeEndDate.toString())
+
+            clientId?.let { requestedClientId ->
+                val clientProjectIds =
+                    ProjectEntity
+                        .find { ProjectsTable.clientId eq EntityID(parseUuid(requestedClientId, "client_id"), ClientsTable) }
+                        .map { it.id }
+                if (clientProjectIds.isEmpty()) return@transaction emptyList()
+                queryCondition = queryCondition and (TimeEntriesTable.projectId inList clientProjectIds)
+            }
+            projectId?.let { requestedProjectId ->
+                queryCondition =
+                    queryCondition and
+                    (TimeEntriesTable.projectId eq EntityID(parseUuid(requestedProjectId, "project_id"), ProjectsTable))
+            }
+            taskId?.let { requestedTaskId ->
+                queryCondition =
+                    queryCondition and
+                    (TimeEntriesTable.taskId eq EntityID(parseUuid(requestedTaskId, "task_id"), TasksTable))
+            }
+
+            val timeEntries = TimeEntryEntity.find { queryCondition }.toList()
+            if (timeEntries.isEmpty()) return@transaction emptyList()
+
+            val projectsById =
+                ProjectEntity
+                    .find { ProjectsTable.id inList timeEntries.map { timeEntry -> timeEntry.projectId }.distinct() }
+                    .associateBy { it.id }
+            val clientsById =
+                ClientEntity
+                    .find { ClientsTable.id inList projectsById.values.map { project -> project.clientId }.distinct() }
+                    .associateBy { it.id }
+            val tasksById =
+                TaskEntity
+                    .find { TasksTable.id inList timeEntries.map { timeEntry -> timeEntry.taskId }.distinct() }
+                    .associateBy { it.id }
+            val currenciesById =
+                CurrencyEntity
+                    .find { CurrencyTable.id inList clientsById.values.map { client -> client.currencyId }.distinct() }
+                    .associateBy { it.id }
+
+            timeEntries.map { timeEntry ->
+                val project = projectsById.getValue(timeEntry.projectId)
+                val client = clientsById.getValue(project.clientId)
+                val task = tasksById.getValue(timeEntry.taskId)
+                val currency = currenciesById.getValue(client.currencyId)
+                val isBillable = task.isBillable && project.isBillable
+                val rateCents = if (isBillable) project.hourlyRateCents ?: client.hourlyRateCents else 0
+                val amountCents = if (isBillable) calculateAmountCents(rateCents, timeEntry.durationMinutes) else 0
+
+                BillableTimeEntryLine(
+                    timeEntryId = timeEntry.id.value.toString(),
+                    entryDate = timeEntry.entryDate,
+                    clientId = client.id.value.toString(),
+                    clientName = client.name,
+                    currencyId = currency.id.value.toString(),
+                    currencyAcronym = currency.acronym,
+                    projectId = project.id.value.toString(),
+                    projectName = project.name,
+                    taskId = task.id.value.toString(),
+                    taskName = task.name,
+                    durationMinutes = timeEntry.durationMinutes,
+                    isBillable = isBillable,
+                    rateCents = rateCents,
+                    amountCents = amountCents,
+                )
+            }
+        }
+
+    companion object {
+        private val isoDatePattern = Regex("\\d{4}-\\d{2}-\\d{2}")
+
+        private fun parseUuid(
+            rawValue: String,
+            fieldName: String,
+        ): UUID =
+            try {
+                UUID.fromString(rawValue)
+            } catch (_: IllegalArgumentException) {
+                throw InvalidTimeEntryException("$fieldName must be a valid UUID")
+            }
+
+        private fun parseDate(
+            rawValue: String,
+            fieldName: String,
+        ): LocalDate {
+            if (!isoDatePattern.matches(rawValue)) {
+                throw InvalidTimeEntryException("$fieldName must use YYYY-MM-DD format")
+            }
+            return try {
+                LocalDate.parse(rawValue, DateTimeFormatter.ISO_LOCAL_DATE)
+            } catch (_: DateTimeParseException) {
+                throw InvalidTimeEntryException("$fieldName must use YYYY-MM-DD format")
+            }
+        }
+
+        private fun calculateAmountCents(
+            rateCents: Int,
+            durationMinutes: Int,
+        ): Int =
+            try {
+                BigDecimal
+                    .valueOf(rateCents.toLong())
+                    .multiply(BigDecimal.valueOf(durationMinutes.toLong()))
+                    .divide(BigDecimal.valueOf(60L), 0, RoundingMode.HALF_UP)
+                    .intValueExact()
+            } catch (_: ArithmeticException) {
+                throw InvalidTimeEntryException("Calculated amount exceeds the supported range")
+            }
+    }
+}

--- a/server/app/src/main/kotlin/pos/ambrosia/services/FreelanceReportService.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/services/FreelanceReportService.kt
@@ -1,0 +1,64 @@
+package pos.ambrosia.services
+
+import pos.ambrosia.models.FreelanceReportCurrencyGroup
+import pos.ambrosia.models.FreelanceReportProjectGroup
+import pos.ambrosia.models.FreelanceReportResponse
+import pos.ambrosia.models.FreelanceReportTaskGroup
+
+class FreelanceReportService(
+    private val billableTimeAggregationService: BillableTimeAggregationService = BillableTimeAggregationService(),
+) {
+    fun getBillingReport(
+        startDate: String,
+        endDate: String,
+        clientId: String? = null,
+    ): FreelanceReportResponse {
+        val billableTimeEntryLines =
+            billableTimeAggregationService.getBillableTimeEntryLines(startDate, endDate, clientId = clientId)
+
+        val currencyGroups =
+            billableTimeEntryLines
+                .groupBy { billableTimeEntryLine -> billableTimeEntryLine.currencyId to billableTimeEntryLine.currencyAcronym }
+                .map { (currencyIdAndAcronym, timeEntryLinesForCurrency) ->
+                    val (currencyId, currencyAcronym) = currencyIdAndAcronym
+                    FreelanceReportCurrencyGroup(
+                        currencyId = currencyId,
+                        currencyAcronym = currencyAcronym,
+                        totalDurationMinutes = timeEntryLinesForCurrency.sumOf { it.durationMinutes },
+                        totalAmountCents = timeEntryLinesForCurrency.sumOf { it.amountCents },
+                        projects = groupByProject(timeEntryLinesForCurrency),
+                    )
+                }.sortedBy { currencyGroup -> currencyGroup.currencyAcronym }
+
+        return FreelanceReportResponse(from = startDate, to = endDate, currencies = currencyGroups)
+    }
+
+    private fun groupByProject(timeEntryLines: List<BillableTimeEntryLine>): List<FreelanceReportProjectGroup> =
+        timeEntryLines
+            .groupBy { billableTimeEntryLine -> billableTimeEntryLine.projectId }
+            .map { (_, timeEntryLinesForProject) ->
+                val representativeLine = timeEntryLinesForProject.first()
+                FreelanceReportProjectGroup(
+                    projectId = representativeLine.projectId,
+                    projectName = representativeLine.projectName,
+                    clientId = representativeLine.clientId,
+                    clientName = representativeLine.clientName,
+                    durationMinutes = timeEntryLinesForProject.sumOf { it.durationMinutes },
+                    amountCents = timeEntryLinesForProject.sumOf { it.amountCents },
+                    tasks = groupByTask(timeEntryLinesForProject),
+                )
+            }.sortedBy { projectGroup -> projectGroup.projectName }
+
+    private fun groupByTask(timeEntryLines: List<BillableTimeEntryLine>): List<FreelanceReportTaskGroup> =
+        timeEntryLines
+            .groupBy { billableTimeEntryLine -> billableTimeEntryLine.taskId }
+            .map { (_, timeEntryLinesForTask) ->
+                val representativeLine = timeEntryLinesForTask.first()
+                FreelanceReportTaskGroup(
+                    taskId = representativeLine.taskId,
+                    taskName = representativeLine.taskName,
+                    durationMinutes = timeEntryLinesForTask.sumOf { it.durationMinutes },
+                    amountCents = timeEntryLinesForTask.sumOf { it.amountCents },
+                )
+            }.sortedBy { taskGroup -> taskGroup.taskName }
+}

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/BillableTimeAggregationServiceTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/BillableTimeAggregationServiceTest.kt
@@ -1,0 +1,124 @@
+package pos.ambrosia.utest
+
+import org.junit.After
+import org.junit.Before
+import pos.ambrosia.services.BillableTimeAggregationService
+import pos.ambrosia.utils.ExposedTestDb
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class BillableTimeAggregationServiceTest {
+    private lateinit var testDatabaseFile: File
+    private val billableTimeAggregationService = BillableTimeAggregationService()
+
+    @Before
+    fun setUp() {
+        testDatabaseFile = ExposedTestDb.connect()
+    }
+
+    @After
+    fun tearDown() {
+        ExposedTestDb.cleanup(testDatabaseFile)
+    }
+
+    @Test
+    fun `resolves the project rate over the client rate when the project has its own rate`() {
+        val currencyId = ExposedTestDb.seedCurrency("USD")
+        val clientId = ExposedTestDb.seedClient("Client", currencyId, hourlyRateCents = 10_000)
+        val projectId = ExposedTestDb.seedProject(clientId, hourlyRateCents = 15_000)
+        val taskId = ExposedTestDb.seedTask("Development")
+        ExposedTestDb.seedTimeEntry(projectId, taskId, entryDate = "2026-08-19", durationMinutes = 60)
+
+        val billableTimeEntryLines =
+            billableTimeAggregationService.getBillableTimeEntryLines("2026-08-17", "2026-08-23")
+
+        assertEquals(15_000, billableTimeEntryLines.single().rateCents)
+        assertEquals(15_000, billableTimeEntryLines.single().amountCents)
+    }
+
+    @Test
+    fun `falls back to the client rate when the project has no rate of its own`() {
+        val currencyId = ExposedTestDb.seedCurrency("USD")
+        val clientId = ExposedTestDb.seedClient("Client", currencyId, hourlyRateCents = 10_000)
+        val projectId = ExposedTestDb.seedProject(clientId, hourlyRateCents = null)
+        val taskId = ExposedTestDb.seedTask("Development")
+        ExposedTestDb.seedTimeEntry(projectId, taskId, entryDate = "2026-08-19", durationMinutes = 30)
+
+        val billableTimeEntryLines =
+            billableTimeAggregationService.getBillableTimeEntryLines("2026-08-17", "2026-08-23")
+
+        assertEquals(10_000, billableTimeEntryLines.single().rateCents)
+        assertEquals(5_000, billableTimeEntryLines.single().amountCents)
+    }
+
+    @Test
+    fun `zeroes the rate and amount for non-billable entries but still reports the duration`() {
+        val currencyId = ExposedTestDb.seedCurrency("USD")
+        val clientId = ExposedTestDb.seedClient("Client", currencyId, hourlyRateCents = 10_000)
+        val nonBillableProjectId = ExposedTestDb.seedProject(clientId, hourlyRateCents = 15_000, isBillable = false)
+        val taskId = ExposedTestDb.seedTask("Development")
+        ExposedTestDb.seedTimeEntry(nonBillableProjectId, taskId, entryDate = "2026-08-19", durationMinutes = 45)
+
+        val billableTimeEntryLine =
+            billableTimeAggregationService.getBillableTimeEntryLines("2026-08-17", "2026-08-23").single()
+
+        assertFalse(billableTimeEntryLine.isBillable)
+        assertEquals(0, billableTimeEntryLine.rateCents)
+        assertEquals(0, billableTimeEntryLine.amountCents)
+        assertEquals(45, billableTimeEntryLine.durationMinutes)
+    }
+
+    @Test
+    fun `filters entries outside the requested date range`() {
+        val currencyId = ExposedTestDb.seedCurrency("USD")
+        val clientId = ExposedTestDb.seedClient("Client", currencyId, hourlyRateCents = 10_000)
+        val projectId = ExposedTestDb.seedProject(clientId)
+        val taskId = ExposedTestDb.seedTask("Development")
+        val inRangeEntryId = ExposedTestDb.seedTimeEntry(projectId, taskId, entryDate = "2026-08-19")
+        ExposedTestDb.seedTimeEntry(projectId, taskId, entryDate = "2026-09-01")
+
+        val billableTimeEntryLines =
+            billableTimeAggregationService.getBillableTimeEntryLines("2026-08-17", "2026-08-23")
+
+        assertEquals(listOf(inRangeEntryId), billableTimeEntryLines.map { it.timeEntryId })
+    }
+
+    @Test
+    fun `filters entries by client id across that client's projects`() {
+        val currencyId = ExposedTestDb.seedCurrency("USD")
+        val matchingClientId = ExposedTestDb.seedClient("Matching Client", currencyId)
+        val matchingProjectId = ExposedTestDb.seedProject(matchingClientId)
+        val otherClientId = ExposedTestDb.seedClient("Other Client", currencyId)
+        val otherProjectId = ExposedTestDb.seedProject(otherClientId)
+        val taskId = ExposedTestDb.seedTask("Development")
+        val matchingEntryId = ExposedTestDb.seedTimeEntry(matchingProjectId, taskId, entryDate = "2026-08-19")
+        ExposedTestDb.seedTimeEntry(otherProjectId, taskId, entryDate = "2026-08-19")
+
+        val billableTimeEntryLines =
+            billableTimeAggregationService.getBillableTimeEntryLines(
+                "2026-08-17",
+                "2026-08-23",
+                clientId = matchingClientId,
+            )
+
+        assertEquals(listOf(matchingEntryId), billableTimeEntryLines.map { it.timeEntryId })
+    }
+
+    @Test
+    fun `returns an empty list when the client filter has no matching projects`() {
+        val currencyId = ExposedTestDb.seedCurrency("USD")
+        val clientWithoutProjectsId = ExposedTestDb.seedClient("Idle Client", currencyId)
+
+        val billableTimeEntryLines =
+            billableTimeAggregationService.getBillableTimeEntryLines(
+                "2026-08-17",
+                "2026-08-23",
+                clientId = clientWithoutProjectsId,
+            )
+
+        assertTrue(billableTimeEntryLines.isEmpty())
+    }
+}

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/FreelanceReportServiceTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/FreelanceReportServiceTest.kt
@@ -1,0 +1,100 @@
+package pos.ambrosia.utest
+
+import org.junit.After
+import org.junit.Before
+import pos.ambrosia.services.FreelanceReportService
+import pos.ambrosia.utils.ExposedTestDb
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class FreelanceReportServiceTest {
+    private lateinit var testDatabaseFile: File
+    private val freelanceReportService = FreelanceReportService()
+
+    @Before
+    fun setUp() {
+        testDatabaseFile = ExposedTestDb.connect()
+    }
+
+    @After
+    fun tearDown() {
+        ExposedTestDb.cleanup(testDatabaseFile)
+    }
+
+    @Test
+    fun `groups billable hours and amounts by project and task within a currency`() {
+        val currencyId = ExposedTestDb.seedCurrency("USD")
+        val clientId = ExposedTestDb.seedClient("Client", currencyId, hourlyRateCents = 6_000)
+        val projectId = ExposedTestDb.seedProject(clientId, name = "Website Revamp")
+        val developmentTaskId = ExposedTestDb.seedTask("Development")
+        val designTaskId = ExposedTestDb.seedTask("Design")
+        ExposedTestDb.seedTimeEntry(projectId, developmentTaskId, entryDate = "2026-08-19", durationMinutes = 60)
+        ExposedTestDb.seedTimeEntry(projectId, developmentTaskId, entryDate = "2026-08-20", durationMinutes = 30)
+        ExposedTestDb.seedTimeEntry(projectId, designTaskId, entryDate = "2026-08-21", durationMinutes = 60)
+
+        val report = freelanceReportService.getBillingReport("2026-08-17", "2026-08-23")
+
+        val currencyGroup = report.currencies.single()
+        assertEquals("USD", currencyGroup.currencyAcronym)
+        assertEquals(150, currencyGroup.totalDurationMinutes)
+        assertEquals(15_000, currencyGroup.totalAmountCents)
+
+        val projectGroup = currencyGroup.projects.single()
+        assertEquals("Website Revamp", projectGroup.projectName)
+        assertEquals(150, projectGroup.durationMinutes)
+        assertEquals(15_000, projectGroup.amountCents)
+
+        val developmentTaskGroup = projectGroup.tasks.first { it.taskName == "Development" }
+        assertEquals(90, developmentTaskGroup.durationMinutes)
+        assertEquals(9_000, developmentTaskGroup.amountCents)
+
+        val designTaskGroup = projectGroup.tasks.first { it.taskName == "Design" }
+        assertEquals(60, designTaskGroup.durationMinutes)
+        assertEquals(6_000, designTaskGroup.amountCents)
+    }
+
+    @Test
+    fun `keeps clients billed in different currencies in separate currency groups with no conversion`() {
+        val usdCurrencyId = ExposedTestDb.seedCurrency("USD")
+        val eurCurrencyId = ExposedTestDb.seedCurrency("EUR")
+        val usdClientId = ExposedTestDb.seedClient("USD Client", usdCurrencyId, hourlyRateCents = 5_000)
+        val eurClientId = ExposedTestDb.seedClient("EUR Client", eurCurrencyId, hourlyRateCents = 4_000)
+        val usdProjectId = ExposedTestDb.seedProject(usdClientId, name = "USD Project")
+        val eurProjectId = ExposedTestDb.seedProject(eurClientId, name = "EUR Project")
+        val taskId = ExposedTestDb.seedTask("Development")
+        ExposedTestDb.seedTimeEntry(usdProjectId, taskId, entryDate = "2026-08-19", durationMinutes = 60)
+        ExposedTestDb.seedTimeEntry(eurProjectId, taskId, entryDate = "2026-08-19", durationMinutes = 60)
+
+        val report = freelanceReportService.getBillingReport("2026-08-17", "2026-08-23")
+
+        assertEquals(setOf("EUR", "USD"), report.currencies.map { it.currencyAcronym }.toSet())
+        val usdGroup = report.currencies.first { it.currencyAcronym == "USD" }
+        val eurGroup = report.currencies.first { it.currencyAcronym == "EUR" }
+        assertEquals(5_000, usdGroup.totalAmountCents)
+        assertEquals(4_000, eurGroup.totalAmountCents)
+    }
+
+    @Test
+    fun `includes non-billable time entries in the totals with a zero amount`() {
+        val currencyId = ExposedTestDb.seedCurrency("USD")
+        val clientId = ExposedTestDb.seedClient("Client", currencyId, hourlyRateCents = 6_000)
+        val nonBillableProjectId = ExposedTestDb.seedProject(clientId, isBillable = false)
+        val taskId = ExposedTestDb.seedTask("Development")
+        ExposedTestDb.seedTimeEntry(nonBillableProjectId, taskId, entryDate = "2026-08-19", durationMinutes = 60)
+
+        val report = freelanceReportService.getBillingReport("2026-08-17", "2026-08-23")
+
+        val currencyGroup = report.currencies.single()
+        assertEquals(60, currencyGroup.totalDurationMinutes)
+        assertEquals(0, currencyGroup.totalAmountCents)
+    }
+
+    @Test
+    fun `returns no currency groups for a range with no time entries`() {
+        val report = freelanceReportService.getBillingReport("2026-08-17", "2026-08-23")
+
+        assertTrue(report.currencies.isEmpty())
+    }
+}

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/FreelanceReportsRouteTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/FreelanceReportsRouteTest.kt
@@ -37,7 +37,8 @@ class FreelanceReportsRouteTest {
     @Test
     fun `route requires authentication and the matching permission`() =
         testApplication {
-            val auth = installNonAdminAuth("freelance-reports-no-permission", "freelance-reports-no-permission-user")
+            val authWithoutPermission =
+                installNonAdminAuth("freelance-reports-no-permission", "freelance-reports-no-permission-user")
             application {
                 install(ContentNegotiation) { json() }
                 handler()
@@ -52,7 +53,7 @@ class FreelanceReportsRouteTest {
                 HttpStatusCode.Forbidden,
                 client
                     .get("/freelance/billing-reports?from=2026-08-17&to=2026-08-23") {
-                        withAuthCookies(auth)
+                        withAuthCookies(authWithoutPermission)
                     }.status,
             )
         }
@@ -60,7 +61,7 @@ class FreelanceReportsRouteTest {
     @Test
     fun `missing from or to returns bad request`() =
         testApplication {
-            val auth = installNonAdminAuth("freelance-reports-invalid", "freelance-reports-invalid-user")
+            val authWithPermission = installNonAdminAuth("freelance-reports-invalid", "freelance-reports-invalid-user")
             grantPermission("freelance-reports-invalid", "freelance_reports_read")
             application {
                 install(ContentNegotiation) { json() }
@@ -70,18 +71,21 @@ class FreelanceReportsRouteTest {
 
             assertEquals(
                 HttpStatusCode.BadRequest,
-                client.get("/freelance/billing-reports?from=2026-08-17") { withAuthCookies(auth) }.status,
+                client.get("/freelance/billing-reports?from=2026-08-17") { withAuthCookies(authWithPermission) }.status,
             )
             assertEquals(
                 HttpStatusCode.BadRequest,
-                client.get("/freelance/billing-reports?from=2026-08-24&to=2026-08-17") { withAuthCookies(auth) }.status,
+                client
+                    .get("/freelance/billing-reports?from=2026-08-24&to=2026-08-17") {
+                        withAuthCookies(authWithPermission)
+                    }.status,
             )
         }
 
     @Test
     fun `happy path returns the grouped report`() =
         testApplication {
-            val auth = installNonAdminAuth("freelance-reports-read", "freelance-reports-read-user")
+            val authWithPermission = installNonAdminAuth("freelance-reports-read", "freelance-reports-read-user")
             grantPermission("freelance-reports-read", "freelance_reports_read")
             val currencyId = ExposedTestDb.seedCurrency("USD")
             val clientId = ExposedTestDb.seedClient("Client Alpha", currencyId, hourlyRateCents = 6_000)
@@ -94,13 +98,13 @@ class FreelanceReportsRouteTest {
                 configureFreelanceReports()
             }
 
-            val response =
+            val billingReportResponse =
                 client.get("/freelance/billing-reports?from=2026-08-17&to=2026-08-23&client_id=$clientId") {
-                    withAuthCookies(auth)
+                    withAuthCookies(authWithPermission)
                 }
 
-            assertEquals(HttpStatusCode.OK, response.status)
-            val report = Json.decodeFromString<FreelanceReportResponse>(response.bodyAsText())
+            assertEquals(HttpStatusCode.OK, billingReportResponse.status)
+            val report = Json.decodeFromString<FreelanceReportResponse>(billingReportResponse.bodyAsText())
             val currencyGroup = report.currencies.single()
             assertEquals("USD", currencyGroup.currencyAcronym)
             val projectGroup = currencyGroup.projects.single()

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/FreelanceReportsRouteTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/FreelanceReportsRouteTest.kt
@@ -1,0 +1,110 @@
+package pos.ambrosia.utest
+
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.install
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.testing.testApplication
+import kotlinx.serialization.json.Json
+import org.junit.After
+import org.junit.Before
+import pos.ambrosia.api.configureFreelanceReports
+import pos.ambrosia.api.handler
+import pos.ambrosia.models.FreelanceReportResponse
+import pos.ambrosia.utils.ExposedTestDb
+import pos.ambrosia.utils.grantPermission
+import pos.ambrosia.utils.installNonAdminAuth
+import pos.ambrosia.utils.withAuthCookies
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class FreelanceReportsRouteTest {
+    private lateinit var databaseFile: File
+
+    @Before
+    fun setUp() {
+        databaseFile = ExposedTestDb.connect()
+    }
+
+    @After
+    fun tearDown() {
+        ExposedTestDb.cleanup(databaseFile)
+    }
+
+    @Test
+    fun `route requires authentication and the matching permission`() =
+        testApplication {
+            val auth = installNonAdminAuth("freelance-reports-no-permission", "freelance-reports-no-permission-user")
+            application {
+                install(ContentNegotiation) { json() }
+                handler()
+                configureFreelanceReports()
+            }
+
+            assertEquals(
+                HttpStatusCode.Unauthorized,
+                client.get("/freelance/billing-reports?from=2026-08-17&to=2026-08-23").status,
+            )
+            assertEquals(
+                HttpStatusCode.Forbidden,
+                client
+                    .get("/freelance/billing-reports?from=2026-08-17&to=2026-08-23") {
+                        withAuthCookies(auth)
+                    }.status,
+            )
+        }
+
+    @Test
+    fun `missing from or to returns bad request`() =
+        testApplication {
+            val auth = installNonAdminAuth("freelance-reports-invalid", "freelance-reports-invalid-user")
+            grantPermission("freelance-reports-invalid", "freelance_reports_read")
+            application {
+                install(ContentNegotiation) { json() }
+                handler()
+                configureFreelanceReports()
+            }
+
+            assertEquals(
+                HttpStatusCode.BadRequest,
+                client.get("/freelance/billing-reports?from=2026-08-17") { withAuthCookies(auth) }.status,
+            )
+            assertEquals(
+                HttpStatusCode.BadRequest,
+                client.get("/freelance/billing-reports?from=2026-08-24&to=2026-08-17") { withAuthCookies(auth) }.status,
+            )
+        }
+
+    @Test
+    fun `happy path returns the grouped report`() =
+        testApplication {
+            val auth = installNonAdminAuth("freelance-reports-read", "freelance-reports-read-user")
+            grantPermission("freelance-reports-read", "freelance_reports_read")
+            val currencyId = ExposedTestDb.seedCurrency("USD")
+            val clientId = ExposedTestDb.seedClient("Client Alpha", currencyId, hourlyRateCents = 6_000)
+            val projectId = ExposedTestDb.seedProject(clientId, name = "Project Alpha")
+            val taskId = ExposedTestDb.seedTask("Development")
+            ExposedTestDb.seedTimeEntry(projectId, taskId, entryDate = "2026-08-19", durationMinutes = 60)
+            application {
+                install(ContentNegotiation) { json() }
+                handler()
+                configureFreelanceReports()
+            }
+
+            val response =
+                client.get("/freelance/billing-reports?from=2026-08-17&to=2026-08-23&client_id=$clientId") {
+                    withAuthCookies(auth)
+                }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            val report = Json.decodeFromString<FreelanceReportResponse>(response.bodyAsText())
+            val currencyGroup = report.currencies.single()
+            assertEquals("USD", currencyGroup.currencyAcronym)
+            val projectGroup = currencyGroup.projects.single()
+            assertEquals("Project Alpha", projectGroup.projectName)
+            assertEquals(6_000, projectGroup.amountCents)
+        }
+}


### PR DESCRIPTION
## Summary

Implements the freelance billing reports API for issue #<fill-in-issue-number>. Adds an endpoint that aggregates billable hours and amounts by project/task for a date range, so `/freelancer/reports` on the frontend has something to render.

## Changes

- Adds `BillableTimeAggregationService`, a standalone service that resolves billable time entries in a date range: rate falls back from project → client, rate/amount are zeroed for non-billable entries, and amounts are rounded with `BigDecimal` (HALF_UP) to avoid rounding drift. Kept as its own service (not private to the report) so the future Invoices API can call the same source of truth instead of duplicating this logic.
- Adds `FreelanceReportService`, which groups those resolved lines into `currency → project → task`. Currency groups are never converted or combined — when a query spans clients billed in different currencies, each currency gets its own totals, matching the product decision that fiat-to-fiat conversion belongs client-side.
- Adds `GET /freelance/billing-reports?from&to&client_id` (`client_id` optional), registered via `configureFreelanceReports()` and guarded by the existing `freelance_reports_read` permission (already seeded in `V45__add_freelance_permissions.sql` — no new migration needed).
- Adds `FreelanceReportResponse` / `FreelanceReportCurrencyGroup` / `FreelanceReportProjectGroup` / `FreelanceReportTaskGroup` response models.
- Non-billable time entries are included in the report (with `amountCents = 0`) so freelancers can see total hours worked, not only billable ones.

## Out of scope

- The frontend Reports page (client-side BTC-equivalent aggregation and CSV export).
- The Invoices API and its invoice-generation aggregation — `BillableTimeAggregationService` is built to be reused by it once it exists, but cross-checking totals against it isn't possible yet.

## Verification

- `./gradlew test --tests "*BillableTimeAggregation*" --tests "*FreelanceReport*"`
- `./gradlew ktlintCheck test`