### PR TITLE
Refactor(server): freelance routes prefix

### DIFF
--- a/server/app/src/main/kotlin/pos/ambrosia/api/Clients.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/api/Clients.kt
@@ -20,7 +20,7 @@ import pos.ambrosia.utils.authorizePermission
 fun Application.configureClients() {
     val clientService = ClientService()
     val projectService = ProjectService()
-    routing { route("/clients") { clients(clientService, projectService) } }
+    routing { route("/freelance/clients") { clients(clientService, projectService) } }
 }
 
 fun Route.clients(

--- a/server/app/src/main/kotlin/pos/ambrosia/api/PayoutAccounts.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/api/PayoutAccounts.kt
@@ -17,7 +17,7 @@ import pos.ambrosia.utils.authorizePermission
 
 fun Application.configurePayoutAccounts() {
     val payoutAccountService = PayoutAccountService()
-    routing { route("/payout-accounts") { payoutAccounts(payoutAccountService) } }
+    routing { route("/freelance/payout-accounts") { payoutAccounts(payoutAccountService) } }
 }
 
 fun Route.payoutAccounts(payoutAccountService: PayoutAccountService) {

--- a/server/app/src/main/kotlin/pos/ambrosia/api/Projects.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/api/Projects.kt
@@ -16,7 +16,7 @@ import pos.ambrosia.utils.authorizePermission
 
 fun Application.configureProjects() {
     val projectService = ProjectService()
-    routing { route("/projects") { projects(projectService) } }
+    routing { route("/freelance/projects") { projects(projectService) } }
 }
 
 fun Route.projects(projectService: ProjectService) {

--- a/server/app/src/main/kotlin/pos/ambrosia/api/TimeEntries.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/api/TimeEntries.kt
@@ -26,7 +26,7 @@ import pos.ambrosia.utils.getCurrentUser
 
 fun Application.configureTimeEntries() {
     val timeEntryService = TimeEntryService()
-    routing { route("/time-entries") { timeEntries(timeEntryService) } }
+    routing { route("/freelance/time-entries") { timeEntries(timeEntryService) } }
 }
 
 fun Route.timeEntries(timeEntryService: TimeEntryService) {

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/FreelanceRoutesTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/FreelanceRoutesTest.kt
@@ -145,9 +145,9 @@ class FreelanceRoutesTest {
                 configureProjects()
             }
 
-            val getProjectResponse = client.get("/projects/$projectId") { withAuthCookies(authCookies) }
+            val getProjectResponse = client.get("/freelance/projects/$projectId") { withAuthCookies(authCookies) }
             val updateProjectResponse =
-                client.put("/projects/$projectId") {
+                client.put("/freelance/projects/$projectId") {
                     withAuthCookies(authCookies)
                     header(HttpHeaders.ContentType, "application/json")
                     setBody(
@@ -159,8 +159,8 @@ class FreelanceRoutesTest {
                         }""",
                     )
                 }
-            val deleteProjectResponse = client.delete("/projects/$projectId") { withAuthCookies(authCookies) }
-            val getDeletedProjectResponse = client.get("/projects/$projectId") { withAuthCookies(authCookies) }
+            val deleteProjectResponse = client.delete("/freelance/projects/$projectId") { withAuthCookies(authCookies) }
+            val getDeletedProjectResponse = client.get("/freelance/projects/$projectId") { withAuthCookies(authCookies) }
 
             assertEquals(HttpStatusCode.OK, getProjectResponse.status)
             assertEquals(HttpStatusCode.OK, updateProjectResponse.status)
@@ -269,7 +269,7 @@ class FreelanceRoutesTest {
             assertEquals(HttpStatusCode.Forbidden, client.get("/freelance/clients") { withAuthCookies(authCookies) }.status)
             assertEquals(
                 HttpStatusCode.Forbidden,
-                client.get("/projects/$projectId") { withAuthCookies(authCookies) }.status,
+                client.get("/freelance/projects/$projectId") { withAuthCookies(authCookies) }.status,
             )
         }
 

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/FreelanceRoutesTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/FreelanceRoutesTest.kt
@@ -57,7 +57,7 @@ class FreelanceRoutesTest {
             }
 
             val createClientResponse =
-                client.post("/clients") {
+                client.post("/freelance/clients") {
                     withAuthCookies(authCookies)
                     header(HttpHeaders.ContentType, "application/json")
                     setBody(
@@ -70,10 +70,10 @@ class FreelanceRoutesTest {
                         }""",
                     )
                 }
-            val listClientsResponse = client.get("/clients") { withAuthCookies(authCookies) }
-            val getClientResponse = client.get("/clients/$clientId") { withAuthCookies(authCookies) }
+            val listClientsResponse = client.get("/freelance/clients") { withAuthCookies(authCookies) }
+            val getClientResponse = client.get("/freelance/clients/$clientId") { withAuthCookies(authCookies) }
             val updateClientResponse =
-                client.put("/clients/$clientId") {
+                client.put("/freelance/clients/$clientId") {
                     withAuthCookies(authCookies)
                     header(HttpHeaders.ContentType, "application/json")
                     setBody(
@@ -86,8 +86,8 @@ class FreelanceRoutesTest {
                         }""",
                     )
                 }
-            val deleteClientResponse = client.delete("/clients/$clientId") { withAuthCookies(authCookies) }
-            val getDeletedClientResponse = client.get("/clients/$clientId") { withAuthCookies(authCookies) }
+            val deleteClientResponse = client.delete("/freelance/clients/$clientId") { withAuthCookies(authCookies) }
+            val getDeletedClientResponse = client.get("/freelance/clients/$clientId") { withAuthCookies(authCookies) }
 
             assertEquals(HttpStatusCode.Created, createClientResponse.status)
             assertEquals(HttpStatusCode.OK, listClientsResponse.status)
@@ -110,7 +110,7 @@ class FreelanceRoutesTest {
             }
 
             val createProjectResponse =
-                client.post("/clients/$clientId/projects") {
+                client.post("/freelance/clients/$clientId/projects") {
                     withAuthCookies(authCookies)
                     header(HttpHeaders.ContentType, "application/json")
                     setBody(
@@ -122,9 +122,9 @@ class FreelanceRoutesTest {
                         }""",
                     )
                 }
-            val listProjectsResponse = client.get("/clients/$clientId/projects") { withAuthCookies(authCookies) }
+            val listProjectsResponse = client.get("/freelance/clients/$clientId/projects") { withAuthCookies(authCookies) }
             val missingClientProjectsResponse =
-                client.get("/clients/00000000-0000-0000-0000-000000000000/projects") {
+                client.get("/freelance/clients/00000000-0000-0000-0000-000000000000/projects") {
                     withAuthCookies(authCookies)
                 }
 
@@ -266,7 +266,7 @@ class FreelanceRoutesTest {
             }
             val projectId = ExposedTestDb.seedFreelanceProject()
 
-            assertEquals(HttpStatusCode.Forbidden, client.get("/clients") { withAuthCookies(authCookies) }.status)
+            assertEquals(HttpStatusCode.Forbidden, client.get("/freelance/clients") { withAuthCookies(authCookies) }.status)
             assertEquals(
                 HttpStatusCode.Forbidden,
                 client.get("/projects/$projectId") { withAuthCookies(authCookies) }.status,

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/FreelanceRoutesTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/FreelanceRoutesTest.kt
@@ -181,7 +181,7 @@ class FreelanceRoutesTest {
             }
 
             val createPayoutAccountResponse =
-                client.post("/payout-accounts") {
+                client.post("/freelance/payout-accounts") {
                     withAuthCookies(authCookies)
                     header(HttpHeaders.ContentType, "application/json")
                     setBody(
@@ -199,11 +199,11 @@ class FreelanceRoutesTest {
                     .parseToJsonElement(createPayoutAccountResponse.bodyAsText())
                     .jsonObject["id"]!!
                     .jsonPrimitive.content
-            val listPayoutAccountsResponse = client.get("/payout-accounts") { withAuthCookies(authCookies) }
+            val listPayoutAccountsResponse = client.get("/freelance/payout-accounts") { withAuthCookies(authCookies) }
             val getPayoutAccountResponse =
-                client.get("/payout-accounts/$createdPayoutAccountId") { withAuthCookies(authCookies) }
+                client.get("/freelance/payout-accounts/$createdPayoutAccountId") { withAuthCookies(authCookies) }
             val updatePayoutAccountResponse =
-                client.put("/payout-accounts/$createdPayoutAccountId") {
+                client.put("/freelance/payout-accounts/$createdPayoutAccountId") {
                     withAuthCookies(authCookies)
                     header(HttpHeaders.ContentType, "application/json")
                     setBody(
@@ -214,9 +214,9 @@ class FreelanceRoutesTest {
                     )
                 }
             val deletePayoutAccountResponse =
-                client.delete("/payout-accounts/$createdPayoutAccountId") { withAuthCookies(authCookies) }
+                client.delete("/freelance/payout-accounts/$createdPayoutAccountId") { withAuthCookies(authCookies) }
             val getDeletedPayoutAccountResponse =
-                client.get("/payout-accounts/$createdPayoutAccountId") { withAuthCookies(authCookies) }
+                client.get("/freelance/payout-accounts/$createdPayoutAccountId") { withAuthCookies(authCookies) }
 
             assertEquals(HttpStatusCode.Created, createPayoutAccountResponse.status)
             assertEquals(HttpStatusCode.OK, listPayoutAccountsResponse.status)
@@ -238,13 +238,13 @@ class FreelanceRoutesTest {
             }
 
             val invalidBankResponse =
-                client.post("/payout-accounts") {
+                client.post("/freelance/payout-accounts") {
                     withAuthCookies(authCookies)
                     header(HttpHeaders.ContentType, "application/json")
                     setBody("""{"type":"bank","accountHolder":"Jane Doe"}""")
                 }
             val invalidLightningResponse =
-                client.post("/payout-accounts") {
+                client.post("/freelance/payout-accounts") {
                     withAuthCookies(authCookies)
                     header(HttpHeaders.ContentType, "application/json")
                     setBody("""{"type":"lightning","bankName":"Acme Bank","lightningAddress":"freelancer@getalby.com"}""")

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/TimeEntriesRouteTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/TimeEntriesRouteTest.kt
@@ -60,30 +60,30 @@ class TimeEntriesRouteTest {
 
             assertEquals(
                 HttpStatusCode.Unauthorized,
-                client.get("/time-entries?from=2026-08-17&to=2026-08-23").status,
+                client.get("/freelance/time-entries?from=2026-08-17&to=2026-08-23").status,
             )
-            assertEquals(HttpStatusCode.Unauthorized, client.post("/time-entries").status)
-            assertEquals(HttpStatusCode.Unauthorized, client.put("/time-entries/${UUID.randomUUID()}").status)
-            assertEquals(HttpStatusCode.Unauthorized, client.delete("/time-entries/${UUID.randomUUID()}").status)
+            assertEquals(HttpStatusCode.Unauthorized, client.post("/freelance/time-entries").status)
+            assertEquals(HttpStatusCode.Unauthorized, client.put("/freelance/time-entries/${UUID.randomUUID()}").status)
+            assertEquals(HttpStatusCode.Unauthorized, client.delete("/freelance/time-entries/${UUID.randomUUID()}").status)
 
             assertEquals(
                 HttpStatusCode.Forbidden,
                 client
-                    .get("/time-entries?from=2026-08-17&to=2026-08-23") {
+                    .get("/freelance/time-entries?from=2026-08-17&to=2026-08-23") {
                         withAuthCookies(auth)
                     }.status,
             )
             assertEquals(
                 HttpStatusCode.Forbidden,
-                client.post("/time-entries") { withAuthCookies(auth) }.status,
+                client.post("/freelance/time-entries") { withAuthCookies(auth) }.status,
             )
             assertEquals(
                 HttpStatusCode.Forbidden,
-                client.put("/time-entries/${UUID.randomUUID()}") { withAuthCookies(auth) }.status,
+                client.put("/freelance/time-entries/${UUID.randomUUID()}") { withAuthCookies(auth) }.status,
             )
             assertEquals(
                 HttpStatusCode.Forbidden,
-                client.delete("/time-entries/${UUID.randomUUID()}") { withAuthCookies(auth) }.status,
+                client.delete("/freelance/time-entries/${UUID.randomUUID()}") { withAuthCookies(auth) }.status,
             )
         }
 
@@ -100,7 +100,7 @@ class TimeEntriesRouteTest {
             }
 
             val response =
-                client.post("/time-entries") {
+                client.post("/freelance/time-entries") {
                     withAuthCookies(auth)
                     header(HttpHeaders.ContentType, "application/json")
                     setBody(requestBody(fixture.projectId, fixture.taskId))
@@ -127,10 +127,10 @@ class TimeEntriesRouteTest {
 
             assertEquals(
                 HttpStatusCode.BadRequest,
-                client.get("/time-entries?from=2026-08-17") { withAuthCookies(auth) }.status,
+                client.get("/freelance/time-entries?from=2026-08-17") { withAuthCookies(auth) }.status,
             )
             val response =
-                client.get("/time-entries?from=2026-08-17&to=2026-08-23") {
+                client.get("/freelance/time-entries?from=2026-08-17&to=2026-08-23") {
                     withAuthCookies(auth)
                 }
             assertEquals(HttpStatusCode.OK, response.status)
@@ -153,7 +153,7 @@ class TimeEntriesRouteTest {
             }
 
             val response =
-                client.put("/time-entries/$entryId") {
+                client.put("/freelance/time-entries/$entryId") {
                     withAuthCookies(auth)
                     header(HttpHeaders.ContentType, "application/json")
                     setBody(requestBody(fixture.projectId, fixture.taskId))
@@ -178,11 +178,11 @@ class TimeEntriesRouteTest {
 
             assertEquals(
                 HttpStatusCode.NoContent,
-                client.delete("/time-entries/$unlockedId") { withAuthCookies(auth) }.status,
+                client.delete("/freelance/time-entries/$unlockedId") { withAuthCookies(auth) }.status,
             )
             assertEquals(
                 HttpStatusCode.Conflict,
-                client.delete("/time-entries/$lockedId") { withAuthCookies(auth) }.status,
+                client.delete("/freelance/time-entries/$lockedId") { withAuthCookies(auth) }.status,
             )
         }
 
@@ -199,14 +199,14 @@ class TimeEntriesRouteTest {
 
             assertEquals(
                 HttpStatusCode.BadRequest,
-                client.get("/time-entries/not-a-uuid") { withAuthCookies(auth) }.status,
+                client.get("/freelance/time-entries/not-a-uuid") { withAuthCookies(auth) }.status,
             )
             assertEquals(
                 HttpStatusCode.BadRequest,
-                client.get("/time-entries?from=2026-08-24&to=2026-08-17") { withAuthCookies(auth) }.status,
+                client.get("/freelance/time-entries?from=2026-08-24&to=2026-08-17") { withAuthCookies(auth) }.status,
             )
             val malformedBodyResponse =
-                client.post("/time-entries") {
+                client.post("/freelance/time-entries") {
                     withAuthCookies(auth)
                     header(HttpHeaders.ContentType, "application/json")
                     setBody("{")
@@ -233,7 +233,7 @@ class TimeEntriesRouteTest {
             }
 
             val createdResponse =
-                client.post("/time-entries") {
+                client.post("/freelance/time-entries") {
                     withAuthCookies(auth)
                     header(HttpHeaders.ContentType, "application/json")
                     setBody(requestBody(fixture.projectId, fixture.taskId))
@@ -241,12 +241,12 @@ class TimeEntriesRouteTest {
             assertEquals(HttpStatusCode.Created, createdResponse.status)
             val created = Json.decodeFromString<TimeEntryResponse>(createdResponse.bodyAsText())
 
-            val getResponse = client.get("/time-entries/${created.id}") { withAuthCookies(auth) }
+            val getResponse = client.get("/freelance/time-entries/${created.id}") { withAuthCookies(auth) }
             assertEquals(HttpStatusCode.OK, getResponse.status)
             assertEquals(created.id, Json.decodeFromString<TimeEntryResponse>(getResponse.bodyAsText()).id)
 
             val putResponse =
-                client.put("/time-entries/${created.id}") {
+                client.put("/freelance/time-entries/${created.id}") {
                     withAuthCookies(auth)
                     header(HttpHeaders.ContentType, "application/json")
                     setBody(
@@ -267,11 +267,11 @@ class TimeEntriesRouteTest {
 
             assertEquals(
                 HttpStatusCode.NoContent,
-                client.delete("/time-entries/${created.id}") { withAuthCookies(auth) }.status,
+                client.delete("/freelance/time-entries/${created.id}") { withAuthCookies(auth) }.status,
             )
             assertEquals(
                 HttpStatusCode.NotFound,
-                client.get("/time-entries/${created.id}") { withAuthCookies(auth) }.status,
+                client.get("/freelance/time-entries/${created.id}") { withAuthCookies(auth) }.status,
             )
             transaction {
                 assertNull(TimeEntryEntity.findById(UUID.fromString(created.id)))
@@ -294,7 +294,7 @@ class TimeEntriesRouteTest {
             }
 
             val response =
-                client.post("/time-entries") {
+                client.post("/freelance/time-entries") {
                     withAuthCookies(auth)
                     header(HttpHeaders.ContentType, "application/json")
                     setBody(requestBody(projectId, taskId))
@@ -321,7 +321,7 @@ class TimeEntriesRouteTest {
             }
 
             val response =
-                client.post("/time-entries") {
+                client.post("/freelance/time-entries") {
                     withAuthCookies(auth)
                     header(HttpHeaders.ContentType, "application/json")
                     setBody(requestBody(projectId, taskId))
@@ -345,7 +345,7 @@ class TimeEntriesRouteTest {
             }
 
             val response =
-                client.post("/time-entries") {
+                client.post("/freelance/time-entries") {
                     withAuthCookies(auth)
                     header(HttpHeaders.ContentType, "application/json")
                     setBody(requestBody(fixture.projectId, fixture.taskId))


### PR DESCRIPTION
## Summary

Groups all freelance domain endpoints under the `/freelance/` prefix, so they are namespaced consistently with `/freelance/billing-reports` (which already had it) and clearly separated from the POS routes.

## Changes

- `Clients.kt`: `/clients` → `/freelance/clients` (includes the nested `/{id}/projects`).
- `Projects.kt`: `/projects` → `/freelance/projects`.
- `PayoutAccounts.kt`: `/payout-accounts` → `/freelance/payout-accounts`.
- `TimeEntries.kt`: `/time-entries` → `/freelance/time-entries`.
- `FreelanceReports.kt` required no changes, it already used `/freelance/billing-reports`.
- Updates `FreelanceRoutesTest.kt` and `TimeEntriesRouteTest.kt` to point at the new routes.
- Reviewed the rest of the codebase (routes registered in `Api.kt`, permissions in `V45__add_freelance_permissions.sql`, freelance commit/PR history, and references in `client/`/`electron/`) to confirm these are the only existing freelance services that needed the prefix; no hardcoded references to the old routes were found outside the server.

No logic or data contract changes — only the base path of each route.

## Testing

- `./gradlew :app:test --tests pos.ambrosia.utest.FreelanceRoutesTest --tests pos.ambrosia.utest.TimeEntriesRouteTest --tests pos.ambrosia.utest.FreelanceReportsRouteTest`
