### PR TITLE
Chore/electron testability

### DIFF
--- a/.github/workflows/electron_unit_test.yml
+++ b/.github/workflows/electron_unit_test.yml
@@ -1,0 +1,32 @@
+name: Electron Unit Tests
+
+on:
+  pull_request:
+    branches:
+      - '**'
+
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        with:
+          node-version: '24'
+          cache: 'npm'
+          cache-dependency-path: electron/package-lock.json
+
+      - run: npm ci
+        working-directory: ./electron
+
+      - run: npm audit --audit-level=high
+        working-directory: ./electron
+
+      - run: npm run test
+        working-directory: ./electron

--- a/electron/__tests__/main.test.js
+++ b/electron/__tests__/main.test.js
@@ -1,0 +1,229 @@
+const fs = require('fs');
+const os = require('os');
+
+const electronUpdaterPath = require.resolve('electron-updater');
+
+function installElectronUpdaterMock() {
+  const fakeAutoUpdater = {
+    on: vi.fn(),
+    checkForUpdates: vi.fn().mockResolvedValue(undefined),
+    downloadUpdate: vi.fn(),
+    quitAndInstall: vi.fn(),
+  };
+  require.cache[electronUpdaterPath] = {
+    id: electronUpdaterPath,
+    filename: electronUpdaterPath,
+    loaded: true,
+    exports: { autoUpdater: fakeAutoUpdater },
+  };
+}
+
+const { installElectronMock } = require('../test-utils/electronMock');
+const { installSpawnMock } = require('../test-utils/spawnMock');
+const { installTreeKillMock } = require('../test-utils/treeKillMock');
+
+function createFakeNotificationClass() {
+  const createdInstances = [];
+  function FakeNotification(options) {
+    this.options = options;
+    this.on = vi.fn();
+    this.show = vi.fn();
+    createdInstances.push(this);
+  }
+  FakeNotification.isSupported = vi.fn().mockReturnValue(true);
+  FakeNotification.createdInstances = createdInstances;
+  return FakeNotification;
+}
+
+function createElectronAppMock() {
+  return {
+    requestSingleInstanceLock: vi.fn().mockReturnValue(true),
+    setName: vi.fn(),
+    whenReady: vi.fn().mockReturnValue(new Promise(() => {})),
+    on: vi.fn(),
+    quit: vi.fn(),
+    relaunch: vi.fn(),
+    getVersion: vi.fn().mockReturnValue('0.8.0-beta'),
+    isPackaged: false,
+    name: 'Ambrosia',
+  };
+}
+
+function collectHandlersByChannel(ipcMainMock) {
+  const handlersByChannel = {};
+  ipcMainMock.handle.mock.calls.forEach(([channel, handler]) => {
+    handlersByChannel[channel] = handler;
+  });
+  return handlersByChannel;
+}
+
+function collectListenersByChannel(ipcMainMock) {
+  const listenersByChannel = {};
+  ipcMainMock.on.mock.calls.forEach(([channel, listener]) => {
+    listenersByChannel[channel] = listener;
+  });
+  return listenersByChannel;
+}
+
+describe('IPC handlers and notifications', () => {
+  const appMock = createElectronAppMock();
+  const NotificationMock = createFakeNotificationClass();
+  const ipcMainMock = { handle: vi.fn(), on: vi.fn() };
+  let ipcHandlersByChannel;
+  let ipcListenersByChannel;
+
+  beforeAll(() => {
+    installSpawnMock();
+    installTreeKillMock();
+    installElectronUpdaterMock();
+    installElectronMock({
+      app: appMock,
+      BrowserWindow: vi.fn(),
+      Menu: { buildFromTemplate: vi.fn().mockReturnValue({ items: [] }), setApplicationMenu: vi.fn() },
+      Notification: NotificationMock,
+      dialog: { showMessageBox: vi.fn(), showErrorBox: vi.fn() },
+      shell: { openPath: vi.fn(), openExternal: vi.fn() },
+      ipcMain: ipcMainMock,
+    });
+    require('../main');
+    ipcHandlersByChannel = collectHandlersByChannel(ipcMainMock);
+    ipcListenersByChannel = collectListenersByChannel(ipcMainMock);
+  });
+
+  beforeEach(() => {
+    vi.spyOn(os, 'homedir').mockReturnValue('/fake/home');
+    vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+    vi.spyOn(fs, 'readFileSync').mockReturnValue('');
+    NotificationMock.isSupported.mockReturnValue(true);
+    NotificationMock.createdInstances.length = 0;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('services:get-statuses', () => {
+    it('returns null before the service manager has been created', () => {
+      expect(ipcHandlersByChannel['services:get-statuses']()).toBe(null);
+    });
+  });
+
+  describe('services:restart', () => {
+    it('rejects before the service manager has been created', async () => {
+      await expect(ipcHandlersByChannel['services:restart']({}, 'backend'))
+        .rejects.toThrow('ServiceManager not initialized');
+    });
+  });
+
+  describe('services:get-logs', () => {
+    it('returns the logs directory', () => {
+      expect(ipcHandlersByChannel['services:get-logs']()).toEqual({
+        logsDir: '/fake/home/.Ambrosia-POS/logs',
+      });
+    });
+  });
+
+  describe('app:relaunch', () => {
+    it('relaunches and quits the app', () => {
+      ipcHandlersByChannel['app:relaunch']();
+
+      expect(appMock.relaunch).toHaveBeenCalled();
+      expect(appMock.quit).toHaveBeenCalled();
+    });
+  });
+
+  describe('phoenixd:get-auto-liquidity', () => {
+    it('returns "off" when no phoenix.conf exists yet', () => {
+      expect(ipcHandlersByChannel['phoenixd:get-auto-liquidity']()).toBe('off');
+    });
+
+    it('returns the configured value from phoenix.conf', () => {
+      fs.existsSync.mockReturnValue(true);
+      fs.readFileSync.mockReturnValue('auto-liquidity=medium\n');
+
+      expect(ipcHandlersByChannel['phoenixd:get-auto-liquidity']()).toBe('medium');
+    });
+  });
+
+  describe('phoenixd:set-auto-liquidity', () => {
+    it('rejects before the service manager has been created', async () => {
+      await expect(ipcHandlersByChannel['phoenixd:set-auto-liquidity']({}, 'medium'))
+        .rejects.toThrow('ServiceManager not initialized');
+    });
+  });
+
+  describe('notifications:admin-activity', () => {
+    it('does not construct a notification when notifications are unsupported', () => {
+      NotificationMock.isSupported.mockReturnValue(false);
+
+      ipcListenersByChannel['notifications:admin-activity']({}, { title: 'New order' });
+
+      expect(NotificationMock.createdInstances).toHaveLength(0);
+    });
+
+    it('normalizes the title with a fallback and shows the notification', () => {
+      ipcListenersByChannel['notifications:admin-activity']({}, { body: 'Order #42 ready' });
+
+      const [notification] = NotificationMock.createdInstances;
+      expect(notification.options).toEqual({ title: 'Ambrosia', body: 'Order #42 ready', silent: false });
+      expect(notification.show).toHaveBeenCalled();
+    });
+
+    it('falls back through title, fallbackActivityTitle, and systemBody for the body', () => {
+      ipcListenersByChannel['notifications:admin-activity']({}, { fallbackActivityTitle: 'Fallback activity' });
+
+      const [notification] = NotificationMock.createdInstances;
+      expect(notification.options.body).toBe('Fallback activity');
+    });
+
+    it('truncates a title longer than 160 characters', () => {
+      ipcListenersByChannel['notifications:admin-activity']({}, { systemTitle: 'x'.repeat(200) });
+
+      const [notification] = NotificationMock.createdInstances;
+      expect(notification.options.title).toHaveLength(160);
+    });
+  });
+});
+
+describe('single-instance lock', () => {
+  async function loadFreshMainWithLock(lockAcquired) {
+    const appMock = createElectronAppMock();
+    appMock.requestSingleInstanceLock.mockReturnValue(lockAcquired);
+    const ipcMainMock = { handle: vi.fn(), on: vi.fn() };
+
+    vi.resetModules();
+    installSpawnMock();
+    installTreeKillMock();
+    installElectronUpdaterMock();
+    installElectronMock({
+      app: appMock,
+      BrowserWindow: vi.fn(),
+      Menu: { buildFromTemplate: vi.fn().mockReturnValue({ items: [] }), setApplicationMenu: vi.fn() },
+      Notification: createFakeNotificationClass(),
+      dialog: { showMessageBox: vi.fn(), showErrorBox: vi.fn() },
+      shell: { openPath: vi.fn(), openExternal: vi.fn() },
+      ipcMain: ipcMainMock,
+    });
+    vi.spyOn(os, 'homedir').mockReturnValue('/fake/home');
+    vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+    await import('../main');
+
+    return appMock;
+  }
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('quits immediately when another instance already holds the lock', async () => {
+    const appMock = await loadFreshMainWithLock(false);
+
+    expect(appMock.quit).toHaveBeenCalled();
+  });
+
+  it('registers a second-instance listener when this is the only instance', async () => {
+    const appMock = await loadFreshMainWithLock(true);
+
+    expect(appMock.on).toHaveBeenCalledWith('second-instance', expect.any(Function));
+  });
+});

--- a/electron/__tests__/preload.entry.test.js
+++ b/electron/__tests__/preload.entry.test.js
@@ -1,0 +1,171 @@
+const { installElectronMock, resetElectronMock } = require('../test-utils/electronMock');
+
+const contextBridgeMock = { exposeInMainWorld: vi.fn() };
+const ipcRendererMock = {
+  send: vi.fn(),
+  invoke: vi.fn(),
+  on: vi.fn(),
+  once: vi.fn(),
+  removeListener: vi.fn(),
+};
+
+let exposedChannelName;
+let exposedElectronApi;
+
+beforeAll(() => {
+  installElectronMock({ contextBridge: contextBridgeMock, ipcRenderer: ipcRendererMock });
+  require('../preload.entry');
+  [exposedChannelName, exposedElectronApi] = contextBridgeMock.exposeInMainWorld.mock.calls[0];
+});
+
+beforeEach(() => {
+  resetElectronMock();
+  contextBridgeMock.exposeInMainWorld.mockClear();
+  ipcRendererMock.send.mockClear();
+  ipcRendererMock.invoke.mockClear();
+  ipcRendererMock.on.mockClear();
+  ipcRendererMock.once.mockClear();
+  ipcRendererMock.removeListener.mockClear();
+});
+
+describe('exposeInMainWorld', () => {
+  it('exposes the API under the "electron" key', () => {
+    expect(exposedChannelName).toBe('electron');
+  });
+});
+
+describe('platform and versions', () => {
+  it('exposes the current process platform and versions', () => {
+    expect(exposedElectronApi.platform).toBe(process.platform);
+    expect(exposedElectronApi.versions).toEqual({
+      node: process.versions.node,
+      chrome: process.versions.chrome,
+      electron: process.versions.electron,
+    });
+  });
+});
+
+describe('ipc.send', () => {
+  it('forwards a whitelisted channel to ipcRenderer.send', () => {
+    exposedElectronApi.ipc.send('ping', 'payload');
+
+    expect(ipcRendererMock.send).toHaveBeenCalledWith('ping', 'payload');
+  });
+
+  it('does not forward a channel outside the send whitelist', () => {
+    exposedElectronApi.ipc.send('not-whitelisted', 'payload');
+
+    expect(ipcRendererMock.send).not.toHaveBeenCalled();
+  });
+});
+
+describe('ipc.invoke', () => {
+  it('forwards a whitelisted channel to ipcRenderer.invoke', () => {
+    ipcRendererMock.invoke.mockResolvedValue('result');
+
+    exposedElectronApi.ipc.invoke('services:get-statuses');
+
+    expect(ipcRendererMock.invoke).toHaveBeenCalledWith('services:get-statuses');
+  });
+
+  it('rejects with an Invalid channel error outside the invoke whitelist', async () => {
+    await expect(exposedElectronApi.ipc.invoke('not-whitelisted')).rejects.toThrow('Invalid channel: not-whitelisted');
+    expect(ipcRendererMock.invoke).not.toHaveBeenCalled();
+  });
+
+  it('passes through string, number, and boolean arguments unchanged', () => {
+    ipcRendererMock.invoke.mockResolvedValue(undefined);
+
+    exposedElectronApi.ipc.invoke('services:restart', 'backend', 3, true);
+
+    expect(ipcRendererMock.invoke).toHaveBeenCalledWith('services:restart', 'backend', 3, true);
+  });
+
+  it('drops a function argument, replacing it with null', () => {
+    ipcRendererMock.invoke.mockResolvedValue(undefined);
+
+    exposedElectronApi.ipc.invoke('services:restart', () => {});
+
+    expect(ipcRendererMock.invoke).toHaveBeenCalledWith('services:restart', null);
+  });
+
+  it('sanitizes a function nested inside an object argument, keeping the other keys', () => {
+    ipcRendererMock.invoke.mockResolvedValue(undefined);
+
+    exposedElectronApi.ipc.invoke('phoenixd:set-auto-liquidity', { value: 'off', onDone: () => {} });
+
+    expect(ipcRendererMock.invoke).toHaveBeenCalledWith('phoenixd:set-auto-liquidity', { value: 'off', onDone: null });
+  });
+
+  it('sanitizes a function nested inside an array argument', () => {
+    ipcRendererMock.invoke.mockResolvedValue(undefined);
+
+    exposedElectronApi.ipc.invoke('services:restart', ['backend', () => {}]);
+
+    expect(ipcRendererMock.invoke).toHaveBeenCalledWith('services:restart', ['backend', null]);
+  });
+
+  it('passes through null and undefined unchanged', () => {
+    ipcRendererMock.invoke.mockResolvedValue(undefined);
+
+    exposedElectronApi.ipc.invoke('services:restart', null, undefined);
+
+    expect(ipcRendererMock.invoke).toHaveBeenCalledWith('services:restart', null, undefined);
+  });
+});
+
+describe('ipc.on', () => {
+  it('registers a listener for a whitelisted receive channel', () => {
+    const callback = vi.fn();
+
+    exposedElectronApi.ipc.on('pong', callback);
+
+    expect(ipcRendererMock.on).toHaveBeenCalledWith('pong', expect.any(Function));
+  });
+
+  it('does not register a listener outside the receive whitelist', () => {
+    exposedElectronApi.ipc.on('not-whitelisted', vi.fn());
+
+    expect(ipcRendererMock.on).not.toHaveBeenCalled();
+  });
+
+  it('strips the IPC event object before forwarding to the callback', () => {
+    const callback = vi.fn();
+
+    exposedElectronApi.ipc.on('pong', callback);
+    const registeredListener = ipcRendererMock.on.mock.calls[0][1];
+    registeredListener({ senderFrame: {} }, 'arg1', 'arg2');
+
+    expect(callback).toHaveBeenCalledWith('arg1', 'arg2');
+  });
+});
+
+describe('ipc.once', () => {
+  it('registers a one-time listener for a whitelisted receive channel', () => {
+    exposedElectronApi.ipc.once('server-status', vi.fn());
+
+    expect(ipcRendererMock.once).toHaveBeenCalledWith('server-status', expect.any(Function));
+  });
+
+  it('does not register a one-time listener outside the receive whitelist', () => {
+    exposedElectronApi.ipc.once('not-whitelisted', vi.fn());
+
+    expect(ipcRendererMock.once).not.toHaveBeenCalled();
+  });
+});
+
+describe('ipc.removeListener', () => {
+  it('forwards removal for a whitelisted receive channel', () => {
+    const callback = vi.fn();
+
+    exposedElectronApi.ipc.removeListener('update:available', callback);
+
+    expect(ipcRendererMock.removeListener).toHaveBeenCalledWith('update:available', callback);
+  });
+
+  it('does not forward removal outside the receive whitelist', () => {
+    exposedElectronApi.ipc.removeListener('not-whitelisted', vi.fn());
+
+    expect(ipcRendererMock.removeListener).not.toHaveBeenCalled();
+  });
+});

--- a/electron/__tests__/splash-preload.entry.test.js
+++ b/electron/__tests__/splash-preload.entry.test.js
@@ -1,0 +1,66 @@
+const { installElectronMock, resetElectronMock } = require('../test-utils/electronMock');
+
+const contextBridgeMock = { exposeInMainWorld: vi.fn() };
+const ipcRendererMock = { on: vi.fn(), removeListener: vi.fn() };
+
+let exposedChannelName;
+let exposedSplashBridge;
+
+beforeAll(() => {
+  installElectronMock({ contextBridge: contextBridgeMock, ipcRenderer: ipcRendererMock });
+  require('../splash-preload.entry');
+  [exposedChannelName, exposedSplashBridge] = contextBridgeMock.exposeInMainWorld.mock.calls[0];
+});
+
+beforeEach(() => {
+  resetElectronMock();
+  contextBridgeMock.exposeInMainWorld.mockClear();
+  ipcRendererMock.on.mockClear();
+  ipcRendererMock.removeListener.mockClear();
+});
+
+describe('exposeInMainWorld', () => {
+  it('exposes the API under the "splashBridge" key', () => {
+    expect(exposedChannelName).toBe('splashBridge');
+  });
+});
+
+describe('on', () => {
+  it('registers a listener for a whitelisted splash channel', () => {
+    exposedSplashBridge.on('splash:update', vi.fn());
+
+    expect(ipcRendererMock.on).toHaveBeenCalledWith('splash:update', expect.any(Function));
+  });
+
+  it('does not register a listener outside the splash whitelist', () => {
+    exposedSplashBridge.on('not-whitelisted', vi.fn());
+
+    expect(ipcRendererMock.on).not.toHaveBeenCalled();
+  });
+
+  it('returns a no-op unsubscribe function outside the splash whitelist', () => {
+    const unsubscribe = exposedSplashBridge.on('not-whitelisted', vi.fn());
+
+    expect(() => unsubscribe()).not.toThrow();
+    expect(ipcRendererMock.removeListener).not.toHaveBeenCalled();
+  });
+
+  it('strips the IPC event object before forwarding data to the callback', () => {
+    const callback = vi.fn();
+
+    exposedSplashBridge.on('splash:update', callback);
+    const registeredListener = ipcRendererMock.on.mock.calls[0][1];
+    registeredListener({ senderFrame: {} }, { progress: 50 });
+
+    expect(callback).toHaveBeenCalledWith({ progress: 50 });
+  });
+
+  it('returns an unsubscribe function that removes the same listener that was registered', () => {
+    const unsubscribe = exposedSplashBridge.on('splash:update', vi.fn());
+    const registeredListener = ipcRendererMock.on.mock.calls[0][1];
+
+    unsubscribe();
+
+    expect(ipcRendererMock.removeListener).toHaveBeenCalledWith('splash:update', registeredListener);
+  });
+});

--- a/electron/eslint.config.mjs
+++ b/electron/eslint.config.mjs
@@ -149,6 +149,23 @@ const eslintConfig = [
       'import/prefer-default-export': 'off',
     },
   },
+  {
+    files: ['**/__tests__/**/*.test.js'],
+    languageOptions: {
+      globals: {
+        // vitest globals
+        describe: 'readonly',
+        it: 'readonly',
+        test: 'readonly',
+        expect: 'readonly',
+        vi: 'readonly',
+        beforeAll: 'readonly',
+        afterAll: 'readonly',
+        beforeEach: 'readonly',
+        afterEach: 'readonly',
+      },
+    },
+  },
 ];
 
 export default eslintConfig;

--- a/electron/eslint.config.mjs
+++ b/electron/eslint.config.mjs
@@ -150,7 +150,7 @@ const eslintConfig = [
     },
   },
   {
-    files: ['**/__tests__/**/*.test.js'],
+    files: ['**/__tests__/**/*.test.js', 'test-utils/**/*.js'],
     languageOptions: {
       globals: {
         // vitest globals

--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -24,7 +24,8 @@
         "esbuild": "0.28.1",
         "eslint": "^9.39.2",
         "eslint-plugin-import": "^2.32.0",
-        "eslint-plugin-n": "^17.23.1"
+        "eslint-plugin-n": "^17.23.1",
+        "vitest": "5.0.0"
       }
     },
     "node_modules/@electron-internal/extract-zip": {
@@ -1029,6 +1030,34 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
+      "integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
     "node_modules/@malept/cross-spawn-promise": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-2.0.0.tgz",
@@ -1097,6 +1126,17 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@oxc-project/types": {
+      "version": "0.148.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.148.0.tgz",
+      "integrity": "sha512-Nm4s/jB+4FpFsPhWGEC4h7rzksesmtnMXomo6rCMcg/b8zLQuOziRgkCS1fxDCXOlJB/6Q8oABOZ/OP6RIPj9A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/oxc-project"
+      }
+    },
     "node_modules/@peculiar/asn1-schema": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.8.0.tgz",
@@ -1148,6 +1188,302 @@
       "engines": {
         "node": ">=14.18.0"
       }
+    },
+    "node_modules/@rolldown/binding-android-arm-eabi": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm-eabi/-/binding-android-arm-eabi-1.2.7.tgz",
+      "integrity": "sha512-EypzgnYCwyVY4NDHKzGmNJT5b+XaQEBniHxsMdeIQLB/tcCzZnhqrzHpZFbX9iaxx+5RiB8caATBtfvZP7zVxQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.7.tgz",
+      "integrity": "sha512-l17HE9EweWaqJZhuUuNBN/FzM62xw+DECVnJyvMsxn8vJFAGLy5QfLDoYAcronkAN8VxKZHezDpulHDPx95vFw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.7.tgz",
+      "integrity": "sha512-8ED8ELFvHXc6OCETIn4gXObPiaR6bckM/ipXtbzlPVDRMBfEGjCKgO90F9YtfdpDatVx/ZQw7aZ1vUMf/+T3Mw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.7.tgz",
+      "integrity": "sha512-/WPripjtiAIZ2tWY7ddijORT0Ujg87wxWW/qcoFVCKAWVDPhtY0xr7Dj0M3GyNGz60jGwTElhro/mkF9dT7dDQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.7.tgz",
+      "integrity": "sha512-14DI4NcqpvbICxSnGLx3PmtDaWqRP/KGSGb6C+JLLVPeZRl6dKdHba3pGsqT3vpdTqhEYIPG0MMQ8c0xYqoJxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.7.tgz",
+      "integrity": "sha512-bxrWIRvHWQvbJwi+VIie/kDJmQxcNE6xxWwZdqF/ExVAigtHkv54WTLQPb+QsZdnFy18fg7JPfWGL0RH6vwIlQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.7.tgz",
+      "integrity": "sha512-toOY2BChBZyuxU7OYX6Tn389di4IzAqPTycVcci0O7FSfBqzRB3RZn+K5Is6ANf4tmgRd/K1yZTsNTXbkXsnLg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.7.tgz",
+      "integrity": "sha512-lAIXTH/aiLRLxsTgQvfhjo4K1ydWIp00+V0voOr9beb/9ZmkUFrSIb03dXNFRgMNvkE6oGsF10ioQ6UsI+vS5Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.7.tgz",
+      "integrity": "sha512-kdnwS28Pkenp/mZMRwjXXXwxQ7pIsm+bF919LUK93BOyhcLsrVKdP2p9fxpiPNPAbNuch8ypQt0pm2P2LYCAGg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.7.tgz",
+      "integrity": "sha512-516OdsyLdr5E65paF3yBF55t8mfm9+gmtCsK3xI7XKXIT7EfRlHhxL8K/NR6Hu8BWSgF5+1w74lTL0+nxcc8Qw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.7.tgz",
+      "integrity": "sha512-r8/z8n7GFaYRln3xmP1Cxy0HH/HLM0uBUPkEuSVEfKGDA89M0FsZRZJRSwe/tJjRx+fpH/gjorfhB8tmEbSFLA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.7.tgz",
+      "integrity": "sha512-pAsE8iiDxUg1xBqdhrTfg45AVDVpirjz00sblEYClGNNcMnDb+e8beQgqIAw6LvauX/APvgxUnwrgun/YYGBhw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.7.tgz",
+      "integrity": "sha512-lTcIYmmnQQA8Or/2DatS6oSqcdLHvendjS+zLu+FwgToynWMRSmQdpM65fTANJgIS4mjbMOo5KT2lnT9SAb96w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.7.tgz",
+      "integrity": "sha512-e3Gu3WxbNk/UqQhxqU7YIYO+9ZBvWNz3U+h/qRFosscMFzdRPbXYSaSWgSnklv2fz1TgzBTcti2z35c/7irsHw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.7.tgz",
+      "integrity": "sha512-W/jg5qoRSqjsEv0+dZi4e687mcHqmVuU0P4fK6qS/xjetW2Gmc1W8j//z5nAeNcC8Ttm0hV46IjcYeuVwYhuiw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
@@ -1201,6 +1537,17 @@
         "@types/responselike": "^1.0.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -1210,6 +1557,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1284,6 +1638,44 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-5.0.0.tgz",
+      "integrity": "sha512-66PGTMIiVJP3t4a5yxU9qPtf7MdTBs8jmToMvy+HVflB3Yy13WJZTtPePdvU+wjRV02SKK5doLbSA6o9pwOmiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.31",
+        "@vitest/spy": "5.0.0",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^1.2.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-5.0.0.tgz",
+      "integrity": "sha512-uy+luWBAPw9XfthoHi5AkfHUnuPYEESjl0p/r+meoBnU8bxg5GDQ3Ey8MjcJ6sqahkL4PFyrvfMJJBw7LbU06g==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@xmldom/xmldom": {
@@ -1744,6 +2136,16 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/async": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
@@ -2049,6 +2451,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -2389,6 +2801,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/detect-node": {
@@ -2803,6 +3226,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -3277,6 +3707,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -3285,6 +3725,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/exponential-backoff": {
@@ -3502,6 +3952,22 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -4590,6 +5056,291 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "peer": true,
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -4653,6 +5404,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-1.2.3.tgz",
+      "integrity": "sha512-Bpb0W2TbLKOZ7vJnOUnVRGq3WL2p+ISV29M6hYPL1AFCpyKZpdr5ytiXoTSSxRVhg8YW7f65+6gbG8WG6PCa/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/matcher": {
@@ -4786,6 +5547,26 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -5050,6 +5831,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -5210,9 +6005,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5276,6 +6071,36 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.28",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.28.tgz",
+      "integrity": "sha512-RRuzqDtt5Y9h3quz5hWhK+TPnsmVs6WwSU6LkJMeY4HstUEDuYTG8UJSdawMRzmzAtV+KEoG8N3Qg2qLy5vM/A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "nanoid": "^3.3.18",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/postject": {
@@ -5657,6 +6482,41 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/rolldown": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.7.tgz",
+      "integrity": "sha512-g0EtLvBjTUB7jhyV0S/TCup3v/XSVl45vUIGbOGU4QPiyjTenCe4mKuFvW9fEgYmS2Fo42AUssRmNuMziXdrig==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@oxc-project/types": "=0.148.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm-eabi": "1.2.7",
+        "@rolldown/binding-android-arm64": "1.2.7",
+        "@rolldown/binding-darwin-arm64": "1.2.7",
+        "@rolldown/binding-darwin-x64": "1.2.7",
+        "@rolldown/binding-freebsd-x64": "1.2.7",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.7",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.7",
+        "@rolldown/binding-linux-arm64-musl": "1.2.7",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.7",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.7",
+        "@rolldown/binding-linux-x64-gnu": "1.2.7",
+        "@rolldown/binding-linux-x64-musl": "1.2.7",
+        "@rolldown/binding-openharmony-arm64": "1.2.7",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.7",
+        "@rolldown/binding-win32-x64-msvc": "1.2.7"
+      }
+    },
     "node_modules/rxjs": {
       "version": "7.8.2",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
@@ -5928,6 +6788,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -5971,6 +6838,17 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-support": {
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
@@ -5990,6 +6868,13 @@
       "license": "BSD-3-Clause",
       "optional": true
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stat-mode": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-1.0.0.tgz",
@@ -5999,6 +6884,13 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -6265,6 +7157,26 @@
       "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
       "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==",
       "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-6.1.4.tgz",
+      "integrity": "sha512-9APumHG7r4yOk4X4WlkmE71aZcv1gvin1czO3OQ1U9iJcFA5Ja/ygyb0vPOVHTthFozUYs8CLoLUlM8grb2lTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
@@ -6596,6 +7508,168 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/vite": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.2.tgz",
+      "integrity": "sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.26",
+        "rolldown": "~1.2.4",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.4.0 || ^0.5.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-5.0.0.tgz",
+      "integrity": "sha512-gpsMNoRhMjMktVxPtstOH4/PJuPyovVaMDr4oDilXaGH1EcqM2OE96SoHT2VIQ6fTGtTjqmHDrEu2X9RQiXf8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/mocker": "5.0.0",
+        "chai": "^6.2.2",
+        "es-module-lexer": "^2.3.2",
+        "expect-type": "^1.4.0",
+        "magic-string": "^1.2.3",
+        "obug": "^2.1.4",
+        "picomatch": "^4.0.7",
+        "std-env": "^4.2.0",
+        "tinybench": "6.1.4",
+        "tinyexec": "1.3.0",
+        "tinyglobby": "^0.2.17",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^22.12.0 || ^24.0.0 || >=26.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "5.0.0",
+        "@vitest/browser-preview": "5.0.0",
+        "@vitest/browser-webdriverio": "^5.0.0-beta.5 || >=5.0.0",
+        "@vitest/coverage-istanbul": "5.0.0",
+        "@vitest/coverage-v8": "5.0.0",
+        "@vitest/ui": "5.0.0",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.4.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/wait-on": {
       "version": "8.0.5",
       "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-8.0.5.tgz",
@@ -6731,6 +7805,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/electron/package.json
+++ b/electron/package.json
@@ -9,6 +9,8 @@
     "dev:inspect": "npm run build:preload && electron --inspect=5858 .",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "build:preload": "node scripts/build-preload.js",
     "build:prepare": "node scripts/prepare-resources-wrapper.js",
     "build": "npm run build:prepare && electron-builder",
@@ -40,7 +42,8 @@
     "esbuild": "0.28.1",
     "eslint": "^9.39.2",
     "eslint-plugin-import": "^2.32.0",
-    "eslint-plugin-n": "^17.23.1"
+    "eslint-plugin-n": "^17.23.1",
+    "vitest": "5.0.0"
   },
   "dependencies": {
     "cross-spawn": "^7.0.6",

--- a/electron/services/__tests__/AutoUpdater.test.js
+++ b/electron/services/__tests__/AutoUpdater.test.js
@@ -1,0 +1,302 @@
+const { EventEmitter } = require('events');
+const fs = require('fs');
+
+const electronUpdaterPath = require.resolve('electron-updater');
+let fakeAutoUpdater;
+
+function installElectronUpdaterMock() {
+  fakeAutoUpdater = new EventEmitter();
+  fakeAutoUpdater.checkForUpdates = vi.fn().mockResolvedValue(undefined);
+  fakeAutoUpdater.downloadUpdate = vi.fn();
+  fakeAutoUpdater.quitAndInstall = vi.fn();
+  require.cache[electronUpdaterPath] = {
+    id: electronUpdaterPath,
+    filename: electronUpdaterPath,
+    loaded: true,
+    exports: { autoUpdater: fakeAutoUpdater },
+  };
+}
+
+const { installElectronMock } = require('../../test-utils/electronMock');
+const { setPlatformAndArch, restorePlatformAndArch } = require('../../test-utils/platformMock');
+const logger = require('../../utils/logger');
+
+const dialogMock = { showMessageBox: vi.fn() };
+const ipcMainMock = { handle: vi.fn(), removeHandler: vi.fn() };
+const shellMock = { openExternal: vi.fn() };
+
+installElectronMock({ dialog: dialogMock, ipcMain: ipcMainMock, shell: shellMock });
+installElectronUpdaterMock();
+
+function createFakeMainWindow() {
+  return {
+    isDestroyed: vi.fn().mockReturnValue(false),
+    webContents: { send: vi.fn() },
+  };
+}
+
+function ipcHandlerFor(channel) {
+  const call = ipcMainMock.handle.mock.calls.find(([registeredChannel]) => registeredChannel === channel);
+  return call[1];
+}
+
+async function loadFreshAutoUpdater() {
+  vi.resetModules();
+  const autoUpdaterModule = await import('../AutoUpdater');
+  return autoUpdaterModule.default;
+}
+
+afterEach(() => {
+  restorePlatformAndArch();
+  vi.clearAllMocks();
+  fakeAutoUpdater.removeAllListeners();
+});
+
+describe('outside Windows', () => {
+  let AutoUpdater;
+  let mainWindow;
+  let onMenuUpdate;
+
+  beforeAll(async () => {
+    setPlatformAndArch('darwin', 'arm64');
+    AutoUpdater = await loadFreshAutoUpdater();
+  });
+
+  beforeEach(() => {
+    mainWindow = createFakeMainWindow();
+    onMenuUpdate = vi.fn();
+    dialogMock.showMessageBox.mockResolvedValue({ response: 1 });
+    fakeAutoUpdater.checkForUpdates.mockResolvedValue(undefined);
+    vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+    vi.spyOn(logger, 'log').mockImplementation(() => {});
+    vi.spyOn(logger, 'error').mockImplementation(() => {});
+  });
+
+  it('does not prompt for a pending update on construction, even if one is stale', () => {
+    fs.existsSync.mockReturnValue(true);
+    vi.spyOn(fs, 'readFileSync').mockReturnValue(JSON.stringify({ version: '1.2.0', downloadedAt: 0 }));
+
+    new AutoUpdater(mainWindow, { releaseUrl: 'https://example.com/releases' });
+
+    expect(dialogMock.showMessageBox).not.toHaveBeenCalled();
+  });
+
+  it('notifies the renderer and updates the menu, without auto-downloading', () => {
+    new AutoUpdater(mainWindow, { onMenuUpdate, releaseUrl: 'https://example.com/releases' });
+
+    fakeAutoUpdater.emit('update-available', { version: '1.2.0' });
+
+    expect(fakeAutoUpdater.downloadUpdate).not.toHaveBeenCalled();
+    expect(onMenuUpdate).toHaveBeenCalledWith(expect.objectContaining({ enabled: true }));
+    expect(mainWindow.webContents.send).toHaveBeenCalledWith('update:available', { version: '1.2.0' });
+  });
+
+  it('opens the tagged release page when the update-available menu item is clicked', async () => {
+    new AutoUpdater(mainWindow, { onMenuUpdate, releaseUrl: 'https://example.com/releases' });
+    fakeAutoUpdater.emit('update-available', { version: '1.2.0' });
+    dialogMock.showMessageBox.mockResolvedValue({ response: 0 });
+
+    const { click } = onMenuUpdate.mock.calls[0][0];
+    click();
+    await Promise.resolve().then().then();
+
+    expect(shellMock.openExternal).toHaveBeenCalledWith('https://example.com/releases/tag/v1.2.0');
+  });
+
+  it('shows an up-to-date dialog only for a manual check', async () => {
+    const autoUpdater = new AutoUpdater(mainWindow, { onMenuUpdate });
+    autoUpdater.checkForUpdatesManual();
+
+    fakeAutoUpdater.emit('update-not-available', { version: '1.2.0' });
+    await Promise.resolve();
+
+    expect(dialogMock.showMessageBox).toHaveBeenCalledWith(mainWindow, expect.objectContaining({ title: 'No Updates Available' }));
+  });
+
+  it('does not show an up-to-date dialog for a background check', () => {
+    new AutoUpdater(mainWindow, { onMenuUpdate });
+
+    fakeAutoUpdater.emit('update-not-available', { version: '1.2.0' });
+
+    expect(dialogMock.showMessageBox).not.toHaveBeenCalled();
+  });
+
+  it('shows an error dialog only for a manual check', () => {
+    const autoUpdater = new AutoUpdater(mainWindow, { onMenuUpdate });
+    autoUpdater.checkForUpdatesManual();
+
+    fakeAutoUpdater.emit('error', new Error('network unreachable'));
+
+    expect(dialogMock.showMessageBox).toHaveBeenCalledWith(mainWindow, expect.objectContaining({ detail: 'network unreachable' }));
+  });
+
+  it('does not show an error dialog for a background check', () => {
+    new AutoUpdater(mainWindow, { onMenuUpdate });
+
+    fakeAutoUpdater.emit('error', new Error('network unreachable'));
+
+    expect(dialogMock.showMessageBox).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when update:install is invoked', () => {
+    new AutoUpdater(mainWindow);
+
+    ipcHandlerFor('update:install')();
+
+    expect(fakeAutoUpdater.quitAndInstall).not.toHaveBeenCalled();
+  });
+
+  it('opens the bare release url when update:open-release is invoked with no pending version', () => {
+    new AutoUpdater(mainWindow, { releaseUrl: 'https://example.com/releases' });
+
+    ipcHandlerFor('update:open-release')();
+
+    expect(shellMock.openExternal).toHaveBeenCalledWith('https://example.com/releases');
+  });
+
+  it('shows an error dialog and resets the menu when a manual check fails to even start', async () => {
+    fakeAutoUpdater.checkForUpdates.mockReturnValue(Promise.reject(new Error('offline')));
+    const autoUpdater = new AutoUpdater(mainWindow, { onMenuUpdate });
+
+    autoUpdater.checkForUpdatesManual();
+    await Promise.resolve().then().then();
+
+    expect(dialogMock.showMessageBox).toHaveBeenCalledWith(mainWindow, expect.objectContaining({ detail: 'offline' }));
+    expect(onMenuUpdate).toHaveBeenLastCalledWith({ label: 'Check for Updates...', enabled: true });
+  });
+
+  it('does not show a dialog when a background check fails to even start', async () => {
+    fakeAutoUpdater.checkForUpdates.mockReturnValue(Promise.reject(new Error('offline')));
+    const autoUpdater = new AutoUpdater(mainWindow, { onMenuUpdate });
+
+    autoUpdater.checkForUpdates();
+    await Promise.resolve().then().then();
+
+    expect(dialogMock.showMessageBox).not.toHaveBeenCalled();
+  });
+
+  it('repeats checkForUpdates on the given interval', async () => {
+    vi.useFakeTimers();
+    const autoUpdater = new AutoUpdater(mainWindow);
+    fakeAutoUpdater.checkForUpdates.mockClear();
+
+    autoUpdater.startPeriodicChecks(1000);
+    expect(fakeAutoUpdater.checkForUpdates).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(fakeAutoUpdater.checkForUpdates).toHaveBeenCalledTimes(2);
+
+    autoUpdater.stopPeriodicChecks();
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(fakeAutoUpdater.checkForUpdates).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
+  });
+
+  it('removes both ipc handlers on destroy', () => {
+    const autoUpdater = new AutoUpdater(mainWindow);
+
+    autoUpdater.destroy();
+
+    expect(ipcMainMock.removeHandler).toHaveBeenCalledWith('update:install');
+    expect(ipcMainMock.removeHandler).toHaveBeenCalledWith('update:open-release');
+  });
+});
+
+describe('on Windows', () => {
+  let AutoUpdater;
+  let mainWindow;
+  let onMenuUpdate;
+
+  beforeAll(async () => {
+    setPlatformAndArch('win32', 'x64');
+    AutoUpdater = await loadFreshAutoUpdater();
+  });
+
+  beforeEach(() => {
+    mainWindow = createFakeMainWindow();
+    onMenuUpdate = vi.fn();
+    dialogMock.showMessageBox.mockResolvedValue({ response: 1 });
+    fakeAutoUpdater.checkForUpdates.mockResolvedValue(undefined);
+    vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+    vi.spyOn(fs, 'mkdirSync').mockImplementation(() => {});
+    vi.spyOn(fs, 'writeFileSync').mockImplementation(() => {});
+    vi.spyOn(fs, 'unlinkSync').mockImplementation(() => {});
+    vi.spyOn(logger, 'log').mockImplementation(() => {});
+    vi.spyOn(logger, 'error').mockImplementation(() => {});
+  });
+
+  it('silently downloads the update instead of notifying the renderer', () => {
+    new AutoUpdater(mainWindow, { onMenuUpdate });
+
+    fakeAutoUpdater.emit('update-available', { version: '1.2.0' });
+
+    expect(fakeAutoUpdater.downloadUpdate).toHaveBeenCalled();
+    expect(mainWindow.webContents.send).not.toHaveBeenCalled();
+  });
+
+  it('saves the update state and notifies the renderer once downloaded', () => {
+    new AutoUpdater(mainWindow, { onMenuUpdate });
+
+    fakeAutoUpdater.emit('update-downloaded', { version: '1.2.0' });
+
+    expect(fs.writeFileSync).toHaveBeenCalledWith(
+      expect.stringContaining('pending-update.json'),
+      expect.stringContaining('"version":"1.2.0"'),
+    );
+    expect(mainWindow.webContents.send).toHaveBeenCalledWith('update:downloaded', { version: '1.2.0' });
+  });
+
+  it('quits and installs when update:install is invoked', () => {
+    new AutoUpdater(mainWindow);
+
+    ipcHandlerFor('update:install')();
+
+    expect(fakeAutoUpdater.quitAndInstall).toHaveBeenCalledWith(false, true);
+  });
+
+  it('does not prompt when there is no pending update file', () => {
+    new AutoUpdater(mainWindow);
+
+    expect(dialogMock.showMessageBox).not.toHaveBeenCalled();
+  });
+
+  it('does not prompt when the pending update is not yet expired', () => {
+    fs.existsSync.mockReturnValue(true);
+    vi.spyOn(fs, 'readFileSync').mockReturnValue(JSON.stringify({ version: '1.2.0', downloadedAt: Date.now() }));
+
+    new AutoUpdater(mainWindow);
+
+    expect(dialogMock.showMessageBox).not.toHaveBeenCalled();
+  });
+
+  it('prompts to restart when a pending update is older than 7 days', () => {
+    fs.existsSync.mockReturnValue(true);
+    const eightDaysAgo = Date.now() - (8 * 24 * 60 * 60 * 1000);
+    vi.spyOn(fs, 'readFileSync').mockReturnValue(JSON.stringify({ version: '1.2.0', downloadedAt: eightDaysAgo }));
+
+    new AutoUpdater(mainWindow);
+
+    expect(dialogMock.showMessageBox).toHaveBeenCalledWith(mainWindow, expect.objectContaining({ title: 'Update Ready to Install' }));
+  });
+
+  it('clears the pending update and installs when the user confirms the restart prompt', async () => {
+    fs.existsSync.mockReturnValue(true);
+    const eightDaysAgo = Date.now() - (8 * 24 * 60 * 60 * 1000);
+    vi.spyOn(fs, 'readFileSync').mockReturnValue(JSON.stringify({ version: '1.2.0', downloadedAt: eightDaysAgo }));
+    dialogMock.showMessageBox.mockResolvedValue({ response: 0 });
+
+    new AutoUpdater(mainWindow);
+    await Promise.resolve().then().then();
+
+    expect(fs.unlinkSync).toHaveBeenCalled();
+    expect(fakeAutoUpdater.quitAndInstall).toHaveBeenCalledWith(false, true);
+  });
+
+  it('does not crash when the pending update file is corrupted', () => {
+    fs.existsSync.mockReturnValue(true);
+    vi.spyOn(fs, 'readFileSync').mockReturnValue('not valid json');
+
+    expect(() => new AutoUpdater(mainWindow)).not.toThrow();
+    expect(logger.error).toHaveBeenCalled();
+  });
+});

--- a/electron/services/__tests__/BackendService.test.js
+++ b/electron/services/__tests__/BackendService.test.js
@@ -1,0 +1,204 @@
+const fs = require('fs');
+
+const { installElectronMock } = require('../../test-utils/electronMock');
+const { createFakeSpawnedProcess, createFakeWriteStream } = require('../../test-utils/fakeChildProcess');
+const { installSpawnMock } = require('../../test-utils/spawnMock');
+const { installTreeKillMock } = require('../../test-utils/treeKillMock');
+const healthCheck = require('../../utils/healthCheck');
+const logger = require('../../utils/logger');
+
+let BackendService;
+let spawnMock;
+let treeKillMock;
+
+beforeAll(() => {
+  installElectronMock();
+  spawnMock = installSpawnMock();
+  treeKillMock = installTreeKillMock();
+  healthCheck.checkBackend = vi.fn();
+  BackendService = require('../BackendService');
+});
+
+let fakeSpawnedProcess;
+
+const backendConfig = { phoenixdPort: 9740, phoenixPassword: 'phoenix-password', webhookSecret: 'webhook-secret' };
+
+beforeEach(() => {
+  fakeSpawnedProcess = createFakeSpawnedProcess();
+  spawnMock.mockReset().mockReturnValue(fakeSpawnedProcess);
+  treeKillMock.mockReset().mockImplementation((_pid, _signal, callback) => callback());
+  healthCheck.checkBackend.mockReset().mockResolvedValue(true);
+  vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+  vi.spyOn(fs, 'mkdirSync').mockImplementation(() => {});
+  vi.spyOn(fs, 'createWriteStream').mockImplementation(createFakeWriteStream);
+  vi.spyOn(logger, 'log').mockImplementation(() => {});
+  vi.spyOn(logger, 'warn').mockImplementation(() => {});
+  vi.spyOn(logger, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('constructor', () => {
+  it('starts with no process, stopped status, and no port', () => {
+    const backendService = new BackendService();
+
+    expect(backendService.getStatus()).toBe('stopped');
+    expect(backendService.getPort()).toBe(null);
+  });
+});
+
+describe('start', () => {
+  it('throws when a process is already running', async () => {
+    const backendService = new BackendService();
+    await backendService.start(9154, backendConfig);
+
+    await expect(backendService.start(9154, backendConfig)).rejects.toThrow('Backend service is already running');
+  });
+
+  it('creates the logs directory when it does not exist', async () => {
+    fs.existsSync.mockReturnValue(false);
+    const backendService = new BackendService();
+
+    await backendService.start(9154, backendConfig);
+
+    expect(fs.mkdirSync).toHaveBeenCalledWith(expect.stringContaining('logs'), { recursive: true });
+  });
+
+  it('does not create the logs directory when it already exists', async () => {
+    fs.existsSync.mockReturnValue(true);
+    const backendService = new BackendService();
+
+    await backendService.start(9154, backendConfig);
+
+    expect(fs.mkdirSync).not.toHaveBeenCalled();
+  });
+
+  it('spawns java with the jar path and port args', async () => {
+    const backendService = new BackendService();
+
+    await backendService.start(9154, backendConfig);
+
+    const [javaPath, args] = spawnMock.mock.calls[0];
+    expect(javaPath).toBe('java');
+    expect(args).toEqual(expect.arrayContaining([
+      '-jar',
+      '--http-bind-ip=127.0.0.1',
+      '--http-bind-port=9154',
+      '--phoenixd-url=http://localhost:9740',
+    ]));
+  });
+
+  it('omits the phoenixd-url arg when a remote phoenixd node is configured', async () => {
+    const backendService = new BackendService();
+
+    await backendService.start(9154, { ...backendConfig, phoenixdRemoteConfigured: true });
+
+    const [, args] = spawnMock.mock.calls[0];
+    expect(args).not.toEqual(expect.arrayContaining([expect.stringContaining('--phoenixd-url')]));
+  });
+
+  it('passes the phoenixd password and webhook secret as env vars', async () => {
+    const backendService = new BackendService();
+
+    await backendService.start(9154, backendConfig);
+
+    const [, , spawnOptions] = spawnMock.mock.calls[0];
+    expect(spawnOptions.env.PHOENIXD_PASSWORD).toBe('phoenix-password');
+    expect(spawnOptions.env.PHOENIXD_WEBHOOK_SECRET).toBe('webhook-secret');
+  });
+
+  it('strips JAVA_* env vars before spawning', async () => {
+    process.env.JAVA_TOOL_OPTIONS = '-Xmx512m';
+    const backendService = new BackendService();
+
+    await backendService.start(9154, backendConfig);
+
+    const [, , spawnOptions] = spawnMock.mock.calls[0];
+    expect(spawnOptions.env.JAVA_TOOL_OPTIONS).toBeUndefined();
+
+    delete process.env.JAVA_TOOL_OPTIONS;
+  });
+
+  it('waits for the backend to become healthy before resolving', async () => {
+    const backendService = new BackendService();
+
+    const result = await backendService.start(9154, backendConfig);
+
+    expect(healthCheck.checkBackend).toHaveBeenCalledWith(9154);
+    expect(result).toEqual({ port: 9154 });
+    expect(backendService.getStatus()).toBe('running');
+  });
+
+  it('stops the process and rethrows when the health check never succeeds', async () => {
+    healthCheck.checkBackend.mockRejectedValue(new Error('Timed out waiting for: http://localhost:9154/api/health'));
+    const backendService = new BackendService();
+
+    await expect(backendService.start(9154, backendConfig))
+      .rejects.toThrow('Timed out waiting for: http://localhost:9154/api/health');
+    expect(backendService.getStatus()).toBe('stopped');
+  });
+});
+
+describe('stop', () => {
+  it('does nothing when there is no process to stop', async () => {
+    const backendService = new BackendService();
+
+    await backendService.stop();
+
+    expect(treeKillMock).not.toHaveBeenCalled();
+  });
+
+  it('resolves once SIGTERM succeeds', async () => {
+    const backendService = new BackendService();
+    await backendService.start(9154, backendConfig);
+
+    await backendService.stop();
+
+    expect(treeKillMock).toHaveBeenCalledWith(fakeSpawnedProcess.pid, 'SIGTERM', expect.any(Function));
+    expect(backendService.getStatus()).toBe('stopped');
+  });
+
+  it('falls back to SIGKILL when sending SIGTERM fails', async () => {
+    treeKillMock.mockImplementation((_pid, signal, callback) => {
+      if (signal === 'SIGTERM') callback(new Error('no such process'));
+      else callback();
+    });
+    const backendService = new BackendService();
+    await backendService.start(9154, backendConfig);
+
+    await backendService.stop();
+
+    expect(treeKillMock).toHaveBeenCalledWith(fakeSpawnedProcess.pid, 'SIGKILL', expect.any(Function));
+  });
+
+  it('force-kills with SIGKILL when SIGTERM never calls back before the timeout', async () => {
+    vi.useFakeTimers();
+    treeKillMock.mockImplementation((_pid, signal, callback) => {
+      if (signal === 'SIGKILL') callback();
+    });
+    const backendService = new BackendService();
+    await backendService.start(9154, backendConfig);
+
+    const stopPromise = backendService.stop();
+    await vi.advanceTimersByTimeAsync(10000);
+    await stopPromise;
+
+    expect(treeKillMock).toHaveBeenCalledWith(fakeSpawnedProcess.pid, 'SIGKILL', expect.any(Function));
+    vi.useRealTimers();
+  });
+});
+
+describe('cleanup', () => {
+  it('resets process, status, and closes the log stream', async () => {
+    const backendService = new BackendService();
+    await backendService.start(9154, backendConfig);
+    const logStreamEndSpy = backendService.logStream.end;
+
+    backendService.cleanup();
+
+    expect(backendService.getStatus()).toBe('stopped');
+    expect(logStreamEndSpy).toHaveBeenCalled();
+  });
+});

--- a/electron/services/__tests__/BackendService.test.js
+++ b/electron/services/__tests__/BackendService.test.js
@@ -28,6 +28,7 @@ beforeEach(() => {
   spawnMock.mockReset().mockReturnValue(fakeSpawnedProcess);
   treeKillMock.mockReset().mockImplementation((_pid, _signal, callback) => callback());
   healthCheck.checkBackend.mockReset().mockResolvedValue(true);
+  vi.spyOn(fs, 'readdirSync').mockReturnValue(['ambrosia-0.8.0-beta.jar']);
   vi.spyOn(fs, 'existsSync').mockReturnValue(true);
   vi.spyOn(fs, 'mkdirSync').mockImplementation(() => {});
   vi.spyOn(fs, 'createWriteStream').mockImplementation(createFakeWriteStream);

--- a/electron/services/__tests__/ConfigurationBootstrap.test.js
+++ b/electron/services/__tests__/ConfigurationBootstrap.test.js
@@ -1,0 +1,191 @@
+const crypto = require('crypto');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { installElectronMock } = require('../../test-utils/electronMock');
+
+let configurationBootstrap;
+
+beforeAll(() => {
+  installElectronMock();
+  configurationBootstrap = require('../ConfigurationBootstrap');
+});
+
+const FAKE_HOME_DIRECTORY = '/fake/home';
+const AMBROSIA_CONFIG_PATH = path.join(FAKE_HOME_DIRECTORY, '.Ambrosia-POS', 'ambrosia.conf');
+const PHOENIX_CONFIG_PATH = path.join(FAKE_HOME_DIRECTORY, '.phoenix', 'phoenix.conf');
+
+let fakeFiles;
+
+function installFakeFileSystem() {
+  fakeFiles = new Map();
+  vi.spyOn(fs, 'existsSync').mockImplementation((filePath) => fakeFiles.has(filePath));
+  vi.spyOn(fs, 'mkdirSync').mockImplementation(() => {});
+  vi.spyOn(fs, 'writeFileSync').mockImplementation((filePath, content) => {
+    fakeFiles.set(filePath, content);
+  });
+  vi.spyOn(fs, 'readFileSync').mockImplementation((filePath) => fakeFiles.get(filePath));
+}
+
+beforeEach(() => {
+  vi.spyOn(os, 'homedir').mockReturnValue(FAKE_HOME_DIRECTORY);
+  installFakeFileSystem();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('generateRandomHex', () => {
+  it('returns a hex string with two characters per byte', () => {
+    expect(configurationBootstrap.generateRandomHex(32)).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('returns a different value on each call', () => {
+    const firstHex = configurationBootstrap.generateRandomHex(32);
+    const secondHex = configurationBootstrap.generateRandomHex(32);
+
+    expect(firstHex).not.toBe(secondHex);
+  });
+});
+
+describe('readConfig', () => {
+  it('returns an empty object when the file does not exist', () => {
+    expect(configurationBootstrap.readConfig('/does/not/exist.conf')).toEqual({});
+  });
+
+  it('parses key=value lines into an object', () => {
+    fakeFiles.set('/config.conf', 'http-bind-ip=127.0.0.1\nhttp-bind-port=9154\n');
+
+    expect(configurationBootstrap.readConfig('/config.conf')).toEqual({
+      'http-bind-ip': '127.0.0.1',
+      'http-bind-port': '9154',
+    });
+  });
+
+  it('skips blank lines and comment lines', () => {
+    fakeFiles.set('/config.conf', '# a comment\n\nhttp-bind-ip=127.0.0.1\n');
+
+    expect(configurationBootstrap.readConfig('/config.conf')).toEqual({ 'http-bind-ip': '127.0.0.1' });
+  });
+
+  it('preserves "=" characters inside the value', () => {
+    fakeFiles.set('/config.conf', 'webhook=http://localhost:9154/webhook?token=abc=def\n');
+
+    expect(configurationBootstrap.readConfig('/config.conf')).toEqual({
+      webhook: 'http://localhost:9154/webhook?token=abc=def',
+    });
+  });
+
+  it('trims whitespace around keys and values', () => {
+    fakeFiles.set('/config.conf', '  http-bind-ip = 127.0.0.1  \n');
+
+    expect(configurationBootstrap.readConfig('/config.conf')).toEqual({ 'http-bind-ip': '127.0.0.1' });
+  });
+});
+
+describe('writeConfig', () => {
+  it('writes key=value lines with a trailing newline', () => {
+    configurationBootstrap.writeConfig('/config.conf', { a: '1', b: '2' });
+
+    expect(fakeFiles.get('/config.conf')).toBe('a=1\nb=2\n');
+  });
+
+  it('writes the file with owner-only permissions', () => {
+    configurationBootstrap.writeConfig('/config.conf', { a: '1' });
+
+    expect(fs.writeFileSync).toHaveBeenCalledWith('/config.conf', 'a=1\n', { encoding: 'utf-8', mode: 0o600 });
+  });
+});
+
+describe('configExists', () => {
+  it('returns false when neither config file exists', () => {
+    expect(configurationBootstrap.configExists()).toBe(false);
+  });
+
+  it('returns false when only the ambrosia config exists', () => {
+    fakeFiles.set(AMBROSIA_CONFIG_PATH, '');
+
+    expect(configurationBootstrap.configExists()).toBe(false);
+  });
+
+  it('returns true when both config files exist', () => {
+    fakeFiles.set(AMBROSIA_CONFIG_PATH, '');
+    fakeFiles.set(PHOENIX_CONFIG_PATH, '');
+
+    expect(configurationBootstrap.configExists()).toBe(true);
+  });
+});
+
+describe('ensureConfigurations', () => {
+  const allocatedPorts = { backend: 9154, phoenixd: 9740, nextjs: 3000 };
+
+  it('creates the data, phoenix, and logs directories when they do not exist', async () => {
+    await configurationBootstrap.ensureConfigurations(allocatedPorts);
+
+    expect(fs.mkdirSync).toHaveBeenCalledWith(path.join(FAKE_HOME_DIRECTORY, '.Ambrosia-POS'), { recursive: true });
+    expect(fs.mkdirSync).toHaveBeenCalledWith(path.join(FAKE_HOME_DIRECTORY, '.phoenix'), { recursive: true });
+    expect(fs.mkdirSync).toHaveBeenCalledWith(path.join(FAKE_HOME_DIRECTORY, '.Ambrosia-POS', 'logs'), { recursive: true });
+  });
+
+  it('generates a new ambrosia config with a secret and a matching secret-hash', async () => {
+    const { ambrosia } = await configurationBootstrap.ensureConfigurations(allocatedPorts);
+
+    expect(ambrosia.secret).toMatch(/^[0-9a-f]{64}$/);
+    expect(ambrosia['secret-hash']).toBe(crypto.createHash('sha256').update(ambrosia.secret).digest('hex'));
+    expect(ambrosia['http-bind-port']).toBe('9154');
+    expect(ambrosia['phoenixd-url']).toBe('http://localhost:9740');
+  });
+
+  it('generates a new phoenix config with independent random secrets', async () => {
+    const { phoenix } = await configurationBootstrap.ensureConfigurations(allocatedPorts);
+
+    expect(phoenix['http-password']).toMatch(/^[0-9a-f]{64}$/);
+    expect(phoenix['http-password-limited-access']).toMatch(/^[0-9a-f]{64}$/);
+    expect(phoenix['webhook-secret']).toMatch(/^[0-9a-f]{64}$/);
+    expect(phoenix['http-password']).not.toBe(phoenix['http-password-limited-access']);
+    expect(phoenix.webhook).toBe('http://127.0.0.1:9154/webhook/phoenixd');
+  });
+
+  it('does not regenerate the ambrosia secret when the config already exists', async () => {
+    fakeFiles.set(AMBROSIA_CONFIG_PATH, 'secret=existing-secret\nsecret-hash=existing-hash\nhttp-bind-port=1111\n');
+    fakeFiles.set(PHOENIX_CONFIG_PATH, 'http-password=existing-password\n');
+
+    const { ambrosia } = await configurationBootstrap.ensureConfigurations(allocatedPorts);
+
+    expect(ambrosia.secret).toBe('existing-secret');
+    expect(ambrosia['secret-hash']).toBe('existing-hash');
+    expect(ambrosia['http-bind-port']).toBe('9154');
+  });
+
+  it('does not overwrite phoenixd-url when a remote phoenixd node is already configured', async () => {
+    fakeFiles.set(
+      AMBROSIA_CONFIG_PATH,
+      'secret=existing-secret\nsecret-hash=existing-hash\nphoenixd-remote=true\nphoenixd-url=http://100.1.1.1:9740\n',
+    );
+    fakeFiles.set(PHOENIX_CONFIG_PATH, 'http-password=existing-password\n');
+
+    const { ambrosia } = await configurationBootstrap.ensureConfigurations(allocatedPorts);
+
+    expect(ambrosia['phoenixd-url']).toBe('http://100.1.1.1:9740');
+  });
+
+  it('does not regenerate phoenix secrets when the config already exists', async () => {
+    fakeFiles.set(AMBROSIA_CONFIG_PATH, 'secret=existing-secret\nsecret-hash=existing-hash\n');
+    fakeFiles.set(PHOENIX_CONFIG_PATH, 'http-password=existing-password\nwebhook-secret=existing-webhook-secret\n');
+
+    const { phoenix } = await configurationBootstrap.ensureConfigurations(allocatedPorts);
+
+    expect(phoenix['http-password']).toBe('existing-password');
+    expect(phoenix['webhook-secret']).toBe('existing-webhook-secret');
+    expect(phoenix.webhook).toBe('http://127.0.0.1:9154/webhook/phoenixd');
+  });
+
+  it('persists both config files to disk when a new config was generated', async () => {
+    await configurationBootstrap.ensureConfigurations(allocatedPorts);
+
+    expect(fakeFiles.has(AMBROSIA_CONFIG_PATH)).toBe(true);
+    expect(fakeFiles.has(PHOENIX_CONFIG_PATH)).toBe(true);
+  });
+});

--- a/electron/services/__tests__/NextJsService.test.js
+++ b/electron/services/__tests__/NextJsService.test.js
@@ -1,0 +1,243 @@
+const fs = require('fs');
+const path = require('path');
+
+const { installElectronMock, setIsPackaged } = require('../../test-utils/electronMock');
+const { createFakeSpawnedProcess, createFakeWriteStream } = require('../../test-utils/fakeChildProcess');
+const { setPlatformAndArch, restorePlatformAndArch } = require('../../test-utils/platformMock');
+const { installSpawnMock } = require('../../test-utils/spawnMock');
+const { installTreeKillMock } = require('../../test-utils/treeKillMock');
+const healthCheck = require('../../utils/healthCheck');
+const logger = require('../../utils/logger');
+
+let NextJsService;
+let spawnMock;
+let treeKillMock;
+
+beforeAll(() => {
+  installElectronMock();
+  spawnMock = installSpawnMock();
+  treeKillMock = installTreeKillMock();
+  healthCheck.checkNextJs = vi.fn();
+  NextJsService = require('../NextJsService');
+});
+
+let fakeSpawnedProcess;
+
+beforeEach(() => {
+  fakeSpawnedProcess = createFakeSpawnedProcess();
+  setIsPackaged(false);
+  delete process.env.NODE_ENV;
+  delete process.resourcesPath;
+  spawnMock.mockReset().mockReturnValue(fakeSpawnedProcess);
+  treeKillMock.mockReset().mockImplementation((_pid, _signal, callback) => callback());
+  healthCheck.checkNextJs.mockReset().mockResolvedValue(true);
+  vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+  vi.spyOn(fs, 'mkdirSync').mockImplementation(() => {});
+  vi.spyOn(fs, 'createWriteStream').mockImplementation(createFakeWriteStream);
+  vi.spyOn(logger, 'log').mockImplementation(() => {});
+  vi.spyOn(logger, 'warn').mockImplementation(() => {});
+  vi.spyOn(logger, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  restorePlatformAndArch();
+  vi.restoreAllMocks();
+});
+
+describe('constructor', () => {
+  it('starts with no process, stopped status, and no port', () => {
+    const nextJsService = new NextJsService();
+
+    expect(nextJsService.getStatus()).toBe('stopped');
+    expect(nextJsService.getPort()).toBe(null);
+  });
+});
+
+describe('start', () => {
+  it('throws when a process is already running', async () => {
+    const nextJsService = new NextJsService();
+    await nextJsService.start(3000);
+
+    await expect(nextJsService.start(3000)).rejects.toThrow('Next.js service is already running');
+  });
+
+  it('creates the logs directory when it does not exist', async () => {
+    fs.existsSync.mockReturnValue(false);
+    const nextJsService = new NextJsService();
+
+    await nextJsService.start(3000);
+
+    expect(fs.mkdirSync).toHaveBeenCalledWith(expect.stringContaining('logs'), { recursive: true });
+  });
+
+  it('runs "npm run dev" in development mode', async () => {
+    const nextJsService = new NextJsService();
+
+    await nextJsService.start(3000);
+
+    const [command, args] = spawnMock.mock.calls[0];
+    expect(command).toBe('npm');
+    expect(args).toEqual(['run', 'dev', '--', '-p', '3000']);
+  });
+
+  it('does not check for server.js in development mode', async () => {
+    fs.existsSync.mockImplementation((checkedPath) => !String(checkedPath).endsWith('server.js'));
+    const nextJsService = new NextJsService();
+
+    await expect(nextJsService.start(3000)).resolves.toEqual(expect.objectContaining({ port: 3000 }));
+  });
+
+  it('runs the bundled Node.js binary against server.js in production mode', async () => {
+    setIsPackaged(true);
+    setPlatformAndArch('darwin', 'arm64');
+    process.resourcesPath = '/fake/resources';
+    const nextJsService = new NextJsService();
+
+    await nextJsService.start(3000);
+
+    const [command, args] = spawnMock.mock.calls[0];
+    expect(command).toBe(path.join('/fake/resources', 'node', 'macos-arm64', 'bin', 'node'));
+    expect(args).toEqual([expect.stringContaining('server.js')]);
+  });
+
+  it('throws when server.js is missing in production mode', async () => {
+    setIsPackaged(true);
+    process.resourcesPath = '/fake/resources';
+    fs.existsSync.mockImplementation((checkedPath) => !String(checkedPath).endsWith('server.js'));
+    const nextJsService = new NextJsService();
+
+    await expect(nextJsService.start(3000)).rejects.toThrow('server.js not found at:');
+  });
+
+  it('throws when spawn returns a process with no pid', async () => {
+    const spawnedProcessWithNoPid = createFakeSpawnedProcess();
+    spawnedProcessWithNoPid.pid = undefined;
+    spawnMock.mockReturnValue(spawnedProcessWithNoPid);
+    const nextJsService = new NextJsService();
+
+    await expect(nextJsService.start(3000)).rejects.toThrow('Failed to spawn Next.js process');
+  });
+
+  it('builds NEXT_PUBLIC_API_URL from the given backend host and port', async () => {
+    const nextJsService = new NextJsService();
+
+    await nextJsService.start(3000, { host: '127.0.0.1', port: '9154' });
+
+    const [, , spawnOptions] = spawnMock.mock.calls[0];
+    expect(spawnOptions.env.NEXT_PUBLIC_API_URL).toBe('http://127.0.0.1:9154');
+  });
+
+  it('defaults the backend host and port when none are given', async () => {
+    const nextJsService = new NextJsService();
+
+    await nextJsService.start(3000);
+
+    const [, , spawnOptions] = spawnMock.mock.calls[0];
+    expect(spawnOptions.env.NEXT_PUBLIC_API_URL).toBe('http://localhost:9154');
+  });
+
+  it('defaults NODE_ENV to production when unset', async () => {
+    const nextJsService = new NextJsService();
+
+    await nextJsService.start(3000);
+
+    const [, , spawnOptions] = spawnMock.mock.calls[0];
+    expect(spawnOptions.env.NODE_ENV).toBe('production');
+  });
+
+  it('waits for Next.js to become healthy before resolving', async () => {
+    const nextJsService = new NextJsService();
+
+    const result = await nextJsService.start(3000);
+
+    expect(healthCheck.checkNextJs).toHaveBeenCalledWith(3000);
+    expect(result).toEqual({ port: 3000, url: 'http://localhost:3000' });
+    expect(nextJsService.getStatus()).toBe('running');
+  });
+
+  it('stops the process and rethrows when the health check never succeeds', async () => {
+    healthCheck.checkNextJs.mockRejectedValue(new Error('Timed out waiting for: http://localhost:3000/'));
+    const nextJsService = new NextJsService();
+
+    await expect(nextJsService.start(3000)).rejects.toThrow('Timed out waiting for: http://localhost:3000/');
+    expect(nextJsService.getStatus()).toBe('stopped');
+  });
+});
+
+describe('stop', () => {
+  it('does nothing when there is no process to stop', async () => {
+    const nextJsService = new NextJsService();
+
+    await nextJsService.stop();
+
+    expect(treeKillMock).not.toHaveBeenCalled();
+  });
+
+  it('resolves once SIGTERM succeeds', async () => {
+    const nextJsService = new NextJsService();
+    await nextJsService.start(3000);
+
+    await nextJsService.stop();
+
+    expect(treeKillMock).toHaveBeenCalledWith(fakeSpawnedProcess.pid, 'SIGTERM', expect.any(Function));
+    expect(nextJsService.getStatus()).toBe('stopped');
+  });
+
+  it('falls back to SIGKILL when sending SIGTERM fails', async () => {
+    treeKillMock.mockImplementation((_pid, signal, callback) => {
+      if (signal === 'SIGTERM') callback(new Error('no such process'));
+      else callback();
+    });
+    const nextJsService = new NextJsService();
+    await nextJsService.start(3000);
+
+    await nextJsService.stop();
+
+    expect(treeKillMock).toHaveBeenCalledWith(fakeSpawnedProcess.pid, 'SIGKILL', expect.any(Function));
+  });
+
+  it('force-kills with SIGKILL when SIGTERM never calls back before the timeout', async () => {
+    vi.useFakeTimers();
+    treeKillMock.mockImplementation((_pid, signal, callback) => {
+      if (signal === 'SIGKILL') callback();
+    });
+    const nextJsService = new NextJsService();
+    await nextJsService.start(3000);
+
+    const stopPromise = nextJsService.stop();
+    await vi.advanceTimersByTimeAsync(5000);
+    await stopPromise;
+
+    expect(treeKillMock).toHaveBeenCalledWith(fakeSpawnedProcess.pid, 'SIGKILL', expect.any(Function));
+    vi.useRealTimers();
+  });
+});
+
+describe('cleanup', () => {
+  it('resets process, status, and closes the log stream', async () => {
+    const nextJsService = new NextJsService();
+    await nextJsService.start(3000);
+    const logStreamEndSpy = nextJsService.logStream.end;
+
+    nextJsService.cleanup();
+
+    expect(nextJsService.getStatus()).toBe('stopped');
+    expect(logStreamEndSpy).toHaveBeenCalled();
+  });
+});
+
+describe('getUrl', () => {
+  it('returns null before a port has been set', () => {
+    const nextJsService = new NextJsService();
+
+    expect(nextJsService.getUrl()).toBe(null);
+  });
+
+  it('returns the localhost URL for the current port once started', async () => {
+    const nextJsService = new NextJsService();
+
+    await nextJsService.start(3000);
+
+    expect(nextJsService.getUrl()).toBe('http://localhost:3000');
+  });
+});

--- a/electron/services/__tests__/PhoenixdService.test.js
+++ b/electron/services/__tests__/PhoenixdService.test.js
@@ -1,0 +1,249 @@
+const childProcess = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const { installElectronMock } = require('../../test-utils/electronMock');
+const { createFakeSpawnedProcess, createFakeWriteStream } = require('../../test-utils/fakeChildProcess');
+const { setPlatformAndArch, restorePlatformAndArch } = require('../../test-utils/platformMock');
+const { installSpawnMock } = require('../../test-utils/spawnMock');
+const { installTreeKillMock } = require('../../test-utils/treeKillMock');
+const healthCheck = require('../../utils/healthCheck');
+const logger = require('../../utils/logger');
+
+let PhoenixdService;
+let spawnMock;
+let treeKillMock;
+
+beforeAll(() => {
+  installElectronMock();
+  spawnMock = installSpawnMock();
+  treeKillMock = installTreeKillMock();
+  healthCheck.checkPhoenixd = vi.fn();
+  childProcess.exec = vi.fn();
+  PhoenixdService = require('../PhoenixdService');
+});
+
+function armAutoExitOnListen(spawnedProcess, exitCode = 0) {
+  spawnedProcess.on('newListener', function autoExitWhenExitIsAwaited(eventName) {
+    if (eventName !== 'exit') return;
+    spawnedProcess.removeListener('newListener', autoExitWhenExitIsAwaited);
+    process.nextTick(() => spawnedProcess.emit('exit', exitCode));
+  });
+}
+
+let fakeSpawnedProcess;
+
+beforeEach(() => {
+  fakeSpawnedProcess = createFakeSpawnedProcess();
+  spawnMock.mockReset().mockReturnValue(fakeSpawnedProcess);
+  treeKillMock.mockReset().mockImplementation((_pid, _signal, callback) => callback());
+  healthCheck.checkPhoenixd.mockReset().mockResolvedValue(true);
+  childProcess.exec.mockReset().mockImplementation((_command, callback) => callback());
+  vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+  vi.spyOn(fs, 'mkdirSync').mockImplementation(() => {});
+  vi.spyOn(fs, 'createWriteStream').mockImplementation(createFakeWriteStream);
+  vi.spyOn(logger, 'log').mockImplementation(() => {});
+  vi.spyOn(logger, 'warn').mockImplementation(() => {});
+  vi.spyOn(logger, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  restorePlatformAndArch();
+  vi.restoreAllMocks();
+});
+
+describe('constructor', () => {
+  it('starts with no process, stopped status, and no port', () => {
+    const phoenixdService = new PhoenixdService();
+
+    expect(phoenixdService.getStatus()).toBe('stopped');
+    expect(phoenixdService.getPort()).toBe(null);
+  });
+});
+
+describe('start', () => {
+  it('throws when a process is already running', async () => {
+    const phoenixdService = new PhoenixdService();
+    await phoenixdService.start(9740);
+
+    await expect(phoenixdService.start(9740)).rejects.toThrow('Phoenixd service is already running');
+  });
+
+  it('creates the data and logs directories when they do not exist', async () => {
+    fs.existsSync.mockReturnValue(false);
+    const phoenixdService = new PhoenixdService();
+
+    await phoenixdService.start(9740);
+
+    expect(fs.mkdirSync).toHaveBeenCalledWith(expect.stringContaining('.phoenix'), { recursive: true });
+    expect(fs.mkdirSync).toHaveBeenCalledWith(expect.stringContaining('logs'), { recursive: true });
+  });
+
+  it('does not create directories that already exist', async () => {
+    fs.existsSync.mockReturnValue(true);
+    const phoenixdService = new PhoenixdService();
+
+    await phoenixdService.start(9740);
+
+    expect(fs.mkdirSync).not.toHaveBeenCalled();
+  });
+
+  it('spawns phoenixd with the port and terms-of-service args', async () => {
+    const phoenixdService = new PhoenixdService();
+
+    await phoenixdService.start(9740);
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      'phoenixd',
+      ['--agree-to-terms-of-service', '--http-bind-ip=127.0.0.1', '--http-bind-port=9740'],
+      expect.objectContaining({ stdio: ['ignore', 'pipe', 'pipe'], detached: false }),
+    );
+  });
+
+  it('does not override JAVA_HOME on non-Windows platforms', async () => {
+    setPlatformAndArch('darwin', 'arm64');
+    const phoenixdService = new PhoenixdService();
+
+    await phoenixdService.start(9740);
+
+    const [, , spawnOptions] = spawnMock.mock.calls[0];
+    expect(spawnOptions.env.JAVA_HOME).toBe(process.env.JAVA_HOME);
+  });
+
+  it('points JAVA_HOME at the bundled x64 JRE on Windows', async () => {
+    setPlatformAndArch('win32', 'x64');
+    const phoenixdService = new PhoenixdService();
+
+    await phoenixdService.start(9740);
+
+    const [, , spawnOptions] = spawnMock.mock.calls[0];
+    expect(spawnOptions.env.JAVA_HOME).toBe(path.join(__dirname, '..', '..', 'jre', 'win-x64'));
+  });
+
+  it('waits for phoenixd to become healthy before resolving', async () => {
+    const phoenixdService = new PhoenixdService();
+
+    const result = await phoenixdService.start(9740);
+
+    expect(healthCheck.checkPhoenixd).toHaveBeenCalledWith(9740);
+    expect(result).toEqual({ port: 9740 });
+    expect(phoenixdService.getStatus()).toBe('running');
+  });
+
+  it('stops the process and rethrows when the health check never succeeds', async () => {
+    healthCheck.checkPhoenixd.mockRejectedValue(new Error('Timed out waiting for: http://localhost:9740/getinfo'));
+    armAutoExitOnListen(fakeSpawnedProcess);
+    const phoenixdService = new PhoenixdService();
+
+    const startPromise = phoenixdService.start(9740);
+
+    await expect(startPromise).rejects.toThrow('Timed out waiting for: http://localhost:9740/getinfo');
+    expect(phoenixdService.getStatus()).toBe('stopped');
+  });
+});
+
+describe('stop', () => {
+  it('does nothing when there is no owned process and no known port', async () => {
+    const phoenixdService = new PhoenixdService();
+
+    await phoenixdService.stop();
+
+    expect(treeKillMock).not.toHaveBeenCalled();
+    expect(childProcess.exec).not.toHaveBeenCalled();
+  });
+
+  it('kills by port when there is a known port but no owned process', async () => {
+    const phoenixdService = new PhoenixdService();
+    phoenixdService.port = 9740;
+
+    await phoenixdService.stop();
+
+    expect(childProcess.exec).toHaveBeenCalledWith(expect.stringContaining('9740'), expect.any(Function));
+  });
+
+  it('resolves once the process exits cleanly after SIGTERM', async () => {
+    armAutoExitOnListen(fakeSpawnedProcess);
+    const phoenixdService = new PhoenixdService();
+    await phoenixdService.start(9740);
+
+    await phoenixdService.stop();
+
+    expect(treeKillMock).toHaveBeenCalledWith(fakeSpawnedProcess.pid, 'SIGTERM', expect.any(Function));
+    expect(phoenixdService.getStatus()).toBe('stopped');
+  });
+
+  it('falls back to SIGKILL when sending SIGTERM fails', async () => {
+    treeKillMock.mockImplementation((_pid, signal, callback) => {
+      if (signal === 'SIGTERM') callback(new Error('no such process'));
+      else callback();
+    });
+    const phoenixdService = new PhoenixdService();
+    await phoenixdService.start(9740);
+
+    await phoenixdService.stop();
+
+    expect(treeKillMock).toHaveBeenCalledWith(fakeSpawnedProcess.pid, 'SIGKILL', expect.any(Function));
+  });
+
+  it('force-kills with SIGKILL when the process does not exit before the timeout', async () => {
+    vi.useFakeTimers();
+    const phoenixdService = new PhoenixdService();
+    await phoenixdService.start(9740);
+
+    const stopPromise = phoenixdService.stop();
+    await vi.advanceTimersByTimeAsync(5000);
+    await stopPromise;
+
+    expect(treeKillMock).toHaveBeenCalledWith(fakeSpawnedProcess.pid, 'SIGKILL', expect.any(Function));
+    vi.useRealTimers();
+  });
+});
+
+describe('killByPort', () => {
+  it('does nothing when no port is given and none is tracked', async () => {
+    const phoenixdService = new PhoenixdService();
+
+    await phoenixdService.killByPort();
+
+    expect(childProcess.exec).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the port is not an integer', async () => {
+    const phoenixdService = new PhoenixdService();
+
+    await phoenixdService.killByPort(NaN);
+
+    expect(childProcess.exec).not.toHaveBeenCalled();
+  });
+
+  it('uses a taskkill command on Windows', async () => {
+    setPlatformAndArch('win32', 'x64');
+    const phoenixdService = new PhoenixdService();
+
+    await phoenixdService.killByPort(9740);
+
+    expect(childProcess.exec).toHaveBeenCalledWith(expect.stringContaining('taskkill'), expect.any(Function));
+  });
+
+  it('uses an lsof/kill command outside Windows', async () => {
+    setPlatformAndArch('darwin', 'arm64');
+    const phoenixdService = new PhoenixdService();
+
+    await phoenixdService.killByPort(9740);
+
+    expect(childProcess.exec).toHaveBeenCalledWith(expect.stringContaining('lsof'), expect.any(Function));
+  });
+});
+
+describe('cleanup', () => {
+  it('resets process, status, and closes the log stream', async () => {
+    const phoenixdService = new PhoenixdService();
+    await phoenixdService.start(9740);
+    const logStreamEndSpy = phoenixdService.logStream.end;
+
+    phoenixdService.cleanup();
+
+    expect(phoenixdService.getStatus()).toBe('stopped');
+    expect(logStreamEndSpy).toHaveBeenCalled();
+  });
+});

--- a/electron/services/__tests__/ServiceManager.test.js
+++ b/electron/services/__tests__/ServiceManager.test.js
@@ -1,0 +1,406 @@
+function createFakeServiceClass() {
+  const createdInstances = [];
+
+  function FakeService() {
+    const instance = {
+      start: vi.fn().mockResolvedValue({ port: 0, url: 'http://localhost:0' }),
+      stop: vi.fn().mockResolvedValue(undefined),
+      getStatus: vi.fn().mockReturnValue('stopped'),
+      getPort: vi.fn().mockReturnValue(null),
+    };
+    createdInstances.push(instance);
+    return instance;
+  }
+
+  const FakeServiceClass = vi.fn(FakeService);
+  FakeServiceClass.createdInstances = createdInstances;
+  return FakeServiceClass;
+}
+
+function installServiceClassMock(modulePath, FakeServiceClass) {
+  const resolvedPath = require.resolve(modulePath);
+  require.cache[resolvedPath] = {
+    id: resolvedPath,
+    filename: resolvedPath,
+    loaded: true,
+    exports: FakeServiceClass,
+  };
+}
+
+const PhoenixdServiceMock = createFakeServiceClass();
+const BackendServiceMock = createFakeServiceClass();
+const NextJsServiceMock = createFakeServiceClass();
+
+const { installElectronMock, setIsPackaged } = require('../../test-utils/electronMock');
+const healthCheck = require('../../utils/healthCheck');
+const logger = require('../../utils/logger');
+
+let ServiceManager;
+let configurationBootstrap;
+let portAllocator;
+
+beforeAll(() => {
+  installElectronMock();
+  installServiceClassMock('../PhoenixdService', PhoenixdServiceMock);
+  installServiceClassMock('../BackendService', BackendServiceMock);
+  installServiceClassMock('../NextJsService', NextJsServiceMock);
+  healthCheck.isPhoenixdRunning = vi.fn();
+  healthCheck.isBackendRunning = vi.fn();
+  configurationBootstrap = require('../ConfigurationBootstrap');
+  portAllocator = require('../../utils/portAllocator');
+  configurationBootstrap.ensureConfigurations = vi.fn();
+  portAllocator.allocatePorts = vi.fn();
+  ServiceManager = require('../ServiceManager');
+});
+
+const allocatedPorts = { phoenixd: 9740, backend: 9154, nextjs: 3000 };
+
+function buildConfigs(ambrosiaOverrides = {}) {
+  return {
+    ambrosia: { 'http-bind-port': '9154', ...ambrosiaOverrides },
+    phoenix: { 'http-password': 'phoenix-password', 'webhook-secret': 'webhook-secret' },
+  };
+}
+
+beforeEach(() => {
+  setIsPackaged(true);
+  portAllocator.allocatePorts.mockReset().mockResolvedValue({ ...allocatedPorts });
+  configurationBootstrap.ensureConfigurations.mockReset().mockResolvedValue(buildConfigs());
+  healthCheck.isPhoenixdRunning.mockReset().mockResolvedValue(false);
+  healthCheck.isBackendRunning.mockReset().mockResolvedValue(false);
+  PhoenixdServiceMock.mockClear();
+  BackendServiceMock.mockClear();
+  NextJsServiceMock.mockClear();
+  PhoenixdServiceMock.createdInstances.length = 0;
+  BackendServiceMock.createdInstances.length = 0;
+  NextJsServiceMock.createdInstances.length = 0;
+  vi.spyOn(logger, 'log').mockImplementation(() => {});
+  vi.spyOn(logger, 'warn').mockImplementation(() => {});
+  vi.spyOn(logger, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('constructor', () => {
+  it('reflects isDevelopment() as devMode when no override is given', () => {
+    setIsPackaged(false);
+
+    const serviceManager = new ServiceManager();
+
+    expect(serviceManager.isDevMode()).toBe(true);
+  });
+
+  it('starts with no external services', () => {
+    const serviceManager = new ServiceManager();
+
+    expect(serviceManager.getServiceStatuses()).toEqual({ phoenixd: 'stopped', backend: 'stopped', nextjs: 'stopped' });
+  });
+});
+
+describe('_startAll in development mode', () => {
+  it('only starts Next.js, using the backend port as the proxy target', async () => {
+    setIsPackaged(false);
+    const serviceManager = new ServiceManager();
+
+    await serviceManager.startAll();
+
+    expect(PhoenixdServiceMock.createdInstances[0].start).not.toHaveBeenCalled();
+    expect(BackendServiceMock.createdInstances[0].start).not.toHaveBeenCalled();
+    expect(NextJsServiceMock.createdInstances[0].start).toHaveBeenCalledWith(3000, { host: 'localhost', port: 9154 });
+  });
+
+  it('returns the Next.js url', async () => {
+    function createRunningNextJsService() {
+      return {
+        start: vi.fn().mockResolvedValue({ port: 3000, url: 'http://localhost:3000' }),
+        stop: vi.fn().mockResolvedValue(undefined),
+        getStatus: vi.fn().mockReturnValue('running'),
+        getPort: vi.fn().mockReturnValue(3000),
+      };
+    }
+
+    setIsPackaged(false);
+    NextJsServiceMock.mockImplementationOnce(createRunningNextJsService);
+    const serviceManager = new ServiceManager();
+
+    await expect(serviceManager.startAll()).resolves.toBe('http://localhost:3000');
+  });
+});
+
+describe('_startAll in production mode', () => {
+  it('starts phoenixd, backend, and nextjs in order when none are external', async () => {
+    const serviceManager = new ServiceManager();
+
+    await serviceManager.startAll();
+
+    expect(PhoenixdServiceMock.createdInstances[0].start).toHaveBeenCalledWith(9740, expect.objectContaining({ 'http-password': 'phoenix-password' }));
+    expect(BackendServiceMock.createdInstances[0].start).toHaveBeenCalledWith(9154, expect.objectContaining({
+      phoenixdPort: 9740,
+      phoenixPassword: 'phoenix-password',
+      webhookSecret: 'webhook-secret',
+      phoenixdRemoteConfigured: false,
+    }));
+    expect(NextJsServiceMock.createdInstances[0].start).toHaveBeenCalledWith(3000, { host: '127.0.0.1', port: 9154 });
+  });
+
+  it('skips starting phoenixd when an NWC wallet is configured', async () => {
+    configurationBootstrap.ensureConfigurations.mockResolvedValue(buildConfigs({ 'nwc-uri': 'nostr+walletconnect://...' }));
+    const serviceManager = new ServiceManager();
+
+    await serviceManager.startAll();
+
+    expect(PhoenixdServiceMock.createdInstances[0].start).not.toHaveBeenCalled();
+  });
+
+  it('skips starting phoenixd and marks it external when a remote node is configured', async () => {
+    configurationBootstrap.ensureConfigurations.mockResolvedValue(buildConfigs({ 'phoenixd-remote': 'true' }));
+    const serviceManager = new ServiceManager();
+
+    await serviceManager.startAll();
+
+    expect(PhoenixdServiceMock.createdInstances[0].start).not.toHaveBeenCalled();
+    expect(BackendServiceMock.createdInstances[0].start).toHaveBeenCalledWith(9154, expect.objectContaining({ phoenixdRemoteConfigured: true }));
+  });
+
+  it('reuses an already-running phoenixd instead of starting a new one', async () => {
+    healthCheck.isPhoenixdRunning.mockResolvedValue(true);
+    const serviceManager = new ServiceManager();
+
+    await serviceManager.startAll();
+
+    expect(PhoenixdServiceMock.createdInstances[0].start).not.toHaveBeenCalled();
+    expect(serviceManager.getPorts().phoenixd).toBe(null);
+  });
+
+  it('reuses an already-running backend instead of starting a new one', async () => {
+    healthCheck.isBackendRunning.mockResolvedValue(true);
+    const serviceManager = new ServiceManager();
+
+    await serviceManager.startAll();
+
+    expect(BackendServiceMock.createdInstances[0].start).not.toHaveBeenCalled();
+  });
+
+  it('emits service:started for each service and all:started at the end', async () => {
+    const serviceManager = new ServiceManager();
+    const startedServiceNames = [];
+    serviceManager.on('service:started', (event) => startedServiceNames.push(event.service));
+    const allStarted = vi.fn();
+    serviceManager.on('all:started', allStarted);
+
+    await serviceManager.startAll();
+
+    expect(startedServiceNames).toEqual(['phoenixd', 'backend', 'nextjs']);
+    expect(allStarted).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops every service and rethrows when a step fails', async () => {
+    function createFailingBackendService() {
+      return {
+        start: vi.fn().mockRejectedValue(new Error('backend failed to start')),
+        stop: vi.fn().mockResolvedValue(undefined),
+        getStatus: vi.fn().mockReturnValue('error'),
+        getPort: vi.fn().mockReturnValue(null),
+      };
+    }
+
+    BackendServiceMock.mockImplementationOnce(createFailingBackendService);
+    const serviceManager = new ServiceManager();
+
+    await expect(serviceManager.startAll()).rejects.toThrow('backend failed to start');
+
+    expect(NextJsServiceMock.createdInstances[0].stop).toHaveBeenCalled();
+    expect(PhoenixdServiceMock.createdInstances[0].stop).toHaveBeenCalled();
+  });
+
+  it('times out after 2 minutes if startup never resolves', async () => {
+    vi.useFakeTimers();
+    portAllocator.allocatePorts.mockReturnValue(new Promise(() => {}));
+    const serviceManager = new ServiceManager();
+
+    const startAllPromise = serviceManager.startAll();
+    const startAllRejection = expect(startAllPromise).rejects.toThrow('Startup timed out after 2 minutes');
+    await vi.advanceTimersByTimeAsync(120000);
+
+    await startAllRejection;
+    vi.useRealTimers();
+  });
+});
+
+describe('stopAll', () => {
+  it('always stops Next.js, even in development mode', async () => {
+    setIsPackaged(false);
+    const serviceManager = new ServiceManager();
+    await serviceManager.startAll();
+
+    await serviceManager.stopAll();
+
+    expect(NextJsServiceMock.createdInstances[0].stop).toHaveBeenCalled();
+  });
+
+  it('does not stop phoenixd or backend in development mode', async () => {
+    setIsPackaged(false);
+    const serviceManager = new ServiceManager();
+    await serviceManager.startAll();
+
+    await serviceManager.stopAll();
+
+    expect(PhoenixdServiceMock.createdInstances[0].stop).not.toHaveBeenCalled();
+    expect(BackendServiceMock.createdInstances[0].stop).not.toHaveBeenCalled();
+  });
+
+  it('does not stop a service that was marked external', async () => {
+    healthCheck.isPhoenixdRunning.mockResolvedValue(true);
+    const serviceManager = new ServiceManager();
+    await serviceManager.startAll();
+
+    await serviceManager.stopAll();
+
+    expect(PhoenixdServiceMock.createdInstances[0].stop).not.toHaveBeenCalled();
+    expect(BackendServiceMock.createdInstances[0].stop).toHaveBeenCalled();
+  });
+
+  it('still attempts to stop the other services when one stop() rejects', async () => {
+    const serviceManager = new ServiceManager();
+    await serviceManager.startAll();
+    NextJsServiceMock.createdInstances[0].stop.mockRejectedValue(new Error('nextjs stop failed'));
+
+    await serviceManager.stopAll();
+
+    expect(BackendServiceMock.createdInstances[0].stop).toHaveBeenCalled();
+    expect(PhoenixdServiceMock.createdInstances[0].stop).toHaveBeenCalled();
+  });
+
+  it('emits all:stopped', async () => {
+    const serviceManager = new ServiceManager();
+    await serviceManager.startAll();
+    const allStopped = vi.fn();
+    serviceManager.on('all:stopped', allStopped);
+
+    await serviceManager.stopAll();
+
+    expect(allStopped).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('restartService', () => {
+  it('does nothing when the target service is external', async () => {
+    healthCheck.isPhoenixdRunning.mockResolvedValue(true);
+    const serviceManager = new ServiceManager();
+    await serviceManager.startAll();
+
+    await serviceManager.restartService('phoenixd');
+
+    expect(PhoenixdServiceMock.createdInstances[0].start).not.toHaveBeenCalled();
+  });
+
+  it('stops and starts phoenixd, clearing its external flag', async () => {
+    const serviceManager = new ServiceManager();
+    await serviceManager.startAll();
+
+    await serviceManager.restartService('phoenixd');
+
+    expect(PhoenixdServiceMock.createdInstances[0].stop).toHaveBeenCalled();
+    expect(PhoenixdServiceMock.createdInstances[0].start).toHaveBeenCalledTimes(2);
+  });
+
+  it('stops and starts the backend with the current phoenixd config', async () => {
+    const serviceManager = new ServiceManager();
+    await serviceManager.startAll();
+
+    await serviceManager.restartService('backend');
+
+    expect(BackendServiceMock.createdInstances[0].stop).toHaveBeenCalled();
+    expect(BackendServiceMock.createdInstances[0].start).toHaveBeenLastCalledWith(9154, expect.objectContaining({
+      phoenixPassword: 'phoenix-password',
+      webhookSecret: 'webhook-secret',
+    }));
+  });
+
+  it('stops and starts nextjs', async () => {
+    const serviceManager = new ServiceManager();
+    await serviceManager.startAll();
+
+    await serviceManager.restartService('nextjs');
+
+    expect(NextJsServiceMock.createdInstances[0].stop).toHaveBeenCalled();
+    expect(NextJsServiceMock.createdInstances[0].start).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws for an unknown service name', async () => {
+    const serviceManager = new ServiceManager();
+    await serviceManager.startAll();
+
+    await expect(serviceManager.restartService('unknown')).rejects.toThrow('Unknown service: unknown');
+  });
+
+  it('emits service:restarted on success', async () => {
+    const serviceManager = new ServiceManager();
+    await serviceManager.startAll();
+    const restarted = vi.fn();
+    serviceManager.on('service:restarted', restarted);
+
+    await serviceManager.restartService('nextjs');
+
+    expect(restarted).toHaveBeenCalledWith({ service: 'nextjs' });
+  });
+
+  it('emits service:error and rethrows on failure', async () => {
+    const serviceManager = new ServiceManager();
+    await serviceManager.startAll();
+    NextJsServiceMock.createdInstances[0].start.mockRejectedValueOnce(new Error('restart failed'));
+    const serviceError = vi.fn();
+    serviceManager.on('service:error', serviceError);
+
+    await expect(serviceManager.restartService('nextjs')).rejects.toThrow('restart failed');
+    expect(serviceError).toHaveBeenCalledWith({ service: 'nextjs', error: expect.any(Error) });
+  });
+});
+
+describe('health monitor', () => {
+  it('emits service:error when a non-external service reports an error status', async () => {
+    vi.useFakeTimers();
+    const serviceManager = new ServiceManager();
+    await serviceManager.startAll();
+    BackendServiceMock.createdInstances[0].getStatus.mockReturnValue('error');
+    const serviceError = vi.fn();
+    serviceManager.on('service:error', serviceError);
+
+    await vi.advanceTimersByTimeAsync(30000);
+
+    expect(serviceError).toHaveBeenCalledWith({ service: 'backend', error: expect.any(Error) });
+    vi.useRealTimers();
+  });
+
+  it('does not monitor a service marked external', async () => {
+    healthCheck.isPhoenixdRunning.mockResolvedValue(true);
+    vi.useFakeTimers();
+    const serviceManager = new ServiceManager();
+    await serviceManager.startAll();
+    PhoenixdServiceMock.createdInstances[0].getStatus.mockReturnValue('error');
+    const serviceError = vi.fn();
+    serviceManager.on('service:error', serviceError);
+
+    await vi.advanceTimersByTimeAsync(30000);
+
+    expect(serviceError).not.toHaveBeenCalledWith(expect.objectContaining({ service: 'phoenixd' }));
+    vi.useRealTimers();
+  });
+
+  it('stops monitoring once stopAll runs', async () => {
+    vi.useFakeTimers();
+    const serviceManager = new ServiceManager();
+    await serviceManager.startAll();
+    await serviceManager.stopAll();
+    BackendServiceMock.createdInstances[0].getStatus.mockReturnValue('error');
+    const serviceError = vi.fn();
+    serviceManager.on('service:error', serviceError);
+
+    await vi.advanceTimersByTimeAsync(30000);
+
+    expect(serviceError).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+});

--- a/electron/test-utils/electronMock.js
+++ b/electron/test-utils/electronMock.js
@@ -8,7 +8,8 @@ const electronModuleExports = {
   },
 };
 
-function installElectronMock() {
+function installElectronMock(additionalExports = {}) {
+  Object.assign(electronModuleExports, additionalExports);
   const electronPath = require.resolve('electron');
   require.cache[electronPath] = {
     id: electronPath,

--- a/electron/test-utils/electronMock.js
+++ b/electron/test-utils/electronMock.js
@@ -1,0 +1,33 @@
+let isPackaged = false;
+
+const electronModuleExports = {
+  app: {
+    get isPackaged() {
+      return isPackaged;
+    },
+  },
+};
+
+function installElectronMock() {
+  const electronPath = require.resolve('electron');
+  require.cache[electronPath] = {
+    id: electronPath,
+    filename: electronPath,
+    loaded: true,
+    exports: electronModuleExports,
+  };
+}
+
+function setIsPackaged(newIsPackaged) {
+  isPackaged = newIsPackaged;
+}
+
+function resetElectronMock() {
+  isPackaged = false;
+}
+
+module.exports = {
+  installElectronMock,
+  setIsPackaged,
+  resetElectronMock,
+};

--- a/electron/test-utils/fakeChildProcess.js
+++ b/electron/test-utils/fakeChildProcess.js
@@ -1,0 +1,15 @@
+const { EventEmitter } = require('events');
+
+function createFakeSpawnedProcess(pid = 1234) {
+  const spawnedProcess = new EventEmitter();
+  spawnedProcess.pid = pid;
+  spawnedProcess.stdout = new EventEmitter();
+  spawnedProcess.stderr = new EventEmitter();
+  return spawnedProcess;
+}
+
+function createFakeWriteStream() {
+  return { write: vi.fn(), end: vi.fn() };
+}
+
+module.exports = { createFakeSpawnedProcess, createFakeWriteStream };

--- a/electron/test-utils/platformMock.js
+++ b/electron/test-utils/platformMock.js
@@ -1,0 +1,14 @@
+const originalPlatform = process.platform;
+const originalArch = process.arch;
+
+function setPlatformAndArch(platform, arch) {
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+  Object.defineProperty(process, 'arch', { value: arch, configurable: true });
+}
+
+function restorePlatformAndArch() {
+  Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+  Object.defineProperty(process, 'arch', { value: originalArch, configurable: true });
+}
+
+module.exports = { setPlatformAndArch, restorePlatformAndArch };

--- a/electron/test-utils/spawnMock.js
+++ b/electron/test-utils/spawnMock.js
@@ -1,0 +1,15 @@
+const spawnPath = require.resolve('cross-spawn');
+let spawnMock;
+
+function installSpawnMock() {
+  spawnMock = vi.fn();
+  require.cache[spawnPath] = {
+    id: spawnPath,
+    filename: spawnPath,
+    loaded: true,
+    exports: spawnMock,
+  };
+  return spawnMock;
+}
+
+module.exports = { installSpawnMock };

--- a/electron/test-utils/treeKillMock.js
+++ b/electron/test-utils/treeKillMock.js
@@ -1,0 +1,15 @@
+const treeKillPath = require.resolve('tree-kill');
+let treeKillMock;
+
+function installTreeKillMock() {
+  treeKillMock = vi.fn((_pid, _signal, callback) => callback());
+  require.cache[treeKillPath] = {
+    id: treeKillPath,
+    filename: treeKillPath,
+    loaded: true,
+    exports: treeKillMock,
+  };
+  return treeKillMock;
+}
+
+module.exports = { installTreeKillMock };

--- a/electron/utils/__tests__/healthCheck.test.js
+++ b/electron/utils/__tests__/healthCheck.test.js
@@ -1,0 +1,297 @@
+const { EventEmitter } = require('events');
+const http = require('http');
+
+const waitOnPath = require.resolve('wait-on');
+let waitOnMock;
+
+function installWaitOnMock() {
+  waitOnMock = vi.fn();
+  require.cache[waitOnPath] = {
+    id: waitOnPath,
+    filename: waitOnPath,
+    loaded: true,
+    exports: waitOnMock,
+  };
+}
+
+let healthCheck;
+let logger;
+
+beforeAll(() => {
+  installWaitOnMock();
+  healthCheck = require('../healthCheck');
+  logger = require('../logger');
+});
+
+function createFakeIncomingMessage(statusCode) {
+  const incomingMessage = new EventEmitter();
+  incomingMessage.statusCode = statusCode;
+  incomingMessage.resume = () => {};
+  return incomingMessage;
+}
+
+function createFakeClientRequest() {
+  const clientRequest = new EventEmitter();
+  clientRequest.setTimeout = vi.fn();
+  clientRequest.destroy = vi.fn();
+  return clientRequest;
+}
+
+function mockHttpGetRespondingWith(statusCode) {
+  vi.spyOn(http, 'get').mockImplementation((_url, callback) => {
+    callback(createFakeIncomingMessage(statusCode));
+    return createFakeClientRequest();
+  });
+}
+
+function mockHttpGetFailingWith(requestError) {
+  vi.spyOn(http, 'get').mockImplementation(() => {
+    const clientRequest = createFakeClientRequest();
+    setImmediate(() => clientRequest.emit('error', requestError));
+    return clientRequest;
+  });
+}
+
+beforeEach(() => {
+  waitOnMock.mockReset();
+  vi.spyOn(logger, 'log').mockImplementation(() => {});
+  vi.spyOn(logger, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('waitForHealth', () => {
+  it('resolves true when waitOn succeeds', async () => {
+    waitOnMock.mockResolvedValue(undefined);
+
+    await expect(healthCheck.waitForHealth('http://localhost:9154/health')).resolves.toBe(true);
+  });
+
+  it('passes the url as the single resource, with the given timeout/interval/verbose', async () => {
+    waitOnMock.mockResolvedValue(undefined);
+
+    await healthCheck.waitForHealth('http://localhost:9154/health', { timeout: 5000, interval: 200, verbose: false });
+
+    expect(waitOnMock).toHaveBeenCalledWith(expect.objectContaining({
+      resources: ['http://localhost:9154/health'],
+      timeout: 5000,
+      interval: 200,
+      verbose: false,
+    }));
+  });
+
+  it('validates 2xx statuses as healthy', async () => {
+    waitOnMock.mockResolvedValue(undefined);
+
+    await healthCheck.waitForHealth('http://localhost:9154/health');
+    const { validateStatus } = waitOnMock.mock.calls[0][0];
+
+    expect(validateStatus(200)).toBe(true);
+    expect(validateStatus(299)).toBe(true);
+  });
+
+  it('rejects a 401 status by default', async () => {
+    waitOnMock.mockResolvedValue(undefined);
+
+    await healthCheck.waitForHealth('http://localhost:9154/health');
+    const { validateStatus } = waitOnMock.mock.calls[0][0];
+
+    expect(validateStatus(401)).toBe(false);
+  });
+
+  it('accepts a 401 status when acceptUnauthorized is true', async () => {
+    waitOnMock.mockResolvedValue(undefined);
+
+    await healthCheck.waitForHealth('http://localhost:9154/health', { acceptUnauthorized: true });
+    const { validateStatus } = waitOnMock.mock.calls[0][0];
+
+    expect(validateStatus(401)).toBe(true);
+  });
+
+  it('rejects and logs when waitOn fails', async () => {
+    waitOnMock.mockRejectedValue(new Error('timed out'));
+
+    await expect(healthCheck.waitForHealth('http://localhost:9154/health')).rejects.toThrow('timed out');
+    expect(logger.error).toHaveBeenCalledWith(
+      '[HealthCheck] http://localhost:9154/health failed health check:',
+      'timed out',
+    );
+  });
+});
+
+describe('checkPhoenixd', () => {
+  it('resolves true immediately when the response is healthy', async () => {
+    mockHttpGetRespondingWith(200);
+
+    await expect(healthCheck.checkPhoenixd(9740)).resolves.toBe(true);
+  });
+
+  it('treats a 401 response as healthy', async () => {
+    mockHttpGetRespondingWith(401);
+
+    await expect(healthCheck.checkPhoenixd(9740)).resolves.toBe(true);
+  });
+
+  it('retries after an unhealthy response and eventually succeeds', async () => {
+    let attemptCount = 0;
+    vi.spyOn(http, 'get').mockImplementation((_url, callback) => {
+      attemptCount += 1;
+      callback(createFakeIncomingMessage(attemptCount < 2 ? 503 : 200));
+      return createFakeClientRequest();
+    });
+
+    await expect(healthCheck.checkPhoenixd(9740, 3, 1)).resolves.toBe(true);
+    expect(attemptCount).toBe(2);
+  });
+
+  it('throws a timeout error after exhausting all attempts', async () => {
+    mockHttpGetRespondingWith(503);
+
+    await expect(healthCheck.checkPhoenixd(9740, 2, 1))
+      .rejects.toThrow('Timed out waiting for: http://localhost:9740/getinfo');
+  });
+
+  it('retries when the request errors out', async () => {
+    let attemptCount = 0;
+    vi.spyOn(http, 'get').mockImplementation((_url, callback) => {
+      attemptCount += 1;
+      if (attemptCount < 2) {
+        const clientRequest = createFakeClientRequest();
+        setImmediate(() => clientRequest.emit('error', new Error('ECONNREFUSED')));
+        return clientRequest;
+      }
+      callback(createFakeIncomingMessage(200));
+      return createFakeClientRequest();
+    });
+
+    await expect(healthCheck.checkPhoenixd(9740, 3, 1)).resolves.toBe(true);
+  });
+});
+
+describe('checkBackend', () => {
+  it('resolves true for a 2xx response', async () => {
+    mockHttpGetRespondingWith(200);
+
+    await expect(healthCheck.checkBackend(9154)).resolves.toBe(true);
+  });
+
+  it('does not treat a 401 response as healthy', async () => {
+    mockHttpGetRespondingWith(401);
+
+    await expect(healthCheck.checkBackend(9154, 1, 1))
+      .rejects.toThrow('Timed out waiting for: http://localhost:9154/api/health');
+  });
+});
+
+describe('checkNextJs', () => {
+  it('resolves true for a 2xx response', async () => {
+    mockHttpGetRespondingWith(200);
+
+    await expect(healthCheck.checkNextJs(3000)).resolves.toBe(true);
+  });
+
+  it('treats a 3xx redirect as healthy', async () => {
+    mockHttpGetRespondingWith(302);
+
+    await expect(healthCheck.checkNextJs(3000)).resolves.toBe(true);
+  });
+
+  it('does not treat a 4xx response as healthy', async () => {
+    mockHttpGetRespondingWith(404);
+
+    await expect(healthCheck.checkNextJs(3000, 1, 1))
+      .rejects.toThrow('Timed out waiting for: http://localhost:3000/');
+  });
+});
+
+describe('makeHttpRequest', () => {
+  it('resolves with the status code and accumulated body on a 2xx response', async () => {
+    vi.spyOn(http, 'get').mockImplementation((_url, callback) => {
+      const incomingMessage = createFakeIncomingMessage(200);
+      callback(incomingMessage);
+      incomingMessage.emit('data', 'chunk-1');
+      incomingMessage.emit('data', 'chunk-2');
+      incomingMessage.emit('end');
+      return createFakeClientRequest();
+    });
+
+    await expect(healthCheck.makeHttpRequest('http://localhost:9154/api/data')).resolves.toEqual({
+      statusCode: 200,
+      data: 'chunk-1chunk-2',
+    });
+  });
+
+  it('rejects with the status code and body on a non-2xx response', async () => {
+    vi.spyOn(http, 'get').mockImplementation((_url, callback) => {
+      const incomingMessage = createFakeIncomingMessage(500);
+      callback(incomingMessage);
+      incomingMessage.emit('data', 'internal error');
+      incomingMessage.emit('end');
+      return createFakeClientRequest();
+    });
+
+    await expect(healthCheck.makeHttpRequest('http://localhost:9154/api/data')).rejects.toThrow('HTTP 500: internal error');
+  });
+
+  it('rejects when the request errors out', async () => {
+    mockHttpGetFailingWith(new Error('ECONNREFUSED'));
+
+    await expect(healthCheck.makeHttpRequest('http://localhost:9154/api/data')).rejects.toThrow('ECONNREFUSED');
+  });
+});
+
+describe('isPhoenixdRunning', () => {
+  it('returns true for a healthy response', async () => {
+    mockHttpGetRespondingWith(200);
+
+    await expect(healthCheck.isPhoenixdRunning(9740)).resolves.toBe(true);
+  });
+
+  it('returns true for a 401 response', async () => {
+    mockHttpGetRespondingWith(401);
+
+    await expect(healthCheck.isPhoenixdRunning(9740)).resolves.toBe(true);
+  });
+
+  it('returns false for an unhealthy response', async () => {
+    mockHttpGetRespondingWith(503);
+
+    await expect(healthCheck.isPhoenixdRunning(9740)).resolves.toBe(false);
+  });
+
+  it('returns false when the request errors out', async () => {
+    mockHttpGetFailingWith(new Error('ECONNREFUSED'));
+
+    await expect(healthCheck.isPhoenixdRunning(9740)).resolves.toBe(false);
+  });
+});
+
+describe('isBackendRunning', () => {
+  it('returns true for any response status', async () => {
+    mockHttpGetRespondingWith(500);
+
+    await expect(healthCheck.isBackendRunning(9154)).resolves.toBe(true);
+  });
+
+  it('returns false when the request errors out', async () => {
+    mockHttpGetFailingWith(new Error('ECONNREFUSED'));
+
+    await expect(healthCheck.isBackendRunning(9154)).resolves.toBe(false);
+  });
+});
+
+describe('isNextJsRunning', () => {
+  it('returns true for a 2xx response', async () => {
+    mockHttpGetRespondingWith(200);
+
+    await expect(healthCheck.isNextJsRunning(3000)).resolves.toBe(true);
+  });
+
+  it('returns false for a 4xx response', async () => {
+    mockHttpGetRespondingWith(404);
+
+    await expect(healthCheck.isNextJsRunning(3000)).resolves.toBe(false);
+  });
+});

--- a/electron/utils/__tests__/logger.test.js
+++ b/electron/utils/__tests__/logger.test.js
@@ -1,0 +1,77 @@
+const originalEnv = { ...process.env };
+
+async function loadLoggerWithEnv(envOverrides) {
+  delete process.env.DEBUG;
+  delete process.env.NODE_ENV;
+  Object.assign(process.env, envOverrides);
+  vi.resetModules();
+  const loggerModule = await import('../logger');
+  return loggerModule.default;
+}
+
+describe('logger', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.env = { ...originalEnv };
+  });
+
+  describe('log', () => {
+    it('does not call console.log when DEBUG and NODE_ENV are unset', async () => {
+      const logger = await loadLoggerWithEnv({});
+
+      logger.log('startup message');
+
+      expect(console.log).not.toHaveBeenCalled();
+    });
+
+    it('calls console.log with the given arguments when DEBUG=true', async () => {
+      const logger = await loadLoggerWithEnv({ DEBUG: 'true' });
+
+      logger.log('startup message', { port: 9154 });
+
+      expect(console.log).toHaveBeenCalledWith('startup message', { port: 9154 });
+    });
+
+    it('calls console.log with the given arguments when NODE_ENV=development', async () => {
+      const logger = await loadLoggerWithEnv({ NODE_ENV: 'development' });
+
+      logger.log('startup message');
+
+      expect(console.log).toHaveBeenCalledWith('startup message');
+    });
+
+    it('does not call console.log when DEBUG is set to a non-"true" value', async () => {
+      const logger = await loadLoggerWithEnv({ DEBUG: '1' });
+
+      logger.log('startup message');
+
+      expect(console.log).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('warn', () => {
+    it('calls console.warn with the given arguments regardless of DEBUG', async () => {
+      const logger = await loadLoggerWithEnv({});
+
+      logger.warn('service degraded', { service: 'phoenixd' });
+
+      expect(console.warn).toHaveBeenCalledWith('service degraded', { service: 'phoenixd' });
+    });
+  });
+
+  describe('error', () => {
+    it('calls console.error with the given arguments regardless of DEBUG', async () => {
+      const logger = await loadLoggerWithEnv({});
+
+      logger.error('startup failed', new Error('port in use'));
+
+      expect(console.error).toHaveBeenCalledWith('startup failed', new Error('port in use'));
+    });
+  });
+});

--- a/electron/utils/__tests__/portAllocator.test.js
+++ b/electron/utils/__tests__/portAllocator.test.js
@@ -1,0 +1,103 @@
+const findFreePortPath = require.resolve('find-free-port');
+let findFreePortMock;
+
+function installFindFreePortMock() {
+  findFreePortMock = vi.fn();
+  require.cache[findFreePortPath] = {
+    id: findFreePortPath,
+    filename: findFreePortPath,
+    loaded: true,
+    exports: findFreePortMock,
+  };
+}
+
+const { installElectronMock, setIsPackaged, resetElectronMock } = require('../../test-utils/electronMock');
+
+let portAllocator;
+let logger;
+
+beforeAll(() => {
+  installElectronMock();
+  installFindFreePortMock();
+  portAllocator = require('../portAllocator');
+  logger = require('../logger');
+});
+
+beforeEach(() => {
+  resetElectronMock();
+  findFreePortMock.mockReset();
+  vi.spyOn(logger, 'log').mockImplementation(() => {});
+  vi.spyOn(logger, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('DEFAULT_PORTS', () => {
+  it('exposes the default phoenixd, backend, and nextjs ports', () => {
+    expect(portAllocator.DEFAULT_PORTS).toEqual({
+      phoenixd: 9740,
+      backend: 9154,
+      nextjs: 3000,
+    });
+  });
+});
+
+describe('allocatePorts', () => {
+  it('returns the default ports in development without calling findFreePort', async () => {
+    setIsPackaged(false);
+
+    const allocatedPorts = await portAllocator.allocatePorts();
+
+    expect(allocatedPorts).toEqual({ phoenixd: 9740, backend: 9154, nextjs: 3000 });
+    expect(findFreePortMock).not.toHaveBeenCalled();
+  });
+
+  it('returns dynamically allocated ports in production', async () => {
+    setIsPackaged(true);
+    findFreePortMock
+      .mockResolvedValueOnce([9741])
+      .mockResolvedValueOnce([9155])
+      .mockResolvedValueOnce([3001]);
+
+    const allocatedPorts = await portAllocator.allocatePorts();
+
+    expect(allocatedPorts).toEqual({ phoenixd: 9741, backend: 9155, nextjs: 3001 });
+  });
+
+  it('requests each port within its documented range', async () => {
+    setIsPackaged(true);
+    findFreePortMock
+      .mockResolvedValueOnce([9741])
+      .mockResolvedValueOnce([9155])
+      .mockResolvedValueOnce([3001]);
+
+    await portAllocator.allocatePorts();
+
+    expect(findFreePortMock).toHaveBeenNthCalledWith(1, 9740, 9800);
+    expect(findFreePortMock).toHaveBeenNthCalledWith(2, 9154, 9200);
+    expect(findFreePortMock).toHaveBeenNthCalledWith(3, 3000, 3100);
+  });
+
+  it('falls back to the default ports when dynamic allocation fails', async () => {
+    setIsPackaged(true);
+    findFreePortMock.mockRejectedValueOnce(new Error('no free port available'));
+
+    const allocatedPorts = await portAllocator.allocatePorts();
+
+    expect(allocatedPorts).toEqual({ phoenixd: 9740, backend: 9154, nextjs: 3000 });
+  });
+
+  it('warns when falling back to the default ports', async () => {
+    setIsPackaged(true);
+    findFreePortMock.mockRejectedValueOnce(new Error('no free port available'));
+
+    await portAllocator.allocatePorts();
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      '[PortAllocator] Dynamic allocation failed, using defaults:',
+      'no free port available',
+    );
+  });
+});

--- a/electron/utils/__tests__/resourcePaths.test.js
+++ b/electron/utils/__tests__/resourcePaths.test.js
@@ -3,6 +3,7 @@ const os = require('os');
 const path = require('path');
 
 const { installElectronMock, setIsPackaged, resetElectronMock } = require('../../test-utils/electronMock');
+const { setPlatformAndArch, restorePlatformAndArch } = require('../../test-utils/platformMock');
 
 let resourcePaths;
 
@@ -11,14 +12,6 @@ beforeAll(() => {
   resourcePaths = require('../resourcePaths');
 });
 
-const originalPlatform = process.platform;
-const originalArch = process.arch;
-
-function setPlatformAndArch(platform, arch) {
-  Object.defineProperty(process, 'platform', { value: platform, configurable: true });
-  Object.defineProperty(process, 'arch', { value: arch, configurable: true });
-}
-
 beforeEach(() => {
   resetElectronMock();
   delete process.env.NODE_ENV;
@@ -26,8 +19,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
-  Object.defineProperty(process, 'arch', { value: originalArch, configurable: true });
+  restorePlatformAndArch();
   vi.restoreAllMocks();
 });
 

--- a/electron/utils/__tests__/resourcePaths.test.js
+++ b/electron/utils/__tests__/resourcePaths.test.js
@@ -1,0 +1,284 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { installElectronMock, setIsPackaged, resetElectronMock } = require('../../test-utils/electronMock');
+
+let resourcePaths;
+
+beforeAll(() => {
+  installElectronMock();
+  resourcePaths = require('../resourcePaths');
+});
+
+const originalPlatform = process.platform;
+const originalArch = process.arch;
+
+function setPlatformAndArch(platform, arch) {
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+  Object.defineProperty(process, 'arch', { value: arch, configurable: true });
+}
+
+beforeEach(() => {
+  resetElectronMock();
+  delete process.env.NODE_ENV;
+  delete process.resourcesPath;
+});
+
+afterEach(() => {
+  Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+  Object.defineProperty(process, 'arch', { value: originalArch, configurable: true });
+  vi.restoreAllMocks();
+});
+
+describe('getPlatform', () => {
+  it('returns macos-arm64 for darwin on arm64', () => {
+    setPlatformAndArch('darwin', 'arm64');
+    expect(resourcePaths.getPlatform()).toBe('macos-arm64');
+  });
+
+  it('returns macos-x64 for darwin on x64', () => {
+    setPlatformAndArch('darwin', 'x64');
+    expect(resourcePaths.getPlatform()).toBe('macos-x64');
+  });
+
+  it('returns win-arm64 for win32 on arm64', () => {
+    setPlatformAndArch('win32', 'arm64');
+    expect(resourcePaths.getPlatform()).toBe('win-arm64');
+  });
+
+  it('returns win-x64 for win32 on x64', () => {
+    setPlatformAndArch('win32', 'x64');
+    expect(resourcePaths.getPlatform()).toBe('win-x64');
+  });
+
+  it('returns linux-arm64 for linux on arm64', () => {
+    setPlatformAndArch('linux', 'arm64');
+    expect(resourcePaths.getPlatform()).toBe('linux-arm64');
+  });
+
+  it('returns linux-x64 for linux on x64', () => {
+    setPlatformAndArch('linux', 'x64');
+    expect(resourcePaths.getPlatform()).toBe('linux-x64');
+  });
+
+  it('throws for an unsupported platform', () => {
+    setPlatformAndArch('freebsd', 'x64');
+    expect(() => resourcePaths.getPlatform()).toThrow('Unsupported platform: freebsd');
+  });
+});
+
+describe('isDevelopment', () => {
+  it('returns true when NODE_ENV=development, even if app.isPackaged is true', () => {
+    process.env.NODE_ENV = 'development';
+    setIsPackaged(true);
+
+    expect(resourcePaths.isDevelopment()).toBe(true);
+  });
+
+  it('returns true when app.isPackaged is false and NODE_ENV is unset', () => {
+    setIsPackaged(false);
+
+    expect(resourcePaths.isDevelopment()).toBe(true);
+  });
+
+  it('returns false when app.isPackaged is true and NODE_ENV is unset', () => {
+    setIsPackaged(true);
+
+    expect(resourcePaths.isDevelopment()).toBe(false);
+  });
+});
+
+describe('getBasePath', () => {
+  it('returns the electron directory in development', () => {
+    setIsPackaged(false);
+
+    expect(resourcePaths.getBasePath()).toBe(path.join(__dirname, '..', '..'));
+  });
+
+  it('returns process.resourcesPath in production', () => {
+    setIsPackaged(true);
+    process.resourcesPath = '/fake/resources';
+
+    expect(resourcePaths.getBasePath()).toBe('/fake/resources');
+  });
+});
+
+describe('getDataDirectory', () => {
+  it('joins the home directory with .Ambrosia-POS', () => {
+    vi.spyOn(os, 'homedir').mockReturnValue('/fake/home');
+
+    expect(resourcePaths.getDataDirectory()).toBe(path.join('/fake/home', '.Ambrosia-POS'));
+  });
+});
+
+describe('getPhoenixDataDirectory', () => {
+  it('joins the home directory with .phoenix', () => {
+    vi.spyOn(os, 'homedir').mockReturnValue('/fake/home');
+
+    expect(resourcePaths.getPhoenixDataDirectory()).toBe(path.join('/fake/home', '.phoenix'));
+  });
+});
+
+describe('getLogsDirectory', () => {
+  it('joins the data directory with logs', () => {
+    vi.spyOn(os, 'homedir').mockReturnValue('/fake/home');
+
+    expect(resourcePaths.getLogsDirectory()).toBe(path.join('/fake/home', '.Ambrosia-POS', 'logs'));
+  });
+});
+
+describe('getJavaPath', () => {
+  it('returns the bare java command in development', () => {
+    setIsPackaged(false);
+
+    expect(resourcePaths.getJavaPath()).toBe('java');
+  });
+
+  it('returns the bundled JRE path in production when it exists', () => {
+    setIsPackaged(true);
+    setPlatformAndArch('darwin', 'arm64');
+    process.resourcesPath = '/fake/resources';
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+
+    const expectedJavaPath = path.join('/fake/resources', 'jre', 'macos-arm64', 'bin', 'java');
+    expect(resourcePaths.getJavaPath()).toBe(expectedJavaPath);
+  });
+
+  it('uses java.exe on Windows in production', () => {
+    setIsPackaged(true);
+    setPlatformAndArch('win32', 'x64');
+    process.resourcesPath = '/fake/resources';
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+
+    const expectedJavaPath = path.join('/fake/resources', 'jre', 'win-x64', 'bin', 'java.exe');
+    expect(resourcePaths.getJavaPath()).toBe(expectedJavaPath);
+  });
+
+  it('throws when the bundled JRE is missing in production', () => {
+    setIsPackaged(true);
+    setPlatformAndArch('darwin', 'arm64');
+    process.resourcesPath = '/fake/resources';
+    vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+
+    expect(() => resourcePaths.getJavaPath()).toThrow('Required resource not found — Java runtime');
+  });
+});
+
+describe('getPhoenixdPath', () => {
+  it('returns the bare phoenixd command in development', () => {
+    setIsPackaged(false);
+
+    expect(resourcePaths.getPhoenixdPath()).toBe('phoenixd');
+  });
+
+  it('returns the bundled binary path in production on macOS', () => {
+    setIsPackaged(true);
+    setPlatformAndArch('darwin', 'x64');
+    process.resourcesPath = '/fake/resources';
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+
+    const expectedPhoenixdPath = path.join('/fake/resources', 'phoenixd', 'macos-x64', 'phoenixd');
+    expect(resourcePaths.getPhoenixdPath()).toBe(expectedPhoenixdPath);
+  });
+
+  it('returns the bat wrapper path in production on Windows', () => {
+    setIsPackaged(true);
+    setPlatformAndArch('win32', 'x64');
+    process.resourcesPath = '/fake/resources';
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+
+    const expectedPhoenixdPath = path.join('/fake/resources', 'phoenixd', 'win-x64', 'bin', 'phoenixd.bat');
+    expect(resourcePaths.getPhoenixdPath()).toBe(expectedPhoenixdPath);
+  });
+
+  it('throws when the bundled binary is missing in production', () => {
+    setIsPackaged(true);
+    setPlatformAndArch('linux', 'x64');
+    process.resourcesPath = '/fake/resources';
+    vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+
+    expect(() => resourcePaths.getPhoenixdPath()).toThrow('Required resource not found — Phoenixd binary');
+  });
+});
+
+describe('getClientPath', () => {
+  it('returns the client directory in development', () => {
+    setIsPackaged(false);
+
+    expect(resourcePaths.getClientPath()).toBe(path.join(__dirname, '..', '..', '..', 'client'));
+  });
+
+  it('returns the bundled client path in production when it exists', () => {
+    setIsPackaged(true);
+    process.resourcesPath = '/fake/resources';
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+
+    expect(resourcePaths.getClientPath()).toBe(path.join('/fake/resources', 'client'));
+  });
+
+  it('throws when the bundled client is missing in production', () => {
+    setIsPackaged(true);
+    process.resourcesPath = '/fake/resources';
+    vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+
+    expect(() => resourcePaths.getClientPath()).toThrow('Required resource not found — Next.js client');
+  });
+});
+
+describe('getBackendJarPath', () => {
+  it('returns the matching JAR in development', () => {
+    setIsPackaged(false);
+    vi.spyOn(fs, 'readdirSync').mockReturnValue(['ambrosia-0.8.0-beta.jar', 'other.txt']);
+
+    const libsDirectory = path.join(__dirname, '..', '..', '..', 'server', 'app', 'build', 'libs');
+    expect(resourcePaths.getBackendJarPath()).toBe(path.join(libsDirectory, 'ambrosia-0.8.0-beta.jar'));
+  });
+
+  it('throws a gradle-build hint in development when no JAR matches', () => {
+    setIsPackaged(false);
+    vi.spyOn(fs, 'readdirSync').mockReturnValue(['other.txt']);
+
+    expect(() => resourcePaths.getBackendJarPath()).toThrow('Run: cd server && ./gradlew jar');
+  });
+
+  it('returns the bundled JAR path in production when it exists', () => {
+    setIsPackaged(true);
+    process.resourcesPath = '/fake/resources';
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+
+    expect(resourcePaths.getBackendJarPath()).toBe(path.join('/fake/resources', 'backend', 'ambrosia.jar'));
+  });
+
+  it('throws when the bundled JAR is missing in production', () => {
+    setIsPackaged(true);
+    process.resourcesPath = '/fake/resources';
+    vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+
+    expect(() => resourcePaths.getBackendJarPath()).toThrow('Required resource not found — Backend JAR');
+  });
+});
+
+describe('getNodePath', () => {
+  it('returns the bare node command in development', () => {
+    setIsPackaged(false);
+
+    expect(resourcePaths.getNodePath()).toBe('node');
+  });
+
+  it('returns the root-level node.exe path in production on Windows', () => {
+    setIsPackaged(true);
+    setPlatformAndArch('win32', 'x64');
+    process.resourcesPath = '/fake/resources';
+
+    expect(resourcePaths.getNodePath()).toBe(path.join('/fake/resources', 'node', 'win-x64', 'node.exe'));
+  });
+
+  it('returns the bin/node path in production on macOS', () => {
+    setIsPackaged(true);
+    setPlatformAndArch('darwin', 'arm64');
+    process.resourcesPath = '/fake/resources';
+
+    expect(resourcePaths.getNodePath()).toBe(path.join('/fake/resources', 'node', 'macos-arm64', 'bin', 'node'));
+  });
+});

--- a/electron/vitest.config.mjs
+++ b/electron/vitest.config.mjs
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+    include: ['**/__tests__/**/*.test.js'],
+    exclude: ['node_modules/**', 'dist/**', 'resources/**', 'build/**'],
+  },
+});


### PR DESCRIPTION
## Changes:

- Add Vitest as the electron test runner, with a require.cache-based mock for the `electron` module (it resolves to a binary path string outside a real Electron process, so no standard mocking approach reaches it) and a first test covering `utils/logger.js`.
- Cover `utils/resourcePaths.js`, `utils/portAllocator.js`, `utils/healthCheck.js`, `preload.entry.js`, and `splash-preload.entry.js`, extending the electron mock to also cover `contextBridge`/`ipcRenderer`.
- Cover the services layer (`ConfigurationBootstrap`, `PhoenixdService`, `BackendService`, `NextJsService`, `ServiceManager`, `AutoUpdater`), adding shared spawn/tree-kill/platform mocks reused across the new service tests and refactored into the existing `resourcePaths` tests.
- Cover `main.js`'s IPC handlers, admin-activity notification, and single-instance lock without modifying the file itself.
- Add a GitHub Actions workflow to run the electron test suite on every pull request.