### PR TITLE
Feat(server): freelance tasks api

### DIFF
--- a/server/app/src/main/kotlin/pos/ambrosia/Api.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/Api.kt
@@ -54,6 +54,7 @@ import pos.ambrosia.api.configureStoreOrders
 import pos.ambrosia.api.configureSuppliers
 import pos.ambrosia.api.configureSystem
 import pos.ambrosia.api.configureTables
+import pos.ambrosia.api.configureTasks
 import pos.ambrosia.api.configureTicketTemplates
 import pos.ambrosia.api.configureTickets
 import pos.ambrosia.api.configureTimeEntries
@@ -125,6 +126,7 @@ class Api {
         configureClients()
         configurePayoutAccounts()
         configureProjects()
+        configureTasks()
         configureCurrency()
         configureTimeEntries()
         configureFreelanceReports()

--- a/server/app/src/main/kotlin/pos/ambrosia/api/Tasks.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/api/Tasks.kt
@@ -1,0 +1,88 @@
+package pos.ambrosia.api
+
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.Application
+import io.ktor.server.request.receive
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.delete
+import io.ktor.server.routing.get
+import io.ktor.server.routing.post
+import io.ktor.server.routing.put
+import io.ktor.server.routing.route
+import io.ktor.server.routing.routing
+import pos.ambrosia.models.FreelanceTaskUpsert
+import pos.ambrosia.services.TaskService
+import pos.ambrosia.utils.authorizePermission
+
+fun Application.configureTasks() {
+    val taskService = TaskService()
+    routing { route("/freelance/tasks") { tasks(taskService) } }
+}
+
+fun Route.tasks(taskService: TaskService) {
+    authorizePermission("tasks_read") {
+        get("") {
+            val tasks = taskService.getTasks()
+            if (tasks.isEmpty()) {
+                call.respond(HttpStatusCode.OK, "No tasks found")
+                return@get
+            }
+            call.respond(HttpStatusCode.OK, tasks)
+        }
+
+        get("/{id}") {
+            val taskId =
+                call.parameters["id"]
+                    ?: return@get call.respond(HttpStatusCode.BadRequest, "Missing or malformed ID")
+            val task =
+                taskService.getTaskById(taskId)
+                    ?: return@get call.respond(HttpStatusCode.NotFound, "Task not found")
+            call.respond(HttpStatusCode.OK, task)
+        }
+    }
+
+    authorizePermission("tasks_create") {
+        post("") {
+            val taskRequest = call.receive<FreelanceTaskUpsert>()
+            val createdTaskId = taskService.addTask(taskRequest)
+            if (createdTaskId == null) {
+                call.respond(HttpStatusCode.BadRequest, "Invalid task data")
+                return@post
+            }
+            call.respond(
+                HttpStatusCode.Created,
+                mapOf("id" to createdTaskId, "message" to "Task added successfully"),
+            )
+        }
+    }
+
+    authorizePermission("tasks_update") {
+        put("/{id}") {
+            val taskId =
+                call.parameters["id"]
+                    ?: return@put call.respond(HttpStatusCode.BadRequest, "Missing or malformed ID")
+            val taskRequest = call.receive<FreelanceTaskUpsert>()
+            val taskWasUpdated = taskService.updateTask(taskId, taskRequest)
+            if (!taskWasUpdated) {
+                call.respond(HttpStatusCode.NotFound, "Task with ID: $taskId not found or invalid")
+                return@put
+            }
+            call.respond(HttpStatusCode.OK, mapOf("id" to taskId, "message" to "Task updated successfully"))
+        }
+    }
+
+    authorizePermission("tasks_delete") {
+        delete("/{id}") {
+            val taskId =
+                call.parameters["id"]
+                    ?: return@delete call.respond(HttpStatusCode.BadRequest, "Missing or malformed ID")
+            val taskWasDeleted = taskService.deleteTask(taskId)
+            if (!taskWasDeleted) {
+                call.respond(HttpStatusCode.NotFound, "Task not found")
+                return@delete
+            }
+            call.respond(HttpStatusCode.NoContent)
+        }
+    }
+}

--- a/server/app/src/main/kotlin/pos/ambrosia/models/AppModels.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/models/AppModels.kt
@@ -592,6 +592,21 @@ data class FreelanceProjectUpsert(
 )
 
 @Serializable
+data class FreelanceTask(
+    val id: String,
+    val name: String,
+    val isBillable: Boolean = true,
+    val isDeleted: Boolean = false,
+    val createdAt: String,
+)
+
+@Serializable
+data class FreelanceTaskUpsert(
+    val name: String,
+    val isBillable: Boolean = true,
+)
+
+@Serializable
 data class PayoutAccount(
     val id: String,
     val type: String,

--- a/server/app/src/main/kotlin/pos/ambrosia/services/TaskService.kt
+++ b/server/app/src/main/kotlin/pos/ambrosia/services/TaskService.kt
@@ -1,0 +1,91 @@
+package pos.ambrosia.services
+
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import pos.ambrosia.db.tables.TaskEntity
+import pos.ambrosia.db.tables.TasksTable
+import pos.ambrosia.logger
+import pos.ambrosia.models.FreelanceTask
+import pos.ambrosia.models.FreelanceTaskUpsert
+import java.time.LocalDateTime
+import java.util.UUID
+
+class TaskService {
+    private fun parseUuid(value: String): UUID? =
+        try {
+            UUID.fromString(value)
+        } catch (_: IllegalArgumentException) {
+            null
+        }
+
+    private fun isValidTaskRequest(taskRequest: FreelanceTaskUpsert): Boolean = taskRequest.name.isNotBlank()
+
+    private fun toTaskModel(taskEntity: TaskEntity): FreelanceTask =
+        FreelanceTask(
+            id = taskEntity.id.value.toString(),
+            name = taskEntity.name,
+            isBillable = taskEntity.isBillable,
+            isDeleted = taskEntity.isDeleted,
+            createdAt = taskEntity.createdAt,
+        )
+
+    fun getTasks(): List<FreelanceTask> =
+        transaction {
+            TaskEntity
+                .find { TasksTable.isDeleted eq false }
+                .map { taskEntity -> toTaskModel(taskEntity) }
+        }
+
+    fun getTaskById(taskId: String): FreelanceTask? =
+        transaction {
+            val taskUuid = parseUuid(taskId) ?: return@transaction null
+            val taskEntity = TaskEntity.findById(taskUuid) ?: return@transaction null
+            if (taskEntity.isDeleted) return@transaction null
+            toTaskModel(taskEntity)
+        }
+
+    fun addTask(taskRequest: FreelanceTaskUpsert): String? =
+        transaction {
+            if (!isValidTaskRequest(taskRequest)) return@transaction null
+
+            val taskId =
+                TaskEntity
+                    .new(UUID.randomUUID()) {
+                        name = taskRequest.name
+                        isBillable = taskRequest.isBillable
+                        isDeleted = false
+                        createdAt = LocalDateTime.now().toString()
+                    }.id.value
+                    .toString()
+            logger.info("Freelance task created: $taskId")
+            taskId
+        }
+
+    fun updateTask(
+        taskId: String,
+        taskRequest: FreelanceTaskUpsert,
+    ): Boolean =
+        transaction {
+            val taskUuid = parseUuid(taskId) ?: return@transaction false
+            if (!isValidTaskRequest(taskRequest)) return@transaction false
+
+            val taskEntity = TaskEntity.findById(taskUuid) ?: return@transaction false
+            if (taskEntity.isDeleted) return@transaction false
+
+            taskEntity.name = taskRequest.name
+            taskEntity.isBillable = taskRequest.isBillable
+            logger.info("Freelance task updated: $taskId")
+            true
+        }
+
+    fun deleteTask(taskId: String): Boolean =
+        transaction {
+            val taskUuid = parseUuid(taskId) ?: return@transaction false
+            val taskEntity = TaskEntity.findById(taskUuid) ?: return@transaction false
+            if (taskEntity.isDeleted) return@transaction false
+
+            taskEntity.isDeleted = true
+            logger.info("Freelance task soft deleted: $taskId")
+            true
+        }
+}

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/FreelanceRoutesTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/FreelanceRoutesTest.kt
@@ -21,6 +21,7 @@ import org.junit.Before
 import pos.ambrosia.api.configureClients
 import pos.ambrosia.api.configurePayoutAccounts
 import pos.ambrosia.api.configureProjects
+import pos.ambrosia.api.configureTasks
 import pos.ambrosia.api.handler
 import pos.ambrosia.services.PermissionsService
 import pos.ambrosia.utils.ExposedTestDb
@@ -255,6 +256,57 @@ class FreelanceRoutesTest {
         }
 
     @Test
+    fun `task routes create list get update and soft delete tasks`() =
+        testApplication {
+            val authCookies = installAdminAuth()
+            grantFreelancePermissions("admin-test-role", taskPermissions)
+            application {
+                install(ContentNegotiation) { json() }
+                handler()
+                configureTasks()
+            }
+
+            val createTaskResponse =
+                client.post("/freelance/tasks") {
+                    withAuthCookies(authCookies)
+                    header(HttpHeaders.ContentType, "application/json")
+                    setBody(
+                        """{
+                            "name": "Development",
+                            "isBillable": true
+                        }""",
+                    )
+                }
+            val taskId =
+                Json
+                    .parseToJsonElement(createTaskResponse.bodyAsText())
+                    .jsonObject["id"]!!
+                    .jsonPrimitive.content
+            val listTasksResponse = client.get("/freelance/tasks") { withAuthCookies(authCookies) }
+            val getTaskResponse = client.get("/freelance/tasks/$taskId") { withAuthCookies(authCookies) }
+            val updateTaskResponse =
+                client.put("/freelance/tasks/$taskId") {
+                    withAuthCookies(authCookies)
+                    header(HttpHeaders.ContentType, "application/json")
+                    setBody(
+                        """{
+                            "name": "Design",
+                            "isBillable": false
+                        }""",
+                    )
+                }
+            val deleteTaskResponse = client.delete("/freelance/tasks/$taskId") { withAuthCookies(authCookies) }
+            val getDeletedTaskResponse = client.get("/freelance/tasks/$taskId") { withAuthCookies(authCookies) }
+
+            assertEquals(HttpStatusCode.Created, createTaskResponse.status)
+            assertEquals(HttpStatusCode.OK, listTasksResponse.status)
+            assertEquals(HttpStatusCode.OK, getTaskResponse.status)
+            assertEquals(HttpStatusCode.OK, updateTaskResponse.status)
+            assertEquals(HttpStatusCode.NoContent, deleteTaskResponse.status)
+            assertEquals(HttpStatusCode.NotFound, getDeletedTaskResponse.status)
+        }
+
+    @Test
     fun `freelance routes require matching permissions`() =
         testApplication {
             val authCookies = installAdminAuth()
@@ -303,6 +355,13 @@ class FreelanceRoutesTest {
                 "payout_accounts_create",
                 "payout_accounts_update",
                 "payout_accounts_delete",
+            )
+        val taskPermissions =
+            listOf(
+                "tasks_read",
+                "tasks_create",
+                "tasks_update",
+                "tasks_delete",
             )
     }
 }

--- a/server/app/src/test/kotlin/pos/ambrosia/utest/TaskServiceTest.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utest/TaskServiceTest.kt
@@ -1,0 +1,109 @@
+package pos.ambrosia.utest
+
+import org.junit.After
+import org.junit.Before
+import pos.ambrosia.models.FreelanceTaskUpsert
+import pos.ambrosia.services.TaskService
+import pos.ambrosia.utils.ExposedTestDb
+import java.io.File
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class TaskServiceTest {
+    private lateinit var databaseFile: File
+    private val service = TaskService()
+
+    @Before
+    fun setUp() {
+        databaseFile = ExposedTestDb.connect()
+    }
+
+    @After
+    fun tearDown() {
+        ExposedTestDb.cleanup(databaseFile)
+    }
+
+    @Test
+    fun `addTask returns id for valid request`() {
+        val taskId = service.addTask(FreelanceTaskUpsert(name = "Development", isBillable = true))
+
+        assertNotNull(taskId)
+        val task = service.getTaskById(taskId)
+        assertNotNull(task)
+        assertEquals("Development", task.name)
+        assertTrue(task.isBillable)
+    }
+
+    @Test
+    fun `addTask rejects blank name`() {
+        assertNull(service.addTask(FreelanceTaskUpsert(name = "   ")))
+    }
+
+    @Test
+    fun `getTasks excludes deleted tasks`() {
+        ExposedTestDb.seedTask(name = "Active")
+        ExposedTestDb.seedTask(name = "Deleted", isDeleted = true)
+
+        val tasks = service.getTasks()
+
+        assertEquals(1, tasks.size)
+        assertEquals("Active", tasks[0].name)
+    }
+
+    @Test
+    fun `getTaskById returns null for invalid missing or deleted task`() {
+        val deletedTaskId = ExposedTestDb.seedTask(isDeleted = true)
+
+        assertNull(service.getTaskById("not-a-uuid"))
+        assertNull(service.getTaskById(UUID.randomUUID().toString()))
+        assertNull(service.getTaskById(deletedTaskId))
+    }
+
+    @Test
+    fun `updateTask updates active task`() {
+        val taskId = ExposedTestDb.seedTask()
+
+        val taskWasUpdated = service.updateTask(taskId, FreelanceTaskUpsert(name = "Design", isBillable = false))
+
+        assertTrue(taskWasUpdated)
+        val task = service.getTaskById(taskId)
+        assertNotNull(task)
+        assertEquals("Design", task.name)
+        assertFalse(task.isBillable)
+    }
+
+    @Test
+    fun `updateTask returns false for invalid missing or deleted task`() {
+        val deletedTaskId = ExposedTestDb.seedTask(isDeleted = true)
+        val validRequest = FreelanceTaskUpsert(name = "Updated")
+
+        assertFalse(service.updateTask("not-a-uuid", validRequest))
+        assertFalse(service.updateTask(UUID.randomUUID().toString(), validRequest))
+        assertFalse(service.updateTask(deletedTaskId, validRequest))
+        assertFalse(service.updateTask(deletedTaskId, validRequest.copy(name = " ")))
+    }
+
+    @Test
+    fun `deleteTask soft deletes task`() {
+        val taskId = ExposedTestDb.seedTask()
+
+        val taskWasDeleted = service.deleteTask(taskId)
+
+        assertTrue(taskWasDeleted)
+        assertNull(service.getTaskById(taskId))
+    }
+
+    @Test
+    fun `deleteTask returns false for invalid missing or already deleted task`() {
+        val deletedTaskId = ExposedTestDb.seedTask(isDeleted = true)
+
+        assertFalse(service.deleteTask("not-a-uuid"))
+        assertFalse(service.deleteTask(UUID.randomUUID().toString()))
+        assertFalse(service.deleteTask(deletedTaskId))
+    }
+}

--- a/server/app/src/test/kotlin/pos/ambrosia/utils/ExposedTestDb.kt
+++ b/server/app/src/test/kotlin/pos/ambrosia/utils/ExposedTestDb.kt
@@ -364,12 +364,14 @@ object ExposedTestDb {
     fun seedTask(
         name: String = "Development",
         isBillable: Boolean = true,
+        isDeleted: Boolean = false,
     ): String =
         transaction {
             TaskEntity
                 .new(UUID.randomUUID()) {
                     this.name = name
                     this.isBillable = isBillable
+                    this.isDeleted = isDeleted
                     createdAt = "2026-08-24 12:00:00"
                 }.id.value
                 .toString()


### PR DESCRIPTION
## Summary

Adds the freelance Task service and API, completing the missing piece of the time-tracking flow: `TimeEntryService` already required an existing, non-deleted `task_id` to create or update any time entry, but there was no way to create or manage tasks — the `tasks_read/create/update/delete` permissions were already provisioned in `V45__add_freelance_permissions.sql` and assigned to the admin role, but never implemented.

## Changes

- Adds `FreelanceTask` / `FreelanceTaskUpsert` API models.
- Adds `TaskService` for listing, creating, updating, reading, and soft-deleting tasks, mirroring `ClientService`'s structure (name required, `isBillable` flag, soft delete).
- Adds task routes under `/freelance/tasks`, already namespaced under the `/freelance/` prefix (matching the upcoming route-prefix refactor for the rest of the freelance endpoints):
  - `GET /freelance/tasks`
  - `POST /freelance/tasks`
  - `GET /freelance/tasks/{id}`
  - `PUT /freelance/tasks/{id}`
  - `DELETE /freelance/tasks/{id}`
- Registers the new API module with `configureTasks()`.
- Uses the existing freelance permissions (`tasks_read/create/update/delete`) added by the freelance permissions migration.
- Extends the `ExposedTestDb.seedTask` test helper with an `isDeleted` parameter to support soft-delete test coverage.

## Testing

- Added focused service tests covering create/read/update/soft-delete and validation (`TaskServiceTest`).
- Added a route test covering the full CRUD flow (`FreelanceRoutesTest`).
- Verified locally with:
  - `./gradlew :app:test --tests pos.ambrosia.utest.TaskServiceTest`
  - `./gradlew :app:test --tests pos.ambrosia.utest.FreelanceRoutesTest`
  - `./gradlew :app:test --tests pos.ambrosia.utest.TimeEntriesRouteTest`
  - `./gradlew :app:ktlintCheck`